### PR TITLE
fips: add cmac kernel module

### DIFF
--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -21,7 +21,7 @@ installkernel() {
         _fipsmodules+="ecb eseqiv fcrypt gcm ghash_generic hmac khazad lzo md4 md5 michael_mic rmd128 "
         _fipsmodules+="rmd160 rmd256 rmd320 rot13 salsa20 seed seqiv serpent sha1 sha224 sha256 sha256_generic "
         _fipsmodules+="sha384 sha512 sha512_generic tcrypt tea tnepres twofish wp256 wp384 wp512 xeta xtea xts zlib "
-        _fipsmodules+="aes_s390 des_s390 prng sha256_s390 sha_common des_check_key ghash_s390 sha1_s390 sha512_s390"
+        _fipsmodules+="aes_s390 des_s390 prng sha256_s390 sha_common des_check_key ghash_s390 sha1_s390 sha512_s390 cmac"
     fi
 
     mkdir -m 0755 -p "${initdir}/etc/modprobe.d"


### PR DESCRIPTION
cmac is now marked as fips_allowed

Resolves: rhbz#1460865