### PR TITLE
ssh-client: Include nss_ libraries

### DIFF
--- a/modules.d/95ssh-client/module-setup.sh
+++ b/modules.d/95ssh-client/module-setup.sh
@@ -63,7 +63,16 @@ inst_sshenv()
 
 # called by dracut
 install() {
+    local _nsslibs
+
     inst_multiple ssh scp
     inst_sshenv
+
+    _nsslibs=$(sed -e '/^#/d' -e 's/^.*://' -e 's/\[NOTFOUND=return\]//' /etc/nsswitch.conf \
+        |  tr -s '[:space:]' '\n' | sort -u | tr -s '[:space:]' '|')
+    _nsslibs=${_nsslibs#|}
+    _nsslibs=${_nsslibs%|}
+
+    inst_libdir_file -n "$_nsslibs" 'libnss_*.so*'
 }
 


### PR DESCRIPTION
SSH uses passwd database and thus need various NSS plugin libraries,
depending upon setting in nsswitch.conf.
    
SSH binary fails within the dracut environment without the libraries:
    
#:/ ssh
No user exist for uid 0
