### PR TITLE
use more portable /usr/bin/env in shebangs

### DIFF
--- a/50-dracut.install
+++ b/50-dracut.install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 COMMAND="$1"
 KERNEL_VERSION="$2"

--- a/51-dracut-rescue-postinst.sh
+++ b/51-dracut-rescue-postinst.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export LANG=C
 

--- a/51-dracut-rescue.install
+++ b/51-dracut-rescue.install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export LANG=C
 

--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # We don't support srcdir != builddir
 echo \#buildapi-variable-no-builddir >/dev/null

--- a/dracut-catimages.sh
+++ b/dracut-catimages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --norc
+#!/usr/bin/env bash --norc
 #
 # Copyright 2009 Red Hat, Inc.  All rights reserved.
 #

--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # functions used by dracut and other tools.
 #

--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # functions used only by dracut and dracut modules
 #

--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/dracut-logger.sh
+++ b/dracut-logger.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # logging faciality module for dracut both at build- and boot-time
 #

--- a/dracut.sh
+++ b/dracut.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --norc
+#!/usr/bin/env bash --norc
 #
 # Generator script for a dracut initramfs
 # Tries to retain some degree of compatibility with the command line

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2005-2010 Harald Hoyer <harald@redhat.com>
 # Copyright 2005-2010 Red Hat, Inc.  All rights reserved.

--- a/mkinitrd-dracut.sh
+++ b/mkinitrd-dracut.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --norc
+#!/usr/bin/env bash --norc
 kver=$(uname -r)
 
 boot_dir="/boot"

--- a/mkinitrd-suse.sh
+++ b/mkinitrd-suse.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --norc
+#!/usr/bin/env bash --norc
 #
 # mkinitrd compability wrapper for SUSE.
 #

--- a/modules.d/00bash/module-setup.sh
+++ b/modules.d/00bash/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/00bootchart/module-setup.sh
+++ b/modules.d/00bootchart/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/00dash/module-setup.sh
+++ b/modules.d/00dash/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/00systemd-bootchart/module-setup.sh
+++ b/modules.d/00systemd-bootchart/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/01systemd-initrd/module-setup.sh
+++ b/modules.d/01systemd-initrd/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/02caps/caps.sh
+++ b/modules.d/02caps/caps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 capsmode=$(getarg rd.caps)
 

--- a/modules.d/02caps/module-setup.sh
+++ b/modules.d/02caps/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/02fips-aesni/module-setup.sh
+++ b/modules.d/02fips-aesni/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/02systemd-networkd/module-setup.sh
+++ b/modules.d/02systemd-networkd/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/03modsign/module-setup.sh
+++ b/modules.d/03modsign/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the GPLv2
 #

--- a/modules.d/03rescue/module-setup.sh
+++ b/modules.d/03rescue/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/04watchdog/module-setup.sh
+++ b/modules.d/04watchdog/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/05busybox/module-setup.sh
+++ b/modules.d/05busybox/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/10i18n/module-setup.sh
+++ b/modules.d/10i18n/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/30convertfs/convertfs.sh
+++ b/modules.d/30convertfs/convertfs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ROOT="$1"
 

--- a/modules.d/30convertfs/do-convertfs.sh
+++ b/modules.d/30convertfs/do-convertfs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if getargbool 0 rd.convertfs; then
     if getargbool 0 rd.debug; then

--- a/modules.d/30convertfs/module-setup.sh
+++ b/modules.d/30convertfs/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/45ifcfg/module-setup.sh
+++ b/modules.d/45ifcfg/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/45url-lib/module-setup.sh
+++ b/modules.d/45url-lib/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # module-setup for url-lib
 
 # called by dracut

--- a/modules.d/50drm/module-setup.sh
+++ b/modules.d/50drm/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/50gensplash/module-setup.sh
+++ b/modules.d/50gensplash/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/50plymouth/module-setup.sh
+++ b/modules.d/50plymouth/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/50plymouth/plymouth-populate-initrd.sh
+++ b/modules.d/50plymouth/plymouth-populate-initrd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PLYMOUTH_LOGO_FILE="/usr/share/pixmaps/system-logo-white.png"
 PLYMOUTH_THEME=$(plymouth-set-default-theme)

--- a/modules.d/80cms/cms-write-ifcfg.sh
+++ b/modules.d/80cms/cms-write-ifcfg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 

--- a/modules.d/80cms/cmsifup.sh
+++ b/modules.d/80cms/cmsifup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 

--- a/modules.d/80cms/cmssetup.sh
+++ b/modules.d/80cms/cmssetup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 

