### PR TITLE
dracut-systemd/module-setup.sh: don't re-create existing symlinks

### DIFF
--- a/modules.d/98dracut-systemd/module-setup.sh
+++ b/modules.d/98dracut-systemd/module-setup.sh
@@ -43,16 +43,9 @@ install() {
 
     inst_script "$moddir/rootfs-generator.sh" $systemdutildir/system-generators/dracut-rootfs-generator
 
-    for i in \
-        emergency.target \
-        rescue.service \
-        systemd-ask-password-console.service \
-        systemd-ask-password-plymouth.service \
-        ; do
-        mkdir -p "${initdir}${systemdsystemunitdir}/${i}.wants"
-        ln_r "${systemdsystemunitdir}/systemd-vconsole-setup.service" \
-            "${systemdsystemunitdir}/${i}.wants/systemd-vconsole-setup.service"
-    done
+    mkdir -p "${initdir}${systemdsystemunitdir}/rescue.service.wants"
+    ln_r "${systemdsystemunitdir}/systemd-vconsole-setup.service" \
+        "${systemdsystemunitdir}/rescue.service.wants/systemd-vconsole-setup.service"
 
     mkdir -p "${initdir}/$systemdsystemunitdir/initrd.target.wants"
     for i in \


### PR DESCRIPTION
These symlinks are created earlier by the systemd module.

This is also a workaroud for incorrect behaviour of
ln from coreutils-8.21 that breaks prelink:

$ mkdir -p /tmp/test/dir
$ touch /tmp/test/file
$ ln -sfnr /tmp/test/file /tmp/test/dir/file
$ stat --printf '%N\n' /tmp/test/dir/file
«/tmp/test/dir/file» -> «../file»
$ ln -sfnr /tmp/test/file /tmp/test/dir/file
$ stat --printf '%N\n' /tmp/test/dir/file
«/tmp/test/dir/file» -> «file»

prelink error:
/usr/sbin/prelink: Failed searching /usr/lib/: Too many levels of
symbolic links
