### PR TITLE
man: make the -k option clear using mkinitrd

### DIFF
--- a/mkinitrd-suse.8.asc
+++ b/mkinitrd-suse.8.asc
@@ -29,8 +29,9 @@ OPTIONS
 
 **-k** _<kernel_list>_::
     List of kernel images for which initrd files are created (relative
-    to _boot_dir_), defaults to _vmlinux_ on ppc/ppc64, _image_ on s390/s390x
-    and _vmlinuz_ for everything else.
+    to _boot_dir_), Image name should begin with the following string,
+    defaults to _vmlinux_ on ppc/ppc64, _image_ on s390/s390x and _vmlinuz_ 
+    for everything else.
 
 **-i** _<initrd_list>_::
     List of file names (relative to _boot_dir_) for the initrd; positions


### PR DESCRIPTION
For example under x86, someone maybe missunderstand that the vmlinuz
is the link /boot/vmlinuz points to a specific kernel image and use
the following command directly.

    mkinitrd -k vmlinuz