### PR TITLE
network: Try to load xennet

### DIFF
--- a/modules.d/90kernel-network-modules/module-setup.sh
+++ b/modules.d/90kernel-network-modules/module-setup.sh
@@ -28,7 +28,7 @@ installkernel() {
         =drivers/net/phy \
         =drivers/net/team \
         =drivers/net/ethernet \
-        ecb arc4 bridge stp llc ipv6 bonding 8021q af_packet virtio_net
+        ecb arc4 bridge stp llc ipv6 bonding 8021q af_packet virtio_net xennet
     hostonly="" instmods iscsi_ibft crc32c iscsi_boot_sysfs
 }
 


### PR DESCRIPTION
This makes dracut boot from NFS in a xen instance.

bnc#896464, bnc#896259

Signed-off-by: Thomas Renninger <trenn@suse.de>