### PR TITLE
On gentoo systemd in /usr

### DIFF
--- a/modules.d/10i18n/console_init.sh
+++ b/modules.d/10i18n/console_init.sh
@@ -6,6 +6,8 @@
 
 if [ -x /lib/systemd/systemd-vconsole-setup ]; then
     /lib/systemd/systemd-vconsole-setup "$@"
+elif [ -x /usr/lib/systemd/systemd-vconsole-setup ]; then
+    /usr/lib/systemd/systemd-vconsole-setup "$@"
 fi
 
 [ -e /etc/vconsole.conf ] && . /etc/vconsole.conf

--- a/modules.d/10i18n/module-setup.sh
+++ b/modules.d/10i18n/module-setup.sh
@@ -12,7 +12,7 @@ depends() {
 }
 
 install() {
-    [ -x /lib/systemd/systemd-vconsole-setup ] && dracut_install /lib/systemd/systemd-vconsole-setup
+    [ -x $systemdutildir/systemd-vconsole-setup ] && dracut_install $systemdutildir/systemd-vconsole-setup
     KBDSUBDIRS=consolefonts,consoletrans,keymaps,unimaps
     DEFAULT_FONT=LatArCyrHeb-16
     I18N_CONF="/etc/locale.conf"

--- a/modules.d/90mdraid/module-setup.sh
+++ b/modules.d/90mdraid/module-setup.sh
@@ -88,8 +88,8 @@ install() {
     inst_hook shutdown 30 "$moddir/md-shutdown.sh"
     inst_script "$moddir/mdraid-cleanup.sh" /sbin/mdraid-cleanup
     inst_script "$moddir/mdraid_start.sh" /sbin/mdraid_start
-    if [ -e /lib/systemd/system/mdmon@.service ]; then
-        inst_simple /lib/systemd/system/mdmon@.service
+    if [ -e $systemdsystemunitdir/mdmon@.service ]; then
+        inst_simple $systemdsystemunitdir/mdmon@.service
     fi
     inst_hook pre-shutdown 30 "$moddir/mdmon-pre-shutdown.sh"
 }

--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -39,6 +39,8 @@ RD_DEBUG=""
 
 if [ -x /lib/systemd/systemd-timestamp ]; then
     RD_TIMESTAMP=$(/lib/systemd/systemd-timestamp)
+elif [ -x /usr/lib/systemd/systemd-timestamp ]; then
+    RD_TIMESTAMP=$(/usr/lib/systemd/systemd-timestamp)
 else
     read RD_TIMESTAMP _tmp < /proc/uptime
     unset _tmp
@@ -124,7 +126,8 @@ getarg 'rd.break=pre-udev' -d 'rdbreak=pre-udev' && emergency_shell -n pre-udev 
 source_hook pre-udev
 
 # start up udev and trigger cold plugs
-/lib/systemd/systemd-udevd --daemon --resolve-names=never
+if [ -x /lib/systemd/systemd-udevd ]; then /lib/systemd/systemd-udevd --daemon --resolve-names=never
+elif [ -x /usr/lib/systemd/systemd-udevd ]; then /usr/lib/systemd/systemd-udevd --daemon --resolve-names=never ; fi
 
 UDEV_LOG_PRIO_ARG=--log-priority
 UDEV_QUEUE_EMPTY="udevadm settle --timeout=0"

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -49,7 +49,7 @@ install() {
     fi
 
     mkdir -p "${initdir}/var"
-    [ -x /lib/systemd/systemd-timestamp ] && inst /lib/systemd/systemd-timestamp
+    [ -x $systemdutildir/systemd-timestamp ] && inst $systemdutildir/systemd-timestamp
     if [[ $realinitpath ]]; then
         for i in $realinitpath; do
             echo "rd.distroinit=$i"


### PR DESCRIPTION
On gentoo systemd installed in /usr. This patch allow generate proper initrd with systemd module and run my system without errors.
