### PR TITLE
Always try to add pinctrl-cherryview

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -11,6 +11,7 @@ installkernel() {
             ohci-hcd ohci-pci \
             uhci-hcd \
             xhci-hcd xhci-pci xhci-plat-hcd \
+            pinctrl-cherryview \
             "=drivers/hid" \
             "=drivers/input/serio" \
             "=drivers/input/keyboard" \


### PR DESCRIPTION
Contrary to previous intel pinctrl drivers, the cherryview driver can be
and usually is built as a module. However, it sets up the SDIO pinout
so sdhci can make use of the SD card reader, which may subsequently
hold a root file system on a card  (bsc#998440).