### PR TITLE
dracut.sh: Update the default value for the --uefi-stub option.

### DIFF
--- a/dracut.8.asc
+++ b/dracut.8.asc
@@ -498,8 +498,7 @@ will not be able to boot.
 **--uefi-stub _<FILE>_**::
     Specifies the UEFI stub loader, which will load the attached kernel, initramfs and
     kernel command line and boots the kernel. The default is
-    _/lib/systemd/boot/efi/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
-    or _/usr/lib/gummiboot/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
+    _/usr/lib/systemd/boot/efi/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
 
 **--kernel-image _<FILE>_**::
     Specifies the kernel image, which to include in the UEFI executable. The default is

--- a/dracut.conf.5.asc
+++ b/dracut.conf.5.asc
@@ -204,8 +204,7 @@ provide a valid _/etc/fstab_.
 *uefi_stub=*"_<FILE>_"::
     Specifies the UEFI stub loader, which will load the attached kernel, initramfs and
     kernel command line and boots the kernel. The default is
-    _/lib/systemd/boot/efi/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
-    or _/usr/lib/gummiboot/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
+    _/usr/lib/systemd/boot/efi/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
 
 *kernel_image=*"_<FILE>_"::
     Specifies the kernel image, which to include in the UEFI executable. The default is

--- a/dracut.sh
+++ b/dracut.sh
@@ -1028,13 +1028,9 @@ if [[ ! $print_cmdline ]]; then
         esac
 
         if ! [[ -s $uefi_stub ]]; then
-            for uefi_stub in \
-                "/lib/systemd/boot/efi/linux${EFI_MACHINE_TYPE_NAME}.efi.stub" \
-                    "/usr/lib/gummiboot/linux${EFI_MACHINE_TYPE_NAME}.efi.stub"; do
-                [[ -s $uefi_stub ]] || continue
-                break
-            done
+            uefi_stub="/usr/lib/systemd/boot/efi/linux${EFI_MACHINE_TYPE_NAME}.efi.stub"
         fi
+
         if ! [[ -s $uefi_stub ]]; then
             dfatal "Can't find a uefi stub '$uefi_stub' to create a UEFI executable"
             exit 1


### PR DESCRIPTION
Debian [0], Fedora [1], Arch [2], and Gentoo [3] all place the EFI stub at
"/usr/lib/systemd/boot/efi/linux${EFI_MACHINE_TYPE_NAME}.efi.stub", and
gummiboot has been dead for quite some time now [4], so update the default.

[0]: <https://packages.debian.org/sid/amd64/systemd/filelist>
[1]: <https://koji.fedoraproject.org/koji/fileinfo?rpmID=8885631&filename=/usr/lib/systemd/boot/efi/linuxx64.efi.stub>
[2]: <https://www.archlinux.org/packages/core/x86_64/systemd/files/>
[3]: <http://www.portagefilelist.de/site/query/listPackageFiles/?category=sys-apps&package=systemd&version=232&do#result> (Search for "stub")
[4]: <https://cgit.freedesktop.org/gummiboot/log/>