### PR TITLE
WIP add mptcp support

### DIFF
--- a/modules.d/45mptcp/module-setup.sh
+++ b/modules.d/45mptcp/module-setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+# called by dracut
+check() {
+    require_binaries ip wc sed grep || return 1
+    return 0
+}
+
+# called by dracut
+depends() {
+    echo network
+    return 0
+}
+
+# called by dracut
+install() {
+    for f in /etc/iproute2/*; do
+        inst $f
+    done
+    inst_multiple ip wc sed grep
+    inst_hook cmdline 95 "$moddir/parse-mptcp.sh"
+    inst_hook initqueue/online 95 "$moddir/mptcp-route.sh"
+    dracut_need_initqueue
+}

--- a/modules.d/45mptcp/mptcp-route.sh
+++ b/modules.d/45mptcp/mptcp-route.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+
+type getargbool >/dev/null 2>&1 || . /lib/dracut-lib.sh
+. /lib/net-lib.sh
+
+if getargbool 0 rd.live.debug -n -y rdlivedebug; then
+    exec > /tmp/liveroot.$$.out
+    exec 2>> /tmp/liveroot.$$.out
+    set -x
+fi
+
+if [ -e /tmp/mptcp.info ]; then
+    . /tmp/mptcp.info
+elif [ -e /tmp/mptcp.info.up ]; then
+    return
+else
+    return
+fi
+
+set -e
+
+prepare_rt_table() {
+    local rttables=/etc/iproute2/rt_tables
+    local iface=$1
+    if ! grep -Eq "\s${iface}\s*"\$ $rttables; then
+        idx=$(wc -l <$rttables)
+        echo -e "$(( 100 + ${idx} ))\t${iface}" >> $rttables
+    fi
+}
+
+get_ipv4_addressses() {
+    local iface=$1
+    ip -4 addr show dev ${iface} | sed -rn '/inet / s_^.*inet ([0-9.]*)/.*$_\1_p'
+}
+
+get_ipv6_addressses() {
+    local iface=$1
+    ip -6 addr show dev ${iface} | sed -rn '/inet6 / s_^.*inet6 ([0-9a-f:]*)/.*$_\1_p'
+}
+
+transfer_routes_ipv4() {
+    local iface=$1
+    ip -4 route flush table ${iface}
+    ip -4 rou show table main | grep "dev ${iface}" | sed -r 's_expires [^ ]*__' | sed -r 's_proto [^ ]*__' | while read line; do
+        [[ -z "$line" ]] && continue
+        ip -4 route add ${line} table ${iface}
+    done
+}
+
+transfer_routes_ipv6() {
+    local iface=$1
+    ip -6 route flush table ${iface}
+    ip -6 route show table main | grep "dev ${iface}" | sed -r 's_expires [^ ]*__' | sed -r 's_proto [^ ]*__' | while read line; do
+        [[ -z "$line" ]] && continue
+        ip -6 route add ${line} table ${iface}
+    done
+}
+
+get_table_id() {
+    local rttables=/etc/iproute2/rt_tables
+    local table=$1
+    sed -rn "/^\s*[0-9]*\s*${table}/ s_^\s*([0-9]+)\s.*_\1_p" $rttables
+}
+
+replace_rules_ipv4() {
+    local iface=$1
+    local tableid=$(get_table_id $iface)
+    while ip -4 rule show | grep -Eq ^${tableid}; do
+        ip -4 rule del table ${tableid}
+    done
+    for ipaddr in $(get_ipv4_addressses ${iface}); do
+        ip -4 rule add from ${ipaddr} table ${iface}
+    done
+}
+
+replace_rules_ipv6() {
+    local iface=$1
+    local tableid=$(get_table_id $iface)
+    while ip -6 rule show | grep -Eq ^${tableid}; do
+        ip -6 rule flush table ${tableid}
+    done
+    for ipaddr in $(get_ipv6_addressses ${iface}); do
+        echo $ipaddr | grep -Eq '^fe80:' && continue
+        ip -6 rule add from ${ipaddr} table ${iface}
+    done
+}
+
+for iface in $mptcpifaces; do
+    if [ ! -e /tmp/net.$iface.up ]; then
+        ip link set up dev ${iface} && touch /tmp/net.$iface.up
+    fi
+    prepare_rt_table ${iface}
+    transfer_routes_ipv4 ${iface}
+    replace_rules_ipv4 ${iface}
+    wait_for_ipv6_auto ${iface} && transfer_routes_ipv6 ${iface}
+    replace_rules_ipv6 ${iface}
+done
+
+touch /tmp/mptcp.info.up

--- a/modules.d/45mptcp/parse-mptcp.sh
+++ b/modules.d/45mptcp/parse-mptcp.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+#
+# Format:
+#       mptcp=<mptcpifaces>
+#
+#       mptcpifaces is a comma-separated list of interfaces
+#
+
+# return if team already parsed
+[ -n "$mptcpifaces" ] && return
+
+# Check if mptcp parameter is valid
+if getarg mptcp= >/dev/null ; then
+    :
+fi
+
+# We translate list of interfaces to space-separated here to mwke it easier to loop over them in ifup
+parsemptcp() {
+    local v=${1}:
+    set --
+    while [ -n "$v" ]; do
+        set -- "$@" "${v%%:*}"
+        v=${v#*:}
+    done
+
+    unset mptcpifaces
+    case $# in
+    1)  mptcpifaces=$(str_replace "$1" "," " ") ;;
+    *)  die "mptcp= requires one parameter with list of interfaces" ;;
+    esac
+}
+
+unset mptcpifaces
+
+# Parse mptcp for mptcpifaces
+if getarg mptcp >/dev/null; then
+    # Read mptcp= parameters if they exist
+    mptcp="$(getarg mptcp=)"
+    if [ ! "$mptcp" = "mptcp" ]; then
+        parsemptcp "$(getarg mptcp=)"
+    fi
+    # Make it suitable for initscripts export
+    echo "mptcpifaces=\"$mptcpifaces\"" >> /tmp/mptcp.info
+    return
+fi


### PR DESCRIPTION
Sometimes kernel have multipath-tcp support, in this case user may want to enable it in boot time to speedup image loading.
This patch does not wait for getting configured interfaces (write for ipv6 slaac only), what is the best method for waiting to configure interfaces, but before anything else?

Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>