### PR TITLE
bridging: generate ifcfg files for both the bridge and interfaces

### DIFF
--- a/modules.d/45ifcfg/write-ifcfg.sh
+++ b/modules.d/45ifcfg/write-ifcfg.sh
@@ -215,7 +215,7 @@ for netup in /tmp/net.*.did-setup ; do
                 echo "MASTER=\"$netif\""
                 echo "NAME=\"$slave\""
                 echo "UUID=\"$(cat /proc/sys/kernel/random/uuid)\""
-            } >> /tmp/ifcfg/ifcfg-$slave
+            } > /tmp/ifcfg/ifcfg-$slave
         done
     fi
 
@@ -237,7 +237,7 @@ for netup in /tmp/net.*.did-setup ; do
                 echo "BRIDGE=\"$bridgename\""
                 echo "NAME=\"$slave\""
                 echo "UUID=\"$(cat /proc/sys/kernel/random/uuid)\""
-            } >> /tmp/ifcfg/ifcfg-$slave
+            } > /tmp/ifcfg/ifcfg-$slave
         done
     fi
     i=1


### PR DESCRIPTION
When a bridged interface is configured to start up on boot via the
kernel command line options, the resulting ifcfg files produced by
the 45ifcfg dracut module are incorrect.  Atlthough the interface is
brought up correctly on start up, and functions as expected, when the
configuration file is imported into the booted system it prevents the
bridged interface from being successfully restarted.

This patch rewrites the section of 45ifcfg responsible for the creation
of the required ifcfg files.

Bug #1123552 https://bugzilla.redhat.com/show_bug.cgi?id=1123552
