### PR TITLE
98integrity: support validating the IMA policy file signature

### DIFF
--- a/modules.d/98integrity/ima-policy-load.sh
+++ b/modules.d/98integrity/ima-policy-load.sh
@@ -30,7 +30,8 @@ load_ima_policy()
     # check the existence of the IMA policy file
     [ -f "${IMAPOLICYPATH}" ] && {
         info "Loading the provided IMA custom policy";
-        cat ${IMAPOLICYPATH} > ${IMASECDIR}/policy;
+        echo -n "${IMAPOLICYPATH}" > ${IMASECDIR}/policy || \
+            cat "${IMAPOLICYPATH}" > ${IMASECDIR}/policy
     }
 
     return 0


### PR DESCRIPTION
IMA validates file signatures based on the security.ima xattr. As of
Linux-4.7, instead of cat'ing the IMA policy into the securityfs policy,
the IMA policy pathname can be written, allowing the IMA policy file
signature to be validated.

This patch first attempts to write the pathname, but on failure falls
back to cat'ing the IMA policy contents .

Signed-off-by: Stefan Berger <stefanb@linux.vnet.ibm.com>
Signed-off-by: Mimi Zohar <zohar@linux.vnet.ibm.com>