### PR TITLE
Aarch64 fixes

### DIFF
--- a/modules.d/50drm/module-setup.sh
+++ b/modules.d/50drm/module-setup.sh
@@ -15,14 +15,14 @@ installkernel() {
     local _modname
     # Include KMS capable drm drivers
 
-    if [[ "$(uname -p)" == arm* ]]; then
-        # arm specific modules needed by drm
+    if [[ "$(uname -m)" == arm* || "$(uname -m)" == aarch64 ]]; then
+        # arm/aarch64 specific modules needed by drm
         instmods \
             "=drivers/gpu/drm/i2c" \
             "=drivers/gpu/drm/panel" \
+            "=drivers/gpu/drm/bridge" \
             "=drivers/pwm" \
             "=drivers/video/backlight" \
-            "=drivers/video/fbdev/omap2/displays-new" \
             ${NULL}
     fi
 

--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -23,10 +23,11 @@ installkernel() {
             virtio virtio_blk virtio_ring virtio_pci virtio_scsi \
             "=drivers/pcmcia" =ide nvme
 
-        if [[ "$(uname -p)" == arm* ]]; then
-            # arm specific modules
+	if [[ "$(uname -m)" == arm* || "$(uname -m)" == aarch64 ]]; then
+            # arm/aarch64 specific modules
             instmods \
                 "=drivers/clk" \
+                "=drivers/dma" \
                 "=drivers/i2c/busses" \
                 "=drivers/phy" \
                 "=drivers/power" \


### PR DESCRIPTION
These add aarch64 to the modules where we specify ARM specifics as well as we need the same extras on the vast majority of aarch64 platforms too

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>