### PR TITLE
ensure parent dir for /usr/lib/initrd-release exists

### DIFF
--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -77,6 +77,7 @@ install() {
     VERSION_ID=$DRACUT_VERSION
     ANSI_COLOR="0;34"
 
+    [ -e "${initdir}/usr/lib" ] || mkdir -m 0755 -p ${initdir}/usr/lib
     {
         echo NAME=\"$NAME\"
         echo VERSION=\"$VERSION\"


### PR DESCRIPTION
```
/usr/lib/dracut/modules.d/99base/module-setup.sh: line 15: 
/var/tmp/dracut.vkZlVJ/initramfs/usr/lib/initrd-release: No such file or directory
ln: failed to create symbolic link 
'/var/tmp/dracut.vkZlVJ/initramfs/usr/lib/os-release': No such file or directory
```

example of full output:
http://lists.pld-linux.org/mailman/pipermail/pld-devel-en/2016-April/024854.html