### PR TITLE
dracut.sh: improve udevdir and systemdutildir fallback logic

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1266,16 +1266,16 @@ done
 [[ -d $udevdir ]] \
     || udevdir="$(pkg-config udev --variable=udevdir 2>/dev/null)"
 if ! [[ -d "$udevdir" ]]; then
-    [[ ! -h /lib ]] && [[ -d /lib/udev ]] && udevdir=/lib/udev
-    [[ -d /usr/lib/udev ]] && udevdir=/usr/lib/udev
+    [[ -e /lib/udev/collect ]] && udevdir=/lib/udev
+    [[ -e /usr/lib/udev/collect ]] && udevdir=/usr/lib/udev
 fi
 
 [[ -d $systemdutildir ]] \
     || systemdutildir=$(pkg-config systemd --variable=systemdutildir 2>/dev/null)
 
 if ! [[ -d "$systemdutildir" ]]; then
-    [[ ! -h /lib ]] && [[ -d /lib/systemd ]] && systemdutildir=/lib/systemd
-    [[ -d /usr/lib/systemd ]] && systemdutildir=/usr/lib/systemd
+    [[ -e /lib/systemd/systemd-udevd ]] && systemdutildir=/lib/systemd
+    [[ -e /usr/lib/systemd/systemd-udevd ]] && systemdutildir=/usr/lib/systemd
 fi
 
 [[ -d $systemdsystemunitdir ]] \


### PR DESCRIPTION
Check for a common binary in systemdutildir. This resolves an issue on
split-usr systems, where it is common to have both /lib/systemd[/system]
and /usr/lib/systemd[/user] present.

Check for systemd-udevd specifically, since some distros (Gentoo) allow
udev to be installed without the rest of the systemd stack.

Similar logic is applied to udevdir simply for consistency.