### PR TITLE
40network/dhclient.conf: rename classless-routes to classless-static-…

### DIFF
--- a/modules.d/40network/dhclient.conf
+++ b/modules.d/40network/dhclient.conf
@@ -1,6 +1,6 @@
 
-option classless-routes code 121 = array of unsigned integer 8;
+option classless-static-routes code 121 = array of unsigned integer 8;
 
 request subnet-mask, broadcast-address, time-offset, routers,
         domain-name, domain-name-servers, domain-search, host-name,
-        root-path, interface-mtu, classless-routes;
+        root-path, interface-mtu, classless-static-routes;


### PR DESCRIPTION
…routes

We tell dhclient to name 121 option "classless-routes",
but in dhclient-script we parse classless_static_routes.
So either have to change the configuration or the script.

And since dhclient uses by default classless_static_routes,
let's change the configuration.