### PR TITLE
dracut.sh: support --tmpdir as a relative path

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -820,7 +820,11 @@ esac
 
 [[ $reproducible == yes ]] && DRACUT_REPRODUCIBLE=1
 
-readonly TMPDIR="$tmpdir"
+readonly TMPDIR="$(realpath -e "$tmpdir")"
+[ -d "$TMPDIR" ] || {
+    printf "%s\n" "dracut: Invalid tmpdir '$tmpdir'." >&2
+    exit 1
+}
 readonly DRACUT_TMPDIR="$(mktemp -p "$TMPDIR/" -d -t dracut.XXXXXX)"
 [ -d "$DRACUT_TMPDIR" ] || {
     printf "%s\n" "dracut: mktemp -p '$TMPDIR/' -d -t dracut.XXXXXX failed." >&2


### PR DESCRIPTION
Dracut changes working directory before attempting to output files under
$DRACUT_TMPDIR , resulting in an IO failure if $DRACUT_TMPDIR is a path
relative to the working directory when dracut was started.

Fixes: https://github.com/dracutdevs/dracut/issues/156

Signed-off-by: David Disseldorp ddiss@suse.de
