### PR TITLE
Add NTFS support to 90dmsquash-live module

### DIFF
--- a/modules.d/90dmsquash-live-ntfs/module-setup.sh
+++ b/modules.d/90dmsquash-live-ntfs/module-setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+command -v
+
+check() {
+    require_binaries ntfs-3g || return 1
+    return 255
+}
+
+depends() {
+    echo 90dmsquash-live
+    return 0
+}
+
+install() {
+    inst_multiple fusermount ulockmgr_server mount.fuse ntfs-3g
+    dracut_need_initqueue
+}
+
+installkernel() {
+    hostonly='' instmods fuse
+}


### PR DESCRIPTION
Support booting from USB media with NTFS filesystem (optionally), which removes the FAT32 related 4 GB file size limit for LiveOS/squashfs.img (and any other file on the same USB media)

Note: I am aware that my patch is not great, but it would be awesome if you could help to make it proper.