### PR TITLE
Set MTU on bond master as opposed to a bond slave

### DIFF
--- a/modules.d/40network/ifup.sh
+++ b/modules.d/40network/ifup.sh
@@ -257,7 +257,7 @@ if [ -z "$NO_BOND_MASTER" ]; then
             done
 
             # Set mtu on bond master
-            [ -n "$bondmtu" ] && ip link set mtu $bondmtu dev $netif
+            [ -n "$bondmtu" ] && ip link set mtu $bondmtu dev $bondname
 
             # add the bits to setup the needed post enslavement parameters
             for arg in $bondoptions ; do


### PR DESCRIPTION
Prior to this commit, the MTU setting was applied to a bond slave
interface.  In older versions of the Linux kernel, this setting
propagated to the bond master and the other bond slaves associated with
the master.  In recent versions of the kernel (observed in Linux 4.12),
increasing the MTU of a slave does not automatically increase the MTU of
the master.  This allows for more flexibility but requires the MTU of
the master to be changed manually.

Ideally, the MTU setting should be applied to the bond master and the
setting will propagate to the bond slaves, since the slaves are required
to have a MTU that is greater than or equal to the bond master.