### PR TITLE
Adds bittorrent support for live images

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -790,13 +790,14 @@ of your compressed filesystem image tarball.
 =====================
 
 **root=**live:__<url>__::
-Boots a live image retrieved from __<url>__.  Valid handlers: __http, httpd, ftp, tftp__.
+Boots a live image retrieved from __<url>__.  Valid handlers: __http, https, ftp, torrent, tftp__.
 +
 [listing]
 .Example
 --
 root=live:http://example.com/liveboot.img
 root=live:ftp://ftp.example.com/liveboot.img
+root=live:torrent://example.com/liveboot.img.torrent
 --
 
 **rd.live.debug=**1::

--- a/modules.d/45url-lib/module-setup.sh
+++ b/modules.d/45url-lib/module-setup.sh
@@ -17,6 +17,7 @@ depends() {
 install() {
     local _dir _crt _found _lib
     inst_simple "$moddir/url-lib.sh" "/lib/url-lib.sh"
+    inst_multiple -o ctorrent
     inst_multiple curl
     # also install libs for curl https
     inst_libdir_file "libnsspem.so*"

--- a/modules.d/45url-lib/url-lib.sh
+++ b/modules.d/45url-lib/url-lib.sh
@@ -82,6 +82,36 @@ set_http_header() {
     echo "header = \"$1: $2\"" >> $CURL_HOME/.curlrc
 }
 
+### TORRENT ##########################################################
+
+ctorrent_args="-E 0 -e 0"
+
+ctorrent_fetch_url() {
+    local url="$1" outloc="$2"
+    url=${url#*//}
+    torrent_outloc="$outloc.torrent"
+    echo "$url" > /proc/self/fd/0
+    if [ -n "$outloc" ]; then
+        curl $curl_args --output - -- "$url" > "$torrent_outloc" || return $?
+    else
+        local outdir="$(mkuniqdir /tmp torrent_fetch_url)"
+        ( cd "$outdir"; curl $curl_args --remote-name "$url" || return $? )
+        torrent_outloc="$outdir/$(ls -A $outdir)"
+        outloc=${torrent_outloc%.*}
+    fi
+    if ! [ -f "$torrent_outloc" ]; then
+        warn "Downloading '$url' failed!"
+        return 253
+    fi
+    ctorrent $ctorrent_args -s $outloc $torrent_outloc >&2
+    if ! [ -f "$outloc" ]; then
+        warn "Torrent download of '$url' failed!"
+        return 253
+    fi
+    if [ -z "$2" ]; then echo "$outloc" ; fi
+}
+add_url_handler ctorrent_fetch_url torrent
+
 ### NFS ##############################################################
 
 [ -e /lib/nfs-lib.sh ] && . /lib/nfs-lib.sh


### PR DESCRIPTION
This patch adds bittorrent support to 45url-lib for those that might want
to retrieve the same live image for multiple systems at once without
saturating the network.

This patch requires ctorrent to be installed into initramfs.

Torrent kernel command line format:
root=live:torrent://example.com/liveboot.img.torrent

Start a tracker:
bttrack --bind <tracker_ip> --port 6969 --dfile dstate --reannounce_interval 60

Create the torrent:
ctorrent -t live_image -u http://<tracker_ip>:6969/announce -s live_image.torrent

Seed the initial torrent:
ctorrent live_image.torrent

Boot the live image.
