### PR TITLE
fcoe: Allow more time for the bnx2x link negotiation before brining u…

### DIFF
--- a/modules.d/95fcoe/fcoe-up.sh
+++ b/modules.d/95fcoe/fcoe-up.sh
@@ -84,8 +84,8 @@ elif [ "$netdriver" = "bnx2x" ]; then
     # If driver is bnx2x, do not use /sys/module/fcoe/parameters/create but fipvlan
     modprobe 8021q
     udevadm settle --timeout=30
-    # Sleep for 3 s to allow dcb negotiation
-    sleep 3
+    # Sleep for 13 s to allow dcb negotiation
+    sleep 13
     fipvlan "$netif" -c -s
 else
     vlan="no"


### PR DESCRIPTION
…p fcoe interfaces.

bnx2x can take no longer than 3 seconds to initialize the link in some setups
which can cause fipvlan to fail and thus the fcoe interface(s) won't be
created.

Add another 10 seconds to give the link enough time to initialize.

Signed-off-by: Chad Dupuis chad.dupuis@cavium.com
