### PR TITLE
90crypt: Fixed crypttab_contains() to also work with device path in /etc/crypttab

### DIFF
--- a/modules.d/90crypt/crypt-lib.sh
+++ b/modules.d/90crypt/crypt-lib.sh
@@ -16,6 +16,14 @@ crypttab_contains() {
                     [ "$dev" -ef "$_dev" ] && return 0
                 done
             fi
+            if [ -e /usr/lib/dracut/modules.d/90crypt/block_uuid.map ]; then
+                # search for line starting with $d
+                _line=$(sed -n "\,^$d .*$,{p}" /usr/lib/dracut/modules.d/90crypt/block_uuid.map)
+                [ -z "$_line" ] && continue
+                # get second column with uuid
+                _uuid="$(echo $_line | sed 's,^.* \(.*$\),\1,')"
+	        strstr "$_uuid" "${luks##luks-}" && return 0
+            fi
         done < /etc/crypttab
     fi
     return 1

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -75,6 +75,8 @@ install() {
             [[ $_dev == UUID=* ]] && \
                 _dev="/dev/disk/by-uuid/${_dev#UUID=}"
 
+            echo "$_dev $(blkid $_dev -s UUID -o value)" > /usr/lib/dracut/modules.d/90crypt/block_uuid.map
+
             for _hdev in "${!host_fs_types[@]}"; do
                 [[ ${host_fs_types[$_hdev]} == "crypto_LUKS" ]] || continue
                 if [[ $_hdev -ef $_dev ]] || [[ /dev/block/$_hdev -ef $_dev ]]; then


### PR DESCRIPTION
blkid is not available when this function is called, so block_uuid.map is put into
the initrd, mapping block devices from /etc/crypttab to UUIDs.

This fixes a bug where udev rules were created by mistake as crypttab_contains()
returned false for devices specified by path in /etc/crypttab which resulted in
error messages during boot.

Signed-off-by: Julian Wolf <juwolf@suse.de>