### PR TITLE
mkinitrd-suse.sh: Fix prefix calculation

### DIFF
--- a/mkinitrd-suse.sh
+++ b/mkinitrd-suse.sh
@@ -104,7 +104,7 @@ calc_netmask() {
     local prefix=$1
 
     [ -z "$prefix" ] && return
-    mask=$(echo "(2 ^ 32) - (2 ^ $prefix)" | bc -l)
+    mask=$(( 0xffffffff << (32 - $prefix) ))
     byte1=$(( mask >> 24 ))
     byte2=$(( mask >> 16 ))
     byte3=$(( mask >> 8 ))


### PR DESCRIPTION
The previous algorithm was incorrect and would return
incorrect results e.g. for a /20 mask. Also gets rid
of an undocumented depencency on bc(1).

Reference: bsc#1035743