### PR TITLE
crypt: Support keyfiles embedded in the initramfs

### DIFF
--- a/modules.d/90crypt/parse-keydev.sh
+++ b/modules.d/90crypt/parse-keydev.sh
@@ -17,7 +17,12 @@ if getargbool 1 rd.luks -n rd_NO_LUKS && \
             continue
         fi
 
-        if [ -n "$keydev" ]; then
+    # A keydev of '/' is treated as the initrd itself
+    if [ "/" == "$keydev" ]; then
+        [ -z "$luksdev" ] && luksdev='*'
+        echo "$luksdev:$keydev:$keypath" >> /tmp/luks.keys
+        continue
+    elif [ -n "$keydev" ]; then
             udevmatch "$keydev" >&7 || {
                 warn 'keydev incorrect!'
                 continue

--- a/modules.d/90crypt/parse-keydev.sh
+++ b/modules.d/90crypt/parse-keydev.sh
@@ -17,12 +17,12 @@ if getargbool 1 rd.luks -n rd_NO_LUKS && \
             continue
         fi
 
-    # A keydev of '/' is treated as the initrd itself
-    if [ "/" == "$keydev" ]; then
-        [ -z "$luksdev" ] && luksdev='*'
-        echo "$luksdev:$keydev:$keypath" >> /tmp/luks.keys
-        continue
-    elif [ -n "$keydev" ]; then
+        # A keydev of '/' is treated as the initrd itself
+        if [ "/" == "$keydev" ]; then
+            [ -z "$luksdev" ] && luksdev='*'
+            echo "$luksdev:$keydev:$keypath" >> /tmp/luks.keys
+            continue
+        elif [ -n "$keydev" ]; then
             udevmatch "$keydev" >&7 || {
                 warn 'keydev incorrect!'
                 continue


### PR DESCRIPTION
To have a self-contained, signed kernel ready for SecureBoot I need to be able to embed a keyfile (which is GnuPG encrypted, of course) into the initramfs. I'm not sure if this is the best way, but it seemed to be the simplest:

If the kernel commandline contains a luks key option `rd.luks.key=keypath:keydev:luksdev`, then keydev can now be the single character `/`, which signals dracut that instead of probing for the keypath it shall assume that the keypath resides inside the initramfs itself (e.g. added via `install_items+="keypath"` in dracut's configuration file).