### PR TITLE
Look for IPv6 RA in wait_for_ipv6_dad, wait_for_ipv6_dad_link and wait_for_ipv6_auto

### DIFF
--- a/modules.d/40network/ifup.sh
+++ b/modules.d/40network/ifup.sh
@@ -108,6 +108,9 @@ do_static() {
     if strglobin $ip '*:*:*'; then
         # note no ip addr flush for ipv6
         ip addr add $ip/$mask ${srv:+peer $srv} dev $netif
+        echo 0 > /proc/sys/net/ipv6/conf/$netif/forwarding
+        echo 1 > /proc/sys/net/ipv6/conf/$netif/accept_ra
+        echo 1 > /proc/sys/net/ipv6/conf/$netif/accept_redirects
         wait_for_ipv6_dad $netif
     else
         if command -v arping2 >/dev/null; then

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -671,6 +671,7 @@ wait_for_ipv6_dad() {
 
     while [ $cnt -lt $timeout ]; do
         [ -z "$(ip -6 addr show dev "$1" tentative)" ] \
+            && [ -n "$(ip -6 route list proto ra dev "$1")" ] \
             && return 0
         [ -n "$(ip -6 addr show dev "$1" dadfailed)" ] \
             && return 1

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -653,7 +653,9 @@ wait_for_ipv6_dad_link() {
     timeout=$(($timeout*10))
 
     while [ $cnt -lt $timeout ]; do
+        echo "wait_for_ipv6_dad_link..." 1>&2
         [ -z "$(ip -6 addr show dev "$1" scope link tentative)" ] \
+            && [ -n "$(ip -6 route list proto ra dev "$1" | grep default)" ] \
             && return 0
         [ -n "$(ip -6 addr show dev "$1" scope link dadfailed)" ] \
             && return 1
@@ -670,8 +672,9 @@ wait_for_ipv6_dad() {
     timeout=$(($timeout*10))
 
     while [ $cnt -lt $timeout ]; do
+        echo "wait_for_ipv6_dad..." 1>&2
         [ -z "$(ip -6 addr show dev "$1" tentative)" ] \
-            && [ -n "$(ip -6 route list proto ra dev "$1")" ] \
+            && [ -n "$(ip -6 route list proto ra dev "$1" | grep default)" ] \
             && return 0
         [ -n "$(ip -6 addr show dev "$1" dadfailed)" ] \
             && return 1
@@ -688,8 +691,9 @@ wait_for_ipv6_auto() {
     timeout=$(($timeout*10))
 
     while [ $cnt -lt $timeout ]; do
+        echo "wait_for_ipv6_auto..." 1>&2
         [ -z "$(ip -6 addr show dev "$1" tentative)" ] \
-            && [ -n "$(ip -6 route list proto ra dev "$1")" ] \
+            && [ -n "$(ip -6 route list proto ra dev "$1" | grep default)" ] \
             && return 0
         sleep 0.1
         cnt=$(($cnt+1))

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -653,7 +653,6 @@ wait_for_ipv6_dad_link() {
     timeout=$(($timeout*10))
 
     while [ $cnt -lt $timeout ]; do
-        echo "wait_for_ipv6_dad_link..." 1>&2
         [ -z "$(ip -6 addr show dev "$1" scope link tentative)" ] \
             && [ -n "$(ip -6 route list proto ra dev "$1" | grep default)" ] \
             && return 0
@@ -672,7 +671,6 @@ wait_for_ipv6_dad() {
     timeout=$(($timeout*10))
 
     while [ $cnt -lt $timeout ]; do
-        echo "wait_for_ipv6_dad..." 1>&2
         [ -z "$(ip -6 addr show dev "$1" tentative)" ] \
             && [ -n "$(ip -6 route list proto ra dev "$1" | grep default)" ] \
             && return 0
@@ -691,7 +689,6 @@ wait_for_ipv6_auto() {
     timeout=$(($timeout*10))
 
     while [ $cnt -lt $timeout ]; do
-        echo "wait_for_ipv6_auto..." 1>&2
         [ -z "$(ip -6 addr show dev "$1" tentative)" ] \
             && [ -n "$(ip -6 route list proto ra dev "$1" | grep default)" ] \
             && return 0

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -654,7 +654,7 @@ wait_for_ipv6_dad_link() {
 
     while [ $cnt -lt $timeout ]; do
         [ -z "$(ip -6 addr show dev "$1" scope link tentative)" ] \
-            && [ -n "$(ip -6 route list proto ra dev "$1" | grep default)" ] \
+            && [ -n "$(ip -6 route list proto ra dev "$1" | grep ^default)" ] \
             && return 0
         [ -n "$(ip -6 addr show dev "$1" scope link dadfailed)" ] \
             && return 1
@@ -672,7 +672,7 @@ wait_for_ipv6_dad() {
 
     while [ $cnt -lt $timeout ]; do
         [ -z "$(ip -6 addr show dev "$1" tentative)" ] \
-            && [ -n "$(ip -6 route list proto ra dev "$1" | grep default)" ] \
+            && [ -n "$(ip -6 route list proto ra dev "$1" | grep ^default)" ] \
             && return 0
         [ -n "$(ip -6 addr show dev "$1" dadfailed)" ] \
             && return 1
@@ -690,7 +690,7 @@ wait_for_ipv6_auto() {
 
     while [ $cnt -lt $timeout ]; do
         [ -z "$(ip -6 addr show dev "$1" tentative)" ] \
-            && [ -n "$(ip -6 route list proto ra dev "$1" | grep default)" ] \
+            && [ -n "$(ip -6 route list proto ra dev "$1" | grep ^default)" ] \
             && return 0
         sleep 0.1
         cnt=$(($cnt+1))


### PR DESCRIPTION
As per title, you need to wait for default route to be set, this is needed before downloading Anaconda's `squashfs.img` when installing from the network.

Here I am adding the same logic we have in wait_for_ipv6_auto into the other two functions (`wait_for_ipv6_dad`, `wait_for_ipv6_dad_link`).
Also enabling RA acceptance in the `do_static` function...