### PR TITLE
Require all interfaces to be up before using iscsistart -b

### DIFF
--- a/modules.d/95iscsi/iscsiroot.sh
+++ b/modules.d/95iscsi/iscsiroot.sh
@@ -43,6 +43,11 @@ fi
 
 handle_firmware()
 {
+    # iscsistart -b may use multiple interfaces so only run when
+    # all are ready.
+    type all_ifaces_up >/dev/null 2>&1 || . /lib/net-lib.sh
+    all_ifaces_up || return 1
+
     if ! [ -e /tmp/iscsistarted-firmware ]; then
         if ! iscsistart -f; then
             warn "iscistart: Could not get list of targets from firmware."


### PR DESCRIPTION
If multiple targets are specified in the ibft, iscsistart will log into
all of them, possibly using multiple interfaces. Since iscsistart is run
indirectly from ifup, require that all interfaces are up before actually
logging into the targets.
