### PR TITLE
dmsquash-live-root: Avoid mount source conflict on $BASE_LOOPDEV.

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -241,7 +241,12 @@ do_live_overlay() {
     fi
 
     # Create a device that always points to a ro base image
-    echo 0 $sz linear $BASE_LOOPDEV 0 | dmsetup create --readonly live-base
+    if [ -n "$overlayfs" ]; then
+        BASE_LOOPDUP=$(losetup -f --show -r $BASE_LOOPDEV)
+        echo 0 $sz linear $BASE_LOOPDUP 0 | dmsetup create --readonly live-base
+    else
+        echo 0 $sz linear $BASE_LOOPDEV 0 | dmsetup create --readonly live-base
+    fi
 }
 
 # we might have a genMinInstDelta delta file for anaconda to take advantage of


### PR DESCRIPTION
The newer mount utilities are more strict about directly shared
devices. For OverlayFS boots, which mount $BASE_LOOPDEV directly,
avoid a mount error by indirectly sharing the read-only base
filesystem through a second, over-attached $BASE_LOOPDEV for
the DM live-base target.

(Tested on Fedora 26 Alpha.)