### PR TITLE
shutdown/shutdown.sh: loop over shutdown hooks until all succeed

### DIFF
--- a/modules.d/99shutdown/shutdown.sh
+++ b/modules.d/99shutdown/shutdown.sh
@@ -90,16 +90,19 @@ _check_shutdown() {
         ( . "$__f" $1 )
         if [ $? -eq 0 ]; then
             rm -f -- $__f
+        else
             __s=0
         fi
     done
     return $__s
 }
 
-while _check_shutdown; do
-:
+_cnt=0
+while [ $_cnt -le 40 ]; do
+    _check_shutdown || break
+    _cnt=$(($_cnt+1))
 done
-_check_shutdown final
+[ $_cnt -ge 40 ] && _check_shutdown final
 
 getarg 'rd.break=shutdown' && emergency_shell --shutdown shutdown "Break before shutdown"
 


### PR DESCRIPTION
Up until now, `_check_shutdown()` returns true if at least one of the shutdown hooks succeeded. Change this to only return true if _all_ succeeded. To prevent an infinite loop, introduce an upper bound of 40 iterations.

To see where this rubber meets the road, consider a dm-crypt volume contained in a ZVOL, with the ZFS pool itself being backed by another dm-crypt volume. For the uninitiated, ZFS is not just a filesystem but also an LVM which may contain virtual block devices called ZVOLs. But that is irrelevant, the only thing that matters is that we have dm-crypt layered on ZFS layered on dm-crypt. Yes, that's a real-world example.

Imagine we have two shutdown hooks, `30-dm-shutdown.sh` and `30-export-zfs.sh`. To properly untangle these layers, `30-dm-shutdown.sh` will be invoked first. It should fail since it was only able to close one of two dm-crypt volumes. Next, `30-export-zfs.sh` will be invoked. It will properly export the ZFS pool and exit successfully.

At this point, `30-dm-shutdown.sh` should be invoked a second time to close the remaining dm-crypt volume. Turns out it isn't because `_check_shutdown()` returns true as one of the shutdown hooks, namely `30-export-zfs.sh`, exited successfully. That is fixed by this patch.
