### PR TITLE
dracut-functions.sh:get_persistent_dev() use persistent_policy

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -223,29 +223,22 @@ get_devpath_block() {
 
 # get a persistent path from a device
 get_persistent_dev() {
-    local i _tmp _dev
+    local i j _tmp _dev _pol
 
     _dev=$(get_maj_min "$1")
     [ -z "$_dev" ] && return
 
-    for i in \
-        /dev/mapper/* \
-        /dev/disk/${persistent_policy:-by-uuid}/* \
-        /dev/disk/by-uuid/* \
-        /dev/disk/by-label/* \
-        /dev/disk/by-partuuid/* \
-        /dev/disk/by-partlabel/* \
-        /dev/disk/by-id/* \
-        /dev/disk/by-path/* \
-        ; do
-        [[ -e "$i" ]] || continue
-        [[ $i == /dev/mapper/control ]] && continue
-        [[ $i == /dev/mapper/mpath* ]] && continue
-        _tmp=$(get_maj_min "$i")
-        if [ "$_tmp" = "$_dev" ]; then
-            printf -- "%s" "$i"
-            return
-        fi
+    for j in ${persistent_policy[@]}; do
+	for i in /dev/disk/${i}/*; do
+            [[ -e "$i" ]] || continue
+            [[ $i == /dev/mapper/control ]] && continue
+            [[ $i == /dev/mapper/mpath* ]] && continue
+            _tmp=$(get_maj_min "$i")
+            if [ "$_tmp" = "$_dev" ]; then
+                printf -- "%s" "$i"
+                return
+            fi
+	done
     done
     printf -- "%s" "$1"
 }

--- a/dracut.8.asc
+++ b/dracut.8.asc
@@ -333,6 +333,8 @@ provide a valid _/etc/fstab_.
     Use _<policy>_ to address disks and partitions.
     _<policy>_ can be any directory name found in /dev/disk.
     E.g. "by-uuid", "by-label"
+    _<policy>_ can also be a list of directories.
+    E.g. the default is "mapper by-uuid by-label by-partuuid by-partlabel by-id by-path"
 
 **--fstab**::
     Use _/etc/fstab_ instead of _/proc/self/mountinfo_.

--- a/dracut.conf.5.asc
+++ b/dracut.conf.5.asc
@@ -101,8 +101,10 @@ Configuration files must have the extension .conf; other extensions are ignored.
 
 *persistent_policy=*"__<policy>__"::
     Use _<policy>_ to address disks and partitions.
-    _<policy>_ can be any directory name found in /dev/disk.
-    E.g. "by-uuid", "by-label"
+    _<policy>_ can be any directory name found in /dev/disk. +
+    E.g. "by-uuid", "by-label" +
+    _<policy>_ can also be a list of directories. +
+    E.g. the default is ( mapper by-uuid by-label by-partuuid by-partlabel by-id by-path )
 
 *tmpdir=*"__<temporary directory>__"::
     Specify temporary directory to use.

--- a/dracut.sh
+++ b/dracut.sh
@@ -732,6 +732,8 @@ stdloglvl=$((stdloglvl + verbosity_mod_l))
 [[ "$hostonly" == "yes" ]] && ! [[ $hostonly_cmdline ]] && hostonly_cmdline="yes"
 [[ $i18n_install_all_l ]] && i18n_install_all=$i18n_install_all_l
 [[ $persistent_policy_l ]] && persistent_policy=$persistent_policy_l
+# add the default fallback
+persistent_policy+=( mapper by-uuid by-label by-partuuid by-partlabel by-id by-path )
 [[ $use_fstab_l ]] && use_fstab=$use_fstab_l
 [[ $mdadmconf_l ]] && mdadmconf=$mdadmconf_l
 [[ $lvmconf_l ]] && lvmconf=$lvmconf_l


### PR DESCRIPTION
set a default value for persistent_policy and let persistent_policy
control on how dracut references a device.
