### PR TITLE
95ssh-client: attempt to copy UserKnownHostsFile to kdump's initramfs

### DIFF
--- a/modules.d/95ssh-client/module-setup.sh
+++ b/modules.d/95ssh-client/module-setup.sh
@@ -45,11 +45,18 @@ inst_sshenv()
         inst_simple /etc/ssh/ssh_config
         sed -i -e 's/\(^[[:space:]]*\)ProxyCommand/\1# ProxyCommand/' ${initdir}/etc/ssh/ssh_config
         while read key val || [ -n "$key" ]; do
-            [[ $key != "GlobalKnownHostsFile" ]] && continue
-            inst_simple "$val"
-            break
-        done < /etc/ssh/ssh_config
-    fi
+            if [ $key != "GlobalKnownHostsFile" ]; then
+                inst_simple "$val"
+            # Copy customized UserKnowHostsFile
+            elif [ $key != "UserKnownHostsFile" ]; then
+                # Make sure that ~/foo will be copied as /root/foo in kdump's initramfs
+                if str_starts "$val" "~/"; then
+                    val="/root/${val#"~/"}"
+                fi
+                inst_simple "$val"
+            fi
+         done < /etc/ssh/ssh_config
+     fi
 
     return 0
 }


### PR DESCRIPTION
Bug related to this issue: https://bugzilla.redhat.com/show_bug.cgi?id=1360131
Now dracut only attempts to copy GlobalKnownHostsFile while generating kdump's
initramfs. This method will cause kdump's failure if users set customized
UserKnownHostsFile in /etc/ssh/ssh_config. This patch simply attempts to copy
those files too while going through /etc/ssh/ssh_config. Note that we need to
make sure ~/foo will be copied as /root/foo in kdump's initramfs.

Signed-off-by: Tong Li <tonli@redhat.com>