### PR TITLE
Break at switch_root only for bare rd.break

### DIFF
--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -353,7 +353,9 @@ wait_for_loginit
 # remove helper symlink
 [ -h /dev/root ] && rm -f -- /dev/root
 
-getarg rd.break -d rdbreak && emergency_shell -n switch_root "Break before switch_root"
+bv=$(getarg rd.break -d rdbreak) && [ -z "$bv" ] &&
+    emergency_shell -n switch_root "Break before switch_root"
+unset bv
 info "Switching root"
 
 


### PR DESCRIPTION
Previously, any rd.break=breakpoint would cause a break
at the desired breakpoint and also another one at switch_root.

To resolve #13.
