### PR TITLE
Conceal ftp user passwd in rdsosreport

### DIFF
--- a/modules.d/95zfcp/parse-zfcp.sh
+++ b/modules.d/95zfcp/parse-zfcp.sh
@@ -5,6 +5,8 @@
 getargbool 1 rd.zfcp.conf -d -n rd_NO_ZFCPCONF || rm /etc/zfcp.conf
 
 for zfcp_arg in $(getargs rd.zfcp -d 'rd_ZFCP='); do
+    echo $zfcp_arg | grep '0\.[0-9a-fA-F]\.[0-9a-fA-F]\{4\},0x[0-9a-fA-F]\{16\},0x[0-9a-fA-F]\{16\}' >/dev/null
+    test $? -ne 0 && die "For argument 'rd.zfcp=$zfcp_arg'\nSorry, invalid format."
     (
         IFS=","
         set $zfcp_arg

--- a/modules.d/99base/rdsosreport.sh
+++ b/modules.d/99base/rdsosreport.sh
@@ -10,7 +10,7 @@ set -x
 
 cat /lib/dracut/dracut-*
 
-cat /proc/cmdline
+cat /proc/cmdline | sed -e 's/\(ftp:\/\/.*\):.*@/\1:*******@/'
 
 [ -f /etc/cmdline ] && cat /etc/cmdline
 
@@ -47,9 +47,9 @@ cat /proc/mdstat
 command -v ip >/dev/null 2>/dev/null && ip addr
 
 if command -v journalctl >/dev/null 2>/dev/null; then
-    journalctl -ab --no-pager -o short-monotonic
+    journalctl -ab --no-pager -o short-monotonic | sed -e 's/\(ftp:\/\/.*\):.*@/\1:*******@/'
 else
-    dmesg
+    dmesg | sed -e 's/\(ftp:\/\/.*\):.*@/\1:*******@/'
     [ -f /run/initramfs/init.log ] && cat /run/initramfs/init.log
 fi
 


### PR DESCRIPTION
When using authenticated FTP, the password contained in the kernel command line.
This causes it to end up in the generated /run/initramfs/rdsosreport.txt

Signed-off-by: Zhiguo Deng bjzgdeng@linux.vnet.ibm.com
