### PR TITLE
Update nfs-lib.sh

### DIFF
--- a/modules.d/95nfs/nfs-lib.sh
+++ b/modules.d/95nfs/nfs-lib.sh
@@ -88,7 +88,7 @@ anaconda_nfs_to_var() {
 # IPv6 nfs path will be treated separately
 anaconda_nfsv6_to_var() {
     nfs="nfs"
-    path="$1:"
+    path="$1"
     options="${path#*:/}"
     path="/${options%%:*}"
     server="${1#*nfs:}"


### PR DESCRIPTION
anaconda_nfsv6_to_var(): fix options parsing. $1 contains  : at the end, this is done by previous functions.