### PR TITLE
change the default value of rd.timeout from 0 to 200

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -147,14 +147,14 @@ Misc
 
 **rd.retry=**__<seconds>__::
     specify how long dracut should retry the initqueue to configure devices.
-    The default is 30 seconds. After 2/3 of the time, degraded raids are force
+    The default is 180 seconds. After 2/3 of the time, degraded raids are force
     started. If you have hardware, which takes a very long time to announce its
     drives, you might want to extend this value.
 
 **rd.timeout=**__<seconds>__::
     specify how long dracut should wait for devices to appear. The
-    default is '0', which means 'forever'. Note that this timeout
-    should be longer than rd.retry to allow for proper configuration.
+    default is 300 seconds. Note that this timeout should be longer
+    than rd.retry to allow for proper configuration.
 
 **rd.noverifyssl**::
     accept self-signed certificates for ssl downloads.

--- a/modules.d/98dracut-systemd/rootfs-generator.sh
+++ b/modules.d/98dracut-systemd/rootfs-generator.sh
@@ -9,7 +9,7 @@ generator_wait_for_dev()
 
     _name="$(str_replace "$1" '/' '\x2f')"
     _timeout=$(getarg rd.timeout)
-    _timeout=${_timeout:-0}
+    _timeout=${_timeout:-300}
 
     if ! [ -e "$hookdir/initqueue/finished/devexists-${_name}.sh" ]; then
 

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -922,7 +922,7 @@ set_systemd_timeout_for_dev()
     fi
 
     _timeout=$(getarg rd.timeout)
-    _timeout=${_timeout:-0}
+    _timeout=${_timeout:-300}
 
     if [ -n "$DRACUT_SYSTEMD" ]; then
         _name=$(dev_unit_name "$1")


### PR DESCRIPTION
Currently rd.timeout default value is 0, this will result in the
systemd job waiting for the target forever, and cause the boot
process hang forever, it's better to wait some default time other
than forever.

We met an issue under kdump, the dump target broke for some reason.
Because wait_for_dev() is invoked due to "--hostonly-cmdline" is
specified when making kdump initramfs in the 1st kernel, we have to
add "rd.timeout=X" to the 1st kernel using grub manually, which is
unacceptable for customers.

This patch sets the default value of rd.timeout to 200s, which is a
little longer than the default value(180s) of rd.try.

Signed-off-by: Xunlei Pang <xlpang@redhat.com>