### PR TITLE
 Install kernel module for active watchdog

### DIFF
--- a/modules.d/04watchdog/module-setup.sh
+++ b/modules.d/04watchdog/module-setup.sh
@@ -32,3 +32,31 @@ install() {
     inst_multiple -o wdctl
 }
 
+installkernel() {
+    [[ -d /sys/class/watchdog/ ]] || return
+    for dir in /sys/class/watchdog/*; do
+	    [[ -d "$dir" ]] || continue
+	    [[ -f "$dir/state" ]] || continue
+	    active=$(< "$dir/state")
+	    ! [[ $hostonly ]] || [[ "$active" =  "active" ]] || continue
+	    # device/modalias will return driver of this device
+	    wdtdrv=$(< "$dir/device/modalias")
+	    # There can be more than one module represented by same
+	    # modalias. Currently load all of them.
+	    # TODO: Need to find a way to avoid any unwanted module
+	    # represented by modalias
+	    wdtdrv=$(modprobe -R $wdtdrv)
+	    instmods $wdtdrv
+	    # however in some cases, we also need to check that if there is
+	    # a specific driver for the parent bus/device.  In such cases
+	    # we also need to enable driver for parent bus/device.
+	    wdtppath=$(readlink -f "$dir/device/..")
+	    while [ -f "$wdtppath/modalias" ]
+	    do
+		    wdtpdrv=$(< "$wdtppath/modalias")
+		    wdtpdrv=$(modprobe -R $wdtpdrv)
+		    instmods $wdtpdrv
+		    wdtppath=$(readlink -f "$wdtppath/..")
+	    done
+    done
+}

--- a/modules.d/04watchdog/module-setup.sh
+++ b/modules.d/04watchdog/module-setup.sh
@@ -12,6 +12,11 @@ depends() {
 
 # called by dracut
 install() {
+    # Do not add watchdog hooks if systemd module is included
+    # In that case, systemd will manage watchdog kick
+    if dracut_module_included "systemd"; then
+	    return
+    fi
     inst_hook cmdline   00 "$moddir/watchdog.sh"
     inst_hook cmdline   50 "$moddir/watchdog.sh"
     inst_hook pre-trigger 00 "$moddir/watchdog.sh"


### PR DESCRIPTION
On behalf of  Pratyush Anand

Changes since V4:
-- Renamed 04watchdog.conf to 00watchdog.conf
Changes since V3:
-- Incorporated changes suggested by Harald for V2 patches

Changes since V2:
-- Added one more patch to update rd.driver.pre with watchdog module name,
so that they are loaded into kernel as early as possible.
-- Removed creation of tmp/active-watchdogs. modinfo will be helpful for
kexec-tools.
-- Now we add modules for active watchdog in hostonly mode and modules for
all watchdog in no-hostonly mode.

Changes since RFC:
-- Added one more patch to take care that dracut does not add watchdog
hooks when systemd module is included. In that case systemd daemon will
manage watchdog for kicking.
-- Removed --nowdt argument. User can use -o or --omit when wathdog module
is not needed. Thanks Harald for this suggestion.
-- Now I also do not check for "hostonly" to add modules for active
watchdog. It seems reasonable to add kernel watchdog modules whenever,
dracut watchdog module has been added.