### PR TITLE
dracut.sh: disable lsinitrd logging when quiet

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1759,7 +1759,7 @@ if ! (
     exit 1
 fi
 
-if (( maxloglvl >= 5 )); then
+if (( maxloglvl >= 5 )) && (( verbosity_mod_l >= 0 )); then
     if [[ $allowlocal ]]; then
 	"$dracutbasedir/lsinitrd.sh" "${DRACUT_TMPDIR}/initramfs.img"| ddebug
     else


### PR DESCRIPTION
Currently in Fedora/RedHat dracut installs its fedora.conf.example
as the default config file, in which sysloglvl is set 5. This leads
to maxloglvl=5 in dracut calls, making unnecessary lsinitrd calls
during initramfs builds by kdump.

This patch disables lsinitrd logging when --quiet option is given,
which is controlled by maxloglvl only before. This will speed up
dracut image building as the following if --quiet is used in kdump:

1) Before this patch
$ kdumpctl stop; touch /etc/kdump.conf; time kdumpctl start
kexec: unloaded kdump kernel
Stopping kdump: [OK]
Detected change(s) in the following file(s):
  /etc/kdump.conf
Rebuilding /boot/initramfs-4.13.0-0.rc1.git4.1.fc27.x86_64kdump.img
kexec: loaded kdump kernel
Starting kdump: [OK]
real    0m26.824s
user    0m9.958s
sys     0m15.106s

2) After this patch
$ kdumpctl stop; touch /etc/kdump.conf; time kdumpctl start
kexec: unloaded kdump kernel
Stopping kdump: [OK]
Detected change(s) in the following file(s):
  /etc/kdump.conf
Rebuilding /boot/initramfs-4.13.0-0.rc1.git4.1.fc27.x86_64kdump.img
kexec: loaded kdump kernel
Starting kdump: [OK]
real    0m20.420s
user    0m8.385s
sys     0m10.468s

Signed-off-by: Ziyue Yang <ziyang@redhat.com>