### PR TITLE
RHEL7: Install module for active watchdog

### DIFF
--- a/modules.d/04watchdog/module-setup.sh
+++ b/modules.d/04watchdog/module-setup.sh
@@ -31,3 +31,31 @@ install() {
     inst_multiple -o wdctl
 }
 
+installkernel() {
+    [[ -d /sys/class/watchdog/ ]] || return
+    for dir in /sys/class/watchdog/*; do
+	    [[ -d "$dir" ]] || continue
+	    [[ -f "$dir/state" ]] || continue
+	    active=$(< "$dir/state")
+	    ! [[ $hostonly ]] || [[ "$active" =  "active" ]] || continue
+	    # device/modalias will return driver of this device
+	    wdtdrv=$(< "$dir/device/modalias")
+	    # There can be more than one module represented by same
+	    # modalias. Currently load all of them.
+	    # TODO: Need to find a way to avoid any unwanted module
+	    # represented by modalias
+	    wdtdrv=$(modprobe -R $wdtdrv)
+	    instmods $wdtdrv
+	    # however in some cases, we also need to check that if there is
+	    # a specific driver for the parent bus/device.  In such cases
+	    # we also need to enable driver for parent bus/device.
+	    wdtppath=$(readlink -f "$dir/device/..")
+	    while [ -f "$wdtppath/modalias" ]
+	    do
+		    wdtpdrv=$(< "$wdtppath/modalias")
+		    wdtpdrv=$(modprobe -R $wdtpdrv)
+		    instmods $wdtpdrv
+		    wdtppath=$(readlink -f "$wdtppath/..")
+	    done
+    done
+}

--- a/modules.d/04watchdog/module-setup.sh
+++ b/modules.d/04watchdog/module-setup.sh
@@ -33,6 +33,7 @@ install() {
 
 installkernel() {
     [[ -d /sys/class/watchdog/ ]] || return
+    wdtcmdline=""
     for dir in /sys/class/watchdog/*; do
 	    [[ -d "$dir" ]] || continue
 	    [[ -f "$dir/state" ]] || continue
@@ -46,6 +47,7 @@ installkernel() {
 	    # represented by modalias
 	    wdtdrv=$(modprobe -R $wdtdrv)
 	    instmods $wdtdrv
+	    wdtcmdline="$wdtcmdline$(echo $wdtdrv | tr " " ","),"
 	    # however in some cases, we also need to check that if there is
 	    # a specific driver for the parent bus/device.  In such cases
 	    # we also need to enable driver for parent bus/device.
@@ -55,7 +57,10 @@ installkernel() {
 		    wdtpdrv=$(< "$wdtppath/modalias")
 		    wdtpdrv=$(modprobe -R $wdtpdrv)
 		    instmods $wdtpdrv
+		    wdtcmdline="$wdtcmdline$(echo $wdtpdrv | tr " " ","),"
 		    wdtppath=$(readlink -f "$wdtppath/..")
 	    done
     done
+    # ensure that watchdog module is loaded as early as possible
+    [[ $wdtcmdline = "" ]] || echo "rd.driver.pre=$wdtcmdline" > ${initdir}/etc/cmdline.d/00-watchdog.conf
 }

--- a/modules.d/04watchdog/module-setup.sh
+++ b/modules.d/04watchdog/module-setup.sh
@@ -11,6 +11,11 @@ depends() {
 }
 
 install() {
+    # Do not add watchdog hooks if systemd module is included
+    # In that case, systemd will manage watchdog kick
+    if dracut_module_included "systemd"; then
+	    return
+    fi
     inst_hook cmdline   00 "$moddir/watchdog.sh"
     inst_hook cmdline   50 "$moddir/watchdog.sh"
     inst_hook pre-trigger 00 "$moddir/watchdog.sh"

--- a/modules.d/04watchdog/module-setup.sh
+++ b/modules.d/04watchdog/module-setup.sh
@@ -55,7 +55,7 @@ installkernel() {
         # however in some cases, we also need to check that if there is
         # a specific driver for the parent bus/device.  In such cases
         # we also need to enable driver for parent bus/device.
-        _wdtppath=$(readlink -f "$_dir/device/..")
+        _wdtppath=$(readlink -f "$_dir/device")
         while [[ -d "$_wdtppath" ]] && [[ "$_wdtppath" != "/sys" ]]; do
             _wdtppath=$(readlink -f "$_wdtppath/..")
             [[ -f "$_wdtppath/modalias" ]] || continue

--- a/modules.d/04watchdog/module-setup.sh
+++ b/modules.d/04watchdog/module-setup.sh
@@ -13,54 +13,64 @@ depends() {
 install() {
     # Do not add watchdog hooks if systemd module is included
     # In that case, systemd will manage watchdog kick
-    if dracut_module_included "systemd"; then
-	    return
+    if ! dracut_module_included "systemd"; then
+        inst_hook cmdline   00 "$moddir/watchdog.sh"
+        inst_hook cmdline   50 "$moddir/watchdog.sh"
+        inst_hook pre-trigger 00 "$moddir/watchdog.sh"
+        inst_hook initqueue 00 "$moddir/watchdog.sh"
+        inst_hook mount     00 "$moddir/watchdog.sh"
+        inst_hook mount     50 "$moddir/watchdog.sh"
+        inst_hook mount     99 "$moddir/watchdog.sh"
+        inst_hook pre-pivot 00 "$moddir/watchdog.sh"
+        inst_hook pre-pivot 99 "$moddir/watchdog.sh"
+        inst_hook cleanup   00 "$moddir/watchdog.sh"
+        inst_hook cleanup   99 "$moddir/watchdog.sh"
     fi
-    inst_hook cmdline   00 "$moddir/watchdog.sh"
-    inst_hook cmdline   50 "$moddir/watchdog.sh"
-    inst_hook pre-trigger 00 "$moddir/watchdog.sh"
-    inst_hook initqueue 00 "$moddir/watchdog.sh"
-    inst_hook mount     00 "$moddir/watchdog.sh"
-    inst_hook mount     50 "$moddir/watchdog.sh"
-    inst_hook mount     99 "$moddir/watchdog.sh"
-    inst_hook pre-pivot 00 "$moddir/watchdog.sh"
-    inst_hook pre-pivot 99 "$moddir/watchdog.sh"
-    inst_hook cleanup   00 "$moddir/watchdog.sh"
-    inst_hook cleanup   99 "$moddir/watchdog.sh"
     inst_hook emergency 02 "$moddir/watchdog-stop.sh"
     inst_multiple -o wdctl
 }
 
 installkernel() {
+    local -A _drivers
+    local _alldrivers _active _wdtdrv _wdtppath _dir
     [[ -d /sys/class/watchdog/ ]] || return
-    wdtcmdline=""
-    for dir in /sys/class/watchdog/*; do
-	    [[ -d "$dir" ]] || continue
-	    [[ -f "$dir/state" ]] || continue
-	    active=$(< "$dir/state")
-	    ! [[ $hostonly ]] || [[ "$active" =  "active" ]] || continue
-	    # device/modalias will return driver of this device
-	    wdtdrv=$(< "$dir/device/modalias")
-	    # There can be more than one module represented by same
-	    # modalias. Currently load all of them.
-	    # TODO: Need to find a way to avoid any unwanted module
-	    # represented by modalias
-	    wdtdrv=$(modprobe -R $wdtdrv)
-	    instmods $wdtdrv
-	    wdtcmdline="$wdtcmdline$(echo $wdtdrv | tr " " ","),"
-	    # however in some cases, we also need to check that if there is
-	    # a specific driver for the parent bus/device.  In such cases
-	    # we also need to enable driver for parent bus/device.
-	    wdtppath=$(readlink -f "$dir/device/..")
-	    while [ -f "$wdtppath/modalias" ]
-	    do
-		    wdtpdrv=$(< "$wdtppath/modalias")
-		    wdtpdrv=$(modprobe -R $wdtpdrv)
-		    instmods $wdtpdrv
-		    wdtcmdline="$wdtcmdline$(echo $wdtpdrv | tr " " ","),"
-		    wdtppath=$(readlink -f "$wdtppath/..")
-	    done
+    for _dir in /sys/class/watchdog/*; do
+        [[ -d "$_dir" ]] || continue
+        [[ -f "$_dir/state" ]] || continue
+        _active=$(< "$_dir/state")
+        ! [[ $hostonly ]] || [[ "$_active" =  "active" ]] || continue
+        # device/modalias will return driver of this device
+        _wdtdrv=$(< "$_dir/device/modalias")
+        # There can be more than one module represented by same
+        # modalias. Currently load all of them.
+        # TODO: Need to find a way to avoid any unwanted module
+        # represented by modalias
+        _wdtdrv=$(modprobe --set-version "$kernel" -R $_wdtdrv 2>/dev/null)
+        if [[ $_wdtdrv ]]; then
+            instmods $_wdtdrv
+            for i in $_wdtdrv; do
+                _drivers[$i]=1
+            done
+        fi
+        # however in some cases, we also need to check that if there is
+        # a specific driver for the parent bus/device.  In such cases
+        # we also need to enable driver for parent bus/device.
+        _wdtppath=$(readlink -f "$_dir/device/..")
+        while [[ -d "$_wdtppath" ]] && [[ "$_wdtppath" != "/sys" ]]; do
+            _wdtppath=$(readlink -f "$_wdtppath/..")
+            [[ -f "$_wdtppath/modalias" ]] || continue
+
+            _wdtdrv=$(< "$_wdtppath/modalias")
+            _wdtdrv=$(modprobe --set-version "$kernel" -R $_wdtdrv 2>/dev/null)
+            if [[ $_wdtdrv ]]; then
+                instmods $_wdtdrv
+                for i in $_wdtdrv; do
+                    _drivers[$i]=1
+                done
+            fi
+        done
     done
     # ensure that watchdog module is loaded as early as possible
-    [[ $wdtcmdline = "" ]] || echo "rd.driver.pre=$wdtcmdline" > ${initdir}/etc/cmdline.d/00-watchdog.conf
+    _alldrivers="${!_drivers[*]}"
+    [[ $_alldrivers ]] && echo "rd.driver.pre=${_alldrivers// /,}" > ${initdir}/etc/cmdline.d/00-watchdog.conf
 }

--- a/modules.d/04watchdog/module-setup.sh
+++ b/modules.d/04watchdog/module-setup.sh
@@ -73,4 +73,6 @@ installkernel() {
     # ensure that watchdog module is loaded as early as possible
     _alldrivers="${!_drivers[*]}"
     [[ $_alldrivers ]] && echo "rd.driver.pre=${_alldrivers// /,}" > ${initdir}/etc/cmdline.d/00-watchdog.conf
+
+    return 0
 }


### PR DESCRIPTION
These patches are necessary in order to enable kexec-tools to recognize change in active watchdog states.
Patches have been cherry-picked from mainline's master branch [1] without any conflict.

[1] git://git.kernel.org/pub/scm/boot/dracut/dracut.git:master