### PR TITLE
write-ifcfg: do't write MTU twice for regular eth devices

### DIFF
--- a/modules.d/45ifcfg/write-ifcfg.sh
+++ b/modules.d/45ifcfg/write-ifcfg.sh
@@ -201,10 +201,7 @@ for netup in /tmp/net.*.did-setup ; do
     # bridge needs different things written to ifcfg
     if [ -z "$bridge" ] && [ -z "$bond" ] && [ -z "$vlan" ]; then
         # standard interface
-        {
-            echo "TYPE=Ethernet"
-            [ -n "$mtu" ] && echo "MTU=\"$mtu\""
-        } >> /tmp/ifcfg/ifcfg-$netif
+        echo "TYPE=Ethernet" >> /tmp/ifcfg/ifcfg-$netif
     fi
 
     if [ -n "$vlan" ] ; then


### PR DESCRIPTION
If MTU is specified, we write it for every type of device in the
beginning. There is not point writing it again for Type=ethernet
devices.