### PR TITLE
98dracut-systemd: Fix module force loading with systemd

### DIFF
--- a/modules.d/98dracut-systemd/dracut-pre-udev.service
+++ b/modules.d/98dracut-systemd/dracut-pre-udev.service
@@ -15,6 +15,7 @@ Before=systemd-udevd.service dracut-pre-trigger.service
 After=dracut-cmdline.service
 Wants=dracut-cmdline.service
 ConditionPathExists=/usr/lib/initrd-release
+ConditionPathExists=|/etc/cmdline.d/20-force_drivers.conf
 ConditionDirectoryNotEmpty=|/lib/dracut/hooks/pre-udev
 ConditionKernelCommandLine=|rd.break=pre-udev
 ConditionKernelCommandLine=|rd.driver.blacklist


### PR DESCRIPTION
This used to work only when specified via the command line
or if systemd was not being used. However, the exisistence of
20_force_driver.conf also requires dracut-pre-udev.service
to be run.

Reference: bsc#986216