### PR TITLE
dracut-init.sh: fix typo

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -231,12 +231,12 @@ dracut_instmods() {
     local i;
     [[ $no_kernel = yes ]] && return
     for i in "$@"; do
-        [[ $i == "--silent" ]] && silent=1
+        [[ $i == "--silent" ]] && _silent=1
     done
 
     $DRACUT_INSTALL \
         ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${hostonly:+-H} ${omit_drivers:+-N "$omit_drivers"} ${srcmods:+--kerneldir "$srcmods"} -m "$@"
-    (($? != 0)) && (($silent == 0)) && derror FAILED: $DRACUT_INSTALL ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${hostonly:+-H} ${omit_drivers:+-N "$omit_drivers"} ${srcmods:+--kerneldir "$srcmods"} -m "$@" || :
+    (($? != 0)) && (($_silent == 0)) && derror FAILED: $DRACUT_INSTALL ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${hostonly:+-H} ${omit_drivers:+-N "$omit_drivers"} ${srcmods:+--kerneldir "$srcmods"} -m "$@" || :
 }
 
 inst_library() {


### PR DESCRIPTION
The variable is called "_silent", not "silent". Just stumbled over this by accident.