### PR TITLE
kernel-install: Skip to create initrd if /etc/machine-id is missing or empty

### DIFF
--- a/50-dracut.install
+++ b/50-dracut.install
@@ -5,6 +5,12 @@ KERNEL_VERSION="$2"
 BOOT_DIR_ABS="$3"
 KERNEL_IMAGE="$4"
 
+# If KERNEL_INSTALL_MACHINE_ID is defined but empty, BOOT_DIR_ABS is a fake directory.
+# So, let's skip to create initrd.
+if ! [[ ${KERNEL_INSTALL_MACHINE_ID-x} ]]; then
+    exit 0
+fi
+
 ret=0
 case "$COMMAND" in
     add)

--- a/51-dracut-rescue.install
+++ b/51-dracut-rescue.install
@@ -33,11 +33,15 @@ dropindirs_sort()
 
 [[ -f /etc/os-release ]] && . /etc/os-release
 
-if [[ ! -f /etc/machine-id ]] || [[ ! -s /etc/machine-id ]]; then
-    systemd-machine-id-setup
+if [[ ${KERNEL_INSTALL_MACHINE_ID+x} ]]; then
+    MACHINE_ID=$KERNEL_INSTALL_MACHINE_ID
+elif [[ -f /etc/machine-id ]] ; then
+    read MACHINE_ID < /etc/machine-id
 fi
 
-[[ -f /etc/machine-id ]] && read MACHINE_ID < /etc/machine-id
+if ! [[ $MACHINE_ID ]]; then
+    exit 0
+fi
 
 if [[ -f /etc/kernel/cmdline ]]; then
     read -r -d '' -a BOOT_OPTIONS < /etc/kernel/cmdline


### PR DESCRIPTION
From systemd-234, kernel-install plugins are called even if /etc/machine-id
is missing or empty, and in that case BOOT_DIR_ABS is a fake directory.
So, let's skip to create initrd in that case.

C.f. https://github.com/systemd/systemd/commit/9d8813b3b4f69d9428e7759ed8a2956d8846b0fb.
Fixes #231.