### PR TITLE
systemd: add more groups to deal with tmpfiles handling.

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -184,6 +184,8 @@ install() {
     grep '^systemd-journal:' /etc/group >> "$initdir/etc/group"
     grep '^wheel:' /etc/group >> "$initdir/etc/group"
     grep '^adm:' /etc/group >> "$initdir/etc/group"
+    grep '^utmp:' /etc/group >> "$initdir/etc/group"
+    grep '^root:' /etc/group >> "$initdir/etc/group"
 
     ln_r $systemdutildir/systemd "/init"
     ln_r $systemdutildir/systemd "/sbin/init"


### PR DESCRIPTION
Both 'utmp' and 'root' groups are mentioned in tmpfiles.d/systemd.conf
and as such should be included.

It's probably better to have something equiv to inst_rule_group_owner()
for udev rules which parses out users and groups and adds them to the
passwd/group db respectively.

Could also rely on sysusers but as the initramfs is static in this
sense, it's more efficient to pre-define the users IMO.
