### PR TITLE
Some fixes for ARM hardware generic host initrd generation

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -32,7 +32,11 @@ installkernel() {
                 "=drivers/power" \
                 "=drivers/regulator" \
                 "=drivers/rtc" \
+                "=drivers/usb/chipidea" \
+                "=drivers/usb/dwc2" \
+                "=drivers/usb/dwc3" \
                 "=drivers/usb/host" \
+                "=drivers/usb/musb" \
                 "=drivers/usb/phy" \
                 ${NULL}
         fi

--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -28,6 +28,8 @@ installkernel() {
             instmods \
                 "=drivers/clk" \
                 "=drivers/i2c/busses" \
+                "=drivers/phy" \
+                "=drivers/power" \
                 "=drivers/regulator" \
                 "=drivers/rtc" \
                 "=drivers/usb/host" \


### PR DESCRIPTION
Add some extra kernel modules for ARM generic host initrd generation to ensure we have all modules to install/boot on ARM SBCs and related platforms. 