### PR TITLE
crypt-loop: cleanup cleanup procedures

### DIFF
--- a/modules.d/90crypt/crypt-lib.sh
+++ b/modules.d/90crypt/crypt-lib.sh
@@ -218,8 +218,7 @@ readkey() {
             if [ -f /lib/dracut-crypt-loop-lib.sh ]; then
                 . /lib/dracut-crypt-loop-lib.sh
                 loop_decrypt "$mntp" "$keypath" "$keydev" "$device"
-                initqueue --onetime --finished --unique --name "crypt-loop-cleanup-99-${mntp##*/}" \
-                    $(command -v umount) "$mntp; " $(command -v rmdir) "$mntp"
+                printf "%s\n" "umount \"$mntp\"; rmdir \"$mntp\";" > ${hookdir}/cleanup/"crypt-loop-cleanup-99-${mntp##*/}".sh
                 return 0
             else
                 die "No loop file support to decrypt '$keypath' on '$keydev'."

--- a/modules.d/91crypt-loop/crypt-loop-lib.sh
+++ b/modules.d/91crypt-loop/crypt-loop-lib.sh
@@ -29,10 +29,8 @@ loop_decrypt() {
 
         [ -b $key ] || die "Failed to unlock $keypath on $keydev for $device."
 
-        initqueue --onetime --finished --unique --name "crypt-loop-cleanup-10-${key##*/}" \
-            $(command -v cryptsetup) "luksClose $key"
-        initqueue --onetime --finished --unique --name "crypt-loop-cleanup-20-${loopdev##*/}" \
-            $(command -v losetup) "-d $loopdev"
+        printf "%s\n" "cryptsetup luksClose \"$key\"" > ${hookdir}/cleanup/"crypt-loop-cleanup-10-${key##*/}".sh
+        printf "%s\n" "losetup -d \"$loopdev\"" > ${hookdir}/cleanup/"crypt-loop-cleanup-20-${loopdev##*/}".sh
     fi
 
     cat $key


### PR DESCRIPTION
Using initqueue --finished to cleanup stuff is not what the
initqueue/finished hook was meant for.

Move stuff to the real cleanup hook.