### PR TITLE
Add systemd-vconsole-setup.service in initrd.target too.

### DIFF
--- a/modules.d/98systemd/module-setup.sh
+++ b/modules.d/98systemd/module-setup.sh
@@ -197,6 +197,7 @@ install() {
     inst_rules 99-systemd.rules
 
     for i in \
+        initrd.target \
         emergency.target \
         dracut-emergency.service \
         rescue.service \


### PR DESCRIPTION
When using modules plymouth and systemd, systemd-vconsole-setup.service not added to initrd.target. This leads to the fact that plymouth runs before systemd-vconsole-setup, and it breaks font in console. This patch adds systemd-vconsole-setup.service in initrd.target, which guarantees start systemd-vconsole-setup before plymouth