--- a/modules.d/80cms/module-setup.sh
+++ b/modules.d/80cms/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/90btrfs/module-setup.sh
+++ b/modules.d/90btrfs/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/90dm/module-setup.sh
+++ b/modules.d/90dm/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/90dmraid/module-setup.sh
+++ b/modules.d/90dmraid/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/90dmsquash-live/module-setup.sh
+++ b/modules.d/90dmsquash-live/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 installkernel() {

--- a/modules.d/90kernel-network-modules/module-setup.sh
+++ b/modules.d/90kernel-network-modules/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/90livenet/fetch-liveupdate.sh
+++ b/modules.d/90livenet/fetch-liveupdate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # fetch-liveupdate - fetch an update image for dmsquash-live media.
 # this gets called by the "initqueue/online" hook for each network interface
 # that comes online.

--- a/modules.d/90livenet/module-setup.sh
+++ b/modules.d/90livenet/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # module-setup.sh for livenet
 
 # called by dracut

--- a/modules.d/90lvm/module-setup.sh
+++ b/modules.d/90lvm/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/90mdraid/module-setup.sh
+++ b/modules.d/90mdraid/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 is_mpath() {
     local _dev=$1

--- a/modules.d/90qemu-net/module-setup.sh
+++ b/modules.d/90qemu-net/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/90qemu/module-setup.sh
+++ b/modules.d/90qemu/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/91crypt-gpg/module-setup.sh
+++ b/modules.d/91crypt-gpg/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # GPG support is optional
 # called by dracut

--- a/modules.d/91crypt-loop/module-setup.sh
+++ b/modules.d/91crypt-loop/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/95cifs/module-setup.sh
+++ b/modules.d/95cifs/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/95dasd/module-setup.sh
+++ b/modules.d/95dasd/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/95dasd_mod/module-setup.sh
+++ b/modules.d/95dasd_mod/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/95dasd_rules/module-setup.sh
+++ b/modules.d/95dasd_rules/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/95debug/module-setup.sh
+++ b/modules.d/95debug/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/95fcoe-uefi/module-setup.sh
+++ b/modules.d/95fcoe-uefi/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/95fcoe-uefi/parse-uefifcoe.sh
+++ b/modules.d/95fcoe-uefi/parse-uefifcoe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 command -v getarg >/dev/null          || . /lib/dracut-lib.sh
 command -v get_fcoe_boot_mac >/dev/null || . /lib/uefi-lib.sh

--- a/modules.d/95fcoe/lldpad.sh
+++ b/modules.d/95fcoe/lldpad.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Note lldpad will stay running after switchroot, the system initscripts
 # are to kill it and start a new lldpad to take over. Data is transfered

--- a/modules.d/95fcoe/module-setup.sh
+++ b/modules.d/95fcoe/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/95fstab-sys/module-setup.sh
+++ b/modules.d/95fstab-sys/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/95nbd/module-setup.sh
+++ b/modules.d/95nbd/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/95nfs/module-setup.sh
+++ b/modules.d/95nfs/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/95rootfs-block/module-setup.sh
+++ b/modules.d/95rootfs-block/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/95ssh-client/module-setup.sh
+++ b/modules.d/95ssh-client/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # fixme: assume user is root
 

--- a/modules.d/95terminfo/module-setup.sh
+++ b/modules.d/95terminfo/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 install() {

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 install() {

--- a/modules.d/95virtfs/module-setup.sh
+++ b/modules.d/95virtfs/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/95zfcp/module-setup.sh
+++ b/modules.d/95zfcp/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/95zfcp_rules/module-setup.sh
+++ b/modules.d/95zfcp_rules/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/95znet/module-setup.sh
+++ b/modules.d/95znet/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/96securityfs/module-setup.sh
+++ b/modules.d/96securityfs/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/97biosdevname/module-setup.sh
+++ b/modules.d/97biosdevname/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/97masterkey/module-setup.sh
+++ b/modules.d/97masterkey/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/98dracut-systemd/dracut-cmdline-ask.sh
+++ b/modules.d/98dracut-systemd/dracut-cmdline-ask.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 

--- a/modules.d/98dracut-systemd/module-setup.sh
+++ b/modules.d/98dracut-systemd/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/98ecryptfs/module-setup.sh
+++ b/modules.d/98ecryptfs/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/98integrity/module-setup.sh
+++ b/modules.d/98integrity/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/98pollcdrom/module-setup.sh
+++ b/modules.d/98pollcdrom/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/98selinux/module-setup.sh
+++ b/modules.d/98selinux/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/98syslog/module-setup.sh
+++ b/modules.d/98syslog/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/98usrmount/module-setup.sh
+++ b/modules.d/98usrmount/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/99fs-lib/module-setup.sh
+++ b/modules.d/99fs-lib/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/99img-lib/module-setup.sh
+++ b/modules.d/99img-lib/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # module-setup for img-lib
 
 # called by dracut

--- a/modules.d/99shutdown/module-setup.sh
+++ b/modules.d/99shutdown/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/99uefi-lib/module-setup.sh
+++ b/modules.d/99uefi-lib/module-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # called by dracut
 check() {

--- a/modules.d/99uefi-lib/uefi-lib.sh
+++ b/modules.d/99uefi-lib/uefi-lib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Red Hat, Inc.  All rights reserved.
 # Copyright 2013 Harald Hoyer <harald@redhat.com>

--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TEST_DESCRIPTION="root filesystem on a ext3 filesystem"
 
 KVERSION=${KVERSION-$(uname -r)}

--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TEST_DESCRIPTION="root filesystem on a ext3 filesystem"
 
 KVERSION="${KVERSION-$(uname -r)}"

--- a/test/TEST-03-USR-MOUNT/test.sh
+++ b/test/TEST-03-USR-MOUNT/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TEST_DESCRIPTION="root filesystem on a btrfs filesystem with /usr subvolume"
 

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TEST_DESCRIPTION="Full systemd serialization/deserialization test with /usr mount"
 
@@ -145,7 +145,7 @@ EOF
 
 #         mkdir -p $initdir/etc/rc.d
 #         cat >$initdir/etc/rc.d/rc.local <<EOF
-# #!/bin/bash
+# #!/usr/bin/env bash
 # exit 0
 # EOF
 

--- a/test/TEST-10-RAID/test.sh
+++ b/test/TEST-10-RAID/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TEST_DESCRIPTION="root filesystem on an encrypted LVM PV on a RAID-5"
 
 KVERSION=${KVERSION-$(uname -r)}

--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TEST_DESCRIPTION="root filesystem on LVM PV"
 
 KVERSION=${KVERSION-$(uname -r)}

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TEST_DESCRIPTION="root filesystem on an encrypted LVM PV on a degraded RAID-5"
 
 KVERSION=${KVERSION-$(uname -r)}

--- a/test/TEST-13-ENC-RAID-LVM/test.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TEST_DESCRIPTION="root filesystem on LVM on encrypted partitions of a RAID-5"
 
 KVERSION=${KVERSION-$(uname -r)}

--- a/test/TEST-14-IMSM/test.sh
+++ b/test/TEST-14-IMSM/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TEST_DESCRIPTION="root filesystem on LVM PV on a isw dmraid"
 
 KVERSION=${KVERSION-$(uname -r)}

--- a/test/TEST-15-BTRFSRAID/test.sh
+++ b/test/TEST-15-BTRFSRAID/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TEST_DESCRIPTION="root filesystem on multiple device btrfs"
 
 KVERSION=${KVERSION-$(uname -r)}

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TEST_DESCRIPTION="root filesystem on a LiveCD dmsquash filesystem"
 
 KVERSION="${KVERSION-$(uname -r)}"

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TEST_DESCRIPTION="root filesystem on LVM PV with thin pool"
 
 KVERSION=${KVERSION-$(uname -r)}

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TEST_DESCRIPTION="root filesystem on NFS"
 
 KVERSION=${KVERSION-$(uname -r)}

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TEST_DESCRIPTION="root filesystem over iSCSI"
 
 KVERSION=${KVERSION-$(uname -r)}

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TEST_DESCRIPTION="root filesystem on NBD"
 

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TEST_DESCRIPTION="root filesystem on NFS with multiple nics"
 
 KVERSION=${KVERSION-$(uname -r)}

--- a/test/TEST-70-BONDBRIDGETEAMVLAN/test.sh
+++ b/test/TEST-70-BONDBRIDGETEAMVLAN/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 TEST_DESCRIPTION="root filesystem on NFS with bridging/bonding/vlan"

--- a/test/TEST-99-RPM/test.sh
+++ b/test/TEST-99-RPM/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TEST_DESCRIPTION="rpm integrity after dracut and kernel install"
 
@@ -60,7 +60,7 @@ test_run() {
     (( i < 5 ))
 
     cat >"$rootdir"/test.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 export LC_MESSAGES=C
 rpm -Va |& grep -F -v '85-display-manager.preset' &> /test.output

--- a/test/run-qemu
+++ b/test/run-qemu
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Check which virtualization technology to use
 # We prefer kvm, kqemu, userspace in that order.
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin

--- a/test/test-functions
+++ b/test/test-functions
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 export PATH
 


### PR DESCRIPTION
This commit changes all shebangs to use `#!/usr/bin/env bash` instead of
expecting bash to be located in `/bin`. This is especially important
on Nixos, which trades LFS for a more safer pure package manager. Also
the trend in some distributions is to give up `/bin/` for putting all
binaries into `/usr/bin/`.