### PR TITLE
remove $$arch() from rpm target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ rpm: dracut-$(VERSION).tar.xz syncheck
 	rpmbuild --define "_topdir $$PWD" --define "_sourcedir $$PWD" \
 	        --define "_specdir $$PWD" --define "_srcrpmdir $$PWD" \
 		--define "_rpmdir $$PWD" -ba dracut.spec; ) && \
-	( mv "$$rpmbuild"/*.rpm $(DESTDIR).; mv "$$rpmbuild"/*.src.rpm $(DESTDIR).;rm -fr -- "$$rpmbuild"; ls $(DESTDIR)*.rpm )
+	( mv "$$rpmbuild"/{,$$(arch)/}*.rpm $(DESTDIR).; rm -fr -- "$$rpmbuild"; ls $(DESTDIR)*.rpm )
 
 syncheck:
 	@ret=0;for i in dracut-initramfs-restore.sh modules.d/*/*.sh; do \

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ rpm: dracut-$(VERSION).tar.xz syncheck
 	rpmbuild --define "_topdir $$PWD" --define "_sourcedir $$PWD" \
 	        --define "_specdir $$PWD" --define "_srcrpmdir $$PWD" \
 		--define "_rpmdir $$PWD" -ba dracut.spec; ) && \
-	( mv "$$rpmbuild"/$$(arch)/*.rpm $(DESTDIR).; mv "$$rpmbuild"/*.src.rpm $(DESTDIR).;rm -fr -- "$$rpmbuild"; ls $(DESTDIR)*.rpm )
+	( mv "$$rpmbuild"/*.rpm $(DESTDIR).; mv "$$rpmbuild"/*.src.rpm $(DESTDIR).;rm -fr -- "$$rpmbuild"; ls $(DESTDIR)*.rpm )
 
 syncheck:
 	@ret=0;for i in dracut-initramfs-restore.sh modules.d/*/*.sh; do \


### PR DESCRIPTION
it seems `rpmbuild` result RPMs are not put inside a `$$(arch)` subdirectory. so the `mv` command that is supposed to move the RPMs into `$(DESTDIR)` is failing. getting rid of arch fixes the problem.