### PR TITLE
dhclient: send client-identifier matching hardware address

### DIFF
--- a/modules.d/40network/dhclient.conf
+++ b/modules.d/40network/dhclient.conf
@@ -1,6 +1,8 @@
 
 option classless-routes code 121 = array of unsigned integer 8;
 
+send dhcp-client-identifier = hardware;
+
 request subnet-mask, broadcast-address, time-offset, routers,
         domain-name, domain-name-servers, domain-search, host-name,
         root-path, interface-mtu, classless-routes;


### PR DESCRIPTION
Forcing dhclient to use hardware address (chaddr) instead of DUID to make it
predictable and allows system installation in whitelist based networks.

By default dhclient can send DUID (LL,LLT or UUID) as client-identifier and server may reject such clients.
https://www.net.princeton.edu/announcements/dhcp-cliid-must-match-chaddr.html