### PR TITLE
Add md4 and arc4 modules for ntlm

### DIFF
--- a/modules.d/95cifs/module-setup.sh
+++ b/modules.d/95cifs/module-setup.sh
@@ -24,6 +24,12 @@ depends() {
 # called by dracut
 installkernel() {
     instmods cifs ipv6
+    # hash algos
+    instmods md4 md5 sha256
+    # ciphers
+    instmods aes arc4 des ecb
+    # macs
+    instmods hmac cmac
 }
 
 # called by dracut


### PR DESCRIPTION
Some crashkernel targets still use legacy NTLM auth, which
require those (bsc#869496). This patch enumerates all dependent
hash algorithems, because even though most of them are probably
compiled in, older ones (e.g. md4 and arc4) usually aren't.