### PR TITLE
systemd: install missing drop-in configs

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -162,7 +162,9 @@ install() {
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
             /etc/systemd/journald.conf \
+            /etc/systemd/journald.conf.d/*.conf \
             /etc/systemd/system.conf \
+            /etc/systemd/system.conf.d/*.conf \
             /etc/hostname \
             /etc/machine-id \
             /etc/machine-info \


### PR DESCRIPTION
This simply installs `/etc/systemd/journal.conf.d/*.conf` and `/etc/systemd/system.conf.d/*.conf` in host-only mode.