### PR TITLE
permissions on dev/shm should be 777, not 755 - #1347436

### DIFF
--- a/modules.d/95fcoe/cleanup-fcoe.sh
+++ b/modules.d/95fcoe/cleanup-fcoe.sh
@@ -4,7 +4,7 @@
 
 if [ -e /var/run/lldpad.pid ]; then
     lldpad -k
-    mkdir -m 0755 -p /run/initramfs/state/dev/shm
+    mkdir -m 0777 -p /run/initramfs/state/dev/shm
     cp /dev/shm/lldpad.state /run/initramfs/state/dev/shm/ > /dev/null 2>&1
     echo "files /dev/shm/lldpad.state" >> /run/initramfs/rwtab
 fi


### PR DESCRIPTION
dracut creates (in some circumstances) /run/initramfs/state/
dev/shm/lldpad.state , which is then sync'ed into the real
root by fedora-import-state. Only dracut creates its dev/shm
directory with 0755 permissions, not 0777. /dev/shm is supposed
to be 0777, and various things break if it isn't (e.g. webkit).

Resolves: RHBZ #1347436