### PR TITLE
network/ifup: write override file before dhcp_do

### DIFF
--- a/modules.d/40network/ifup.sh
+++ b/modules.d/40network/ifup.sh
@@ -376,6 +376,11 @@ for p in $(getargs ip=); do
     # If this option isn't directed at our interface, skip it
     [ -n "$dev" ] && [ "$dev" != "$netif" ] && continue
 
+    # Store config for later use
+    for i in ip srv gw mask hostname macaddr mtu dns1 dns2; do
+        eval '[ "$'$i'" ] && echo '$i'="$'$i'"'
+    done > /tmp/net.$netif.override
+
     for autoopt in $(str_replace "$autoconf" "," " "); do
         case $autoopt in
             dhcp|on|any)
@@ -396,11 +401,6 @@ for p in $(getargs ip=); do
         [ -n "$s" ] || continue
         echo nameserver $s >> /tmp/net.$netif.resolv.conf
     done
-
-    # Store config for later use
-    for i in ip srv gw mask hostname macaddr mtu dns1 dns2; do
-        eval '[ "$'$i'" ] && echo '$i'="$'$i'"'
-    done > /tmp/net.$netif.override
 
     if [ $ret -eq 0 ]; then
         > /tmp/net.${netif}.up


### PR DESCRIPTION
Commit cf376023e6d0d4abd9816fa954bb917fc2557713 moved writing .resolv.conf and .override
after dhcp_do, because dhcp_do was overwriting .resolv.conf. But .override does not have
such problem and on the contrary dhcp_do reads .override file if it is present. So let's
move it back.

https://bugzilla.redhat.com/show_bug.cgi?id=1415004