### PR TITLE
Enable core dumps with systemd from initrd

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -33,6 +33,7 @@ install() {
 
     inst_multiple -o \
         $systemdutildir/systemd \
+        $systemdutildir/systemd-coredump \
         $systemdutildir/systemd-cgroups-agent \
         $systemdutildir/systemd-shutdown \
         $systemdutildir/systemd-reply-password \


### PR DESCRIPTION
systemd sets /proc/sys/kernel/core_pattern to use systemd-coredump.
However, systemd-coredump is missing from initrd, making dumping
the core in initrd impossible by default.
