### PR TITLE
network/dhclient-script: also parse dot separated $new_classless_static_routes

### DIFF
--- a/modules.d/40network/dhclient-script.sh
+++ b/modules.d/40network/dhclient-script.sh
@@ -191,7 +191,10 @@ case $reason in
             echo '. /lib/net-lib.sh'
             echo "setup_net $netif"
             if [ -n "$new_classless_static_routes" ]; then
+                OLDIFS="$IFS"
+                IFS=".$IFS"
                 parse_option_121 $new_classless_static_routes
+                IFS="$OLDIFS"
             fi
             echo "source_hook initqueue/online $netif"
             [ -e /tmp/net.$netif.manualup ] || echo "/sbin/netroot $netif"


### PR DESCRIPTION
Previously our dhclient-script expected that $new_classless_static_routes
will have all values separated by a whitespace. But at least on F25
dhclient will put there the destination descriptor in the same format
as it is used by ISC dhcp-server.
For example:
new_classless_static_routes=32.10.198.122.47 192.168.78.4
while our current code expects
new_classless_static_routes=32 10 198 122 47 192 168 78 4

So let's just accept both of these formats by adding "." to IFS.

For details plesse see https://tools.ietf.org/html/rfc3442
"Classless Route Option Format"