### PR TITLE
qemu: include the qemu_fw_cfg kernel module

### DIFF
--- a/modules.d/90qemu/module-setup.sh
+++ b/modules.d/90qemu/module-setup.sh
@@ -27,5 +27,6 @@ installkernel() {
             ata_piix ata_generic pata_acpi cdrom sr_mod ahci \
             virtio_blk virtio virtio_ring virtio_pci \
             virtio_scsi virtio_console virtio_rng \
-            spapr-vscsi
+            spapr-vscsi \
+            qemu_fw_cfg
 }


### PR DESCRIPTION
This adds support for /sys/firmware/qemu_fw_cfg on QEMU guests started with the -fw_cfg option.