### PR TITLE
Fix wrong keymap inclusion

### DIFF
--- a/modules.d/10i18n/module-setup.sh
+++ b/modules.d/10i18n/module-setup.sh
@@ -30,8 +30,9 @@ install() {
     # This is from 10redhat-i18n.
     findkeymap () {
         local MAP=$1
+        local MAPNAME=${1%.map*}
         [[ ! -f $MAP ]] && \
-            MAP=$(find ${kbddir}/keymaps -type f -name $MAP -o -name $MAP.\* | head -n1)
+            MAP=$(find ${kbddir}/keymaps -type f -name ${MAPNAME} -o -name ${MAPNAME}.map -o -name ${MAPNAME}.map.\* | head -n1)
         [[ " $KEYMAPS " = *" $MAP "* ]] && return
         KEYMAPS="$KEYMAPS $MAP"
         case $MAP in


### PR DESCRIPTION
For MAP=lt, dracut would choose lt.std.map instead of lt.map.

Signed-off-by: Fabian Vogt fvogt@suse.com
