### PR TITLE
Remove useless code in mdraid:

### DIFF
--- a/modules.d/90mdraid/65-md-incremental-imsm.rules
+++ b/modules.d/90mdraid/65-md-incremental-imsm.rules
@@ -31,8 +31,6 @@ PROGRAM="/bin/sh -c 'for i in $sys/$devpath/holders/md[0-9_]*; do [ -e $$i ] && 
 ENV{DEVTYPE}!="partition", \
     RUN+="/sbin/partx -d --nr 1-1024 $env{DEVNAME}"
 
-RUN+="/sbin/initqueue --timeout --name 50-mdraid_start --onetime --unique /sbin/mdraid_start"
-
 #
 # Incrementally build the md array; this will automatically assemble
 # any eventual containers as well (imsm, ddf)


### PR DESCRIPTION
For now, waiting /dev/md* and force run a degraded raid is done by
/usr/lib/systemd/system/mdadm-last-resort@.{service,timer}.
And "RUN+="/sbin/initqueue --timeout --name 50-mdraid_start --onetime --unique /sbin/mdraid_start"
was not effective since commit a025cc17f0d8145492ffbb37735deca208e768bd removed
RUN+="/sbin/initqueue --finished --unique --name md_finished /sbin/md_finished.sh"