### PR TITLE
livenet: support nfs:// urls in livenet-generator

### DIFF
--- a/modules.d/90livenet/livenet-generator.sh
+++ b/modules.d/90livenet/livenet-generator.sh
@@ -16,6 +16,9 @@ fi
 [ "${liveroot%%:*}" = "live" ] || exit 0
 
 case "$liveroot" in
+    live:nfs://*|nfs://*) \
+        root="${root#live:}"
+        rootok=1 ;;
     live:http://*|http://*) \
         root="${root#live:}"
         rootok=1 ;;


### PR DESCRIPTION
This is a further improvement on PR #105 which re-adds support for nfs:// urls to root=live:nfs://... Symptoms prior to applying this patch are that sysroot.mount times out when following the nfs:// syntax for the path to the live image. An additional case is added to livenet-generator to support the nfs protocol.