### PR TITLE
network: Only bring up wired network interfaces

### DIFF
--- a/modules.d/40network/net-genrules.sh
+++ b/modules.d/40network/net-genrules.sh
@@ -102,7 +102,7 @@ command -v fix_bootif >/dev/null || . /lib/net-lib.sh
     # Default: We don't know the interface to use, handle all
     # Fixme: waiting for the interface as well.
     else
-        cond='ACTION=="add", SUBSYSTEM=="net"'
+        cond='ACTION=="add", SUBSYSTEM=="net", ENV{DEVTYPE}!="wlan|wwan"'
         # if you change the name of "91-default-net.rules", also change modules.d/80cms/cmssetup.sh
         echo "$cond, $runcmd" > /etc/udev/rules.d/91-default-net.rules
     fi


### PR DESCRIPTION
The dracut network module is only supposed to be used for wired interfaces
but if driver modules for wireless devices are wrongly copied, these will
be loaded and the available interfaces brought up.

If the rd.neednet=1 command line parameter is used, dhclient will attempt
to request an IP address for the interfaces and these requests will fail.

But other dracut modules that depend on the network to be settled, will
have to wait for the DHCP requests to timeout. Which can be a lot of time
since the dhclient default timeout value is 60 seconds.

Instead of trying to blacklist all possible kernel modules for wireless
devices, only bring up network interfaces if these are for wired devices.

Suggested-by: Harald Hoyer <harald@redhat.com>
Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>