### PR TITLE
systemd: ensure journal is volatile

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -210,9 +210,10 @@ install() {
     done
 
     mkdir -p "$initdir/etc/systemd"
-    # turn off RateLimit for journal
+    # We must use a volatile journal, and we don't want rate-limiting
     {
         echo "[Journal]"
+        echo "Storage=volatile"
         echo "RateLimitInterval=0"
         echo "RateLimitBurst=0"
     } >> "$initdir/etc/systemd/journald.conf"


### PR DESCRIPTION
If journald.conf already contains Storage=persistent, journald will
write to /var/log/journal/, which ends up at /run/initramfs/log/journal/
after switching root. We want to make sure early boot logs are written
to /run/log/journal/ so they can be flushed to /var/log/journal/ after
switching root.