### PR TITLE
Add NTFS support to 90dmsquash-live module

### DIFF
--- a/modules.d/90dmsquash-live-ntfs/module-setup.sh
+++ b/modules.d/90dmsquash-live-ntfs/module-setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+command -v
+
+check() {
+    require_binaries ntfs-3g || return 1
+    return 255
+}
+
+depends() {
+    echo 90dmsquash-live
+    return 0
+}
+
+install() {
+    inst_multiple fusermount ulockmgr_server mount.fuse ntfs-3g
+    dracut_need_initqueue
+}
+
+installkernel() {
+    hostonly='' instmods fuse
+}

--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -79,7 +79,20 @@ if [ -f $livedev ]; then
     esac
     [ -e /sys/fs/$fstype ] || modprobe $fstype
 else
-    mount -n -t $fstype -o ${liverw:-ro} $livedev /run/initramfs/live
+    if [ "$(blkid -o value -s TYPE $livedev)" != "ntfs" ]; then
+        mount -n -t $fstype -o ${liverw:-ro} $livedev /run/initramfs/live
+    else
+        # Symlinking /usr/bin/ntfs-3g as /sbin/mount.ntfs seems to boot
+        # at the first glance, but ends with lots and lots of squashfs
+        # errors, because systemd attempts to kill the ntfs-3g process?!
+        if [ -x "$(find_binary "ntfs-3g")" ]; then
+            ( exec -a @ntfs-3g ntfs-3g -o ${liverw:-ro} $livedev /run/initramfs/live ) | vwarn
+        else
+            die "Failed to mount block device of live image: Missing NTFS support"
+            exit 1
+        fi
+    fi
+
     if [ "$?" != "0" ]; then
         die "Failed to mount block device of live image"
         exit 1


### PR DESCRIPTION
Support booting from USB media with NTFS filesystem (optionally),
which removes the FAT32 related 4 GB file size limit for LiveOS/
squashfs.img (and any other file on the same USB media).

Backports 37437cac8a1f2c411ead5fca28fb743a6f36f912 from dracut 046