### PR TITLE
dracut-systemd/dracut-cmdline.sh: Don't error out if there is no root…

### DIFF
--- a/modules.d/98dracut-systemd/dracut-cmdline.sh
+++ b/modules.d/98dracut-systemd/dracut-cmdline.sh
@@ -21,7 +21,12 @@ getargbool 0 rd.udev.log-priority=debug -d rd.udev.debug -d -n -y rdudevdebug &&
 
 source_conf /etc/conf.d
 
-root=$(getarg root=)
+# Get the "root=" parameter from the kernel command line, but differentiate
+# between the case where it was set to the empty string and the case where it
+# wasn't specified at all.
+if ! root="$(getarg root=)"; then
+    root='UNSET'
+fi
 
 rflags="$(getarg rootflags=)"
 getargbool 0 ro && rflags="${rflags},ro"
@@ -65,9 +70,12 @@ case "$root" in
     /dev/*)
         root="block:${root}"
         rootok=1 ;;
+    UNSET|gpt-auto)
+        # systemd's gpt-auto-generator handles this case.
+        rootok=1 ;;
 esac
 
-[ -z "$root" ] && die "No or empty root= argument"
+[ -z "$root" ] && die "Empty root= argument"
 [ -z "$rootok" ] && die "Don't know how to handle 'root=$root'"
 
 export root rflags fstype netroot NEWROOT


### PR DESCRIPTION
…= argument.

Thanks to systemd's gpt-auto-generator [0] (which implements the Discoverable
Partitions Specification [1]), it is no longer necessary to always specify the
root= argument.

However, dracut would still refuse to boot if there was no root= argument (or
if it was set to the special value "gpt-auto" [2]). This commit stops dracut
from aborting the boot process in these cases and simply lets systemd do its
magic.

[0] https://github.com/systemd/systemd/blob/v229/src/gpt-auto-generator
[1] https://www.freedesktop.org/wiki/Specifications/DiscoverablePartitionsSpec/
[2] https://github.com/systemd/systemd/blob/v229/src/gpt-auto-generator/gpt-auto-generator.c#L928