### PR TITLE
fix build with KMOD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ pkglibdir ?= ${libdir}/dracut
 sysconfdir ?= ${prefix}/etc
 bindir ?= ${prefix}/bin
 mandir ?= ${prefix}/share/man
-CFLAGS ?= -O2 -g -Wall $(KMOD_CFLAGS)
-CFLAGS += -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
+CFLAGS ?= -O2 -g -Wall
+CFLAGS += -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 $(KMOD_CFLAGS)
 bashcompletiondir ?= ${datadir}/bash-completion/completions
 pkgconfigdatadir ?= $(datadir)/pkgconfig
 


### PR DESCRIPTION
This prevents to fail build when your distro have own CFLAGS env already
@haraldh Please merge

+ CC=/usr/bin/clang
+ export CC
+ CXX=/usr/bin/clang++
+ export CXX
+ CFLAGS='-Os -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fstack-protector-all -fPIC -flto -fPIE'
+ export CFLAGS
+ CXXFLAGS='-Os -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fstack-protector-all -fPIC -flto -fPIE'
+ export CXXFLAGS
+ FFLAGS='-Os -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fstack-protector-all -fPIC -flto'
+ export FFLAGS
+ LDFLAGS='-Os -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fstack-protector-all -fPIC -flto -Wl,-O2  -Wl,--no-undefined -flto -Wl,-z,now -pie'
+ export LDFLAGS
+ CROSSCOMPILE='--target=x86_64-mandriva-linux-gnu --build=x86_64-mandriva-linux-gnu'
+ export CROSSCOMPILE
+ CONFIGURE_TOP=.
+ '[' -f ./configure.in -o -f ./configure.ac ']'
++ pkg-config --variable=completionsdir bash-completion
+ ./configure --target=x86_64-mandriva-linux-gnu --build=x86_64-mandriva-linux-gnu --disable-static --disable-silent-rules --disable-dependency-tracking --disable-rpath --program-prefix= --prefix=/usr --exec-prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --sysconfdir=/etc --datadir=/usr/share --includedir=/usr/include --libdir=/usr/lib64 --libexecdir=/usr/libexec --localstatedir=/var --sharedstatedir=/var/lib --mandir=/usr/share/man --infodir=/usr/share/info --systemdsystemunitdir=/lib/systemd/system --bashcompletiondir= --libdir=/usr/lib
Ignoring unknown option '--target=x86_64-mandriva-linux-gnu'
Ignoring unknown option '--build=x86_64-mandriva-linux-gnu'
Ignoring unknown option '--disable-static'
Ignoring unknown option '--disable-silent-rules'
Ignoring unknown option '--disable-dependency-tracking'
Ignoring unknown option '--disable-rpath'
+ /usr/bin/make -j20 -O CC=/usr/bin/clang
/usr/bin/clang -Os -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fstack-protector-all -fPIC -flto -fPIE -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2   -c -o skipcpio/skipcpio.o skipcpio/skipcpio.c
/usr/bin/clang -Os -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fstack-protector-all -fPIC -flto -fPIE -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2   -c -o install/dracut-install.o install/dracut-install.c
install/dracut-install.c:41:10: fatal error: 'libkmod.h' file not found
#include <libkmod.h>
         ^~~~~~~~~~~
1 error generated.
make: *** [<builtin>: install/dracut-install.o] Error 1
make: *** Waiting for unfinished jobs....