### PR TITLE
modules: kernel: add phy and power modules to generic initrd

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -28,6 +28,8 @@ installkernel() {
             instmods \
                 "=drivers/clk" \
                 "=drivers/i2c/busses" \
+                "=drivers/phy" \
+                "=drivers/power" \
                 "=drivers/regulator" \
                 "=drivers/rtc" \
                 "=drivers/usb/host" \


### PR DESCRIPTION
The phy and power modules are needed by some of the recent ARM
devices that have appeared like CHIP and some exynos devices.

Signed-off-by: Peter Robinson pbrobinson@gmail.com
