### PR TITLE
udev-rules: pull in 40-redhat-cpu-hotplug.rules (#1460707)

### DIFF
--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -27,6 +27,7 @@ install() {
     fi
 
     inst_rules \
+        40-redhat-cpu-hotplug.rules \
         40-redhat.rules \
         50-firmware.rules \
         50-udev-default.rules \


### PR DESCRIPTION
Cpu hotplug policy was split off to separate file. Let's pull in the new
rules file by default.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1266322

Resolves: #1460707