### PR TITLE
lvm_scan.sh: use -K when calling lvchange

### DIFF
--- a/modules.d/90lvm/lvm_scan.sh
+++ b/modules.d/90lvm/lvm_scan.sh
@@ -114,7 +114,7 @@ if [ -n "$LVS" ] ; then
     info "Scanning devices $lvmdevs for LVM logical volumes $LVS"
     lvm lvscan $lvm_ignorelockingfailure 2>&1 | vinfo
     for LV in $LVS; do
-        lvm lvchange --yes -ay $lvm_quirk_args $LV 2>&1 | vinfo
+        lvm lvchange --yes -K -ay $lvm_quirk_args $LV 2>&1 | vinfo
     done
 fi
 


### PR DESCRIPTION
The --ignoreactivationskip/-K switch was added to LVM2 in 2.02.99
(July 2013) and is used to control the activation of volumes with
the activation skip flag set: without -K these volumes will be
ignored when 'lvchange -ay $LV' is issued.

This prevents an LVM2 thin-privisioned snapshot from being used
as the root device when booting with "rd.lvm.lv=vg/lv" since the
activation skip flag is set for these snapshots by default (the
legacy non-thinp snapshots do not set this flag and can already
be activated and used as a root device by specifying appropriate
values for rd.lvm.lv).

This is only used in the rd.lvm.lv case since in that situation
we are activating one or more named LVs specified by the user:
the flag is not given when calling 'vgchange' since this may
cause many unwanted volumes to be activated during early user
space. Users wishing to use a specific snapshot volume should
specify it with 'rd.lvm.lv'.

This will be used to make booting into LVM2 snapshot volumes
simpler for end-users.