### PR TITLE
Do not try to autodetect the output name on non-uefi

### DIFF
--- a/dracut.8.asc
+++ b/dracut.8.asc
@@ -17,8 +17,10 @@ DESCRIPTION
 
 Create an initramfs <image> for the kernel with the version <kernel version>.
 If <kernel version> is omitted, then the version of the actual running
-kernel is used. If <image> is omitted or empty, then the default location
-/boot/initramfs-<kernel version>.img is used.
+kernel is used. If <image> is omitted or empty, then the default location is
+/boot/initramfs-<kernel version>.img for non-UEFI installations, and
+<efidir>/Linux/linux-<kernel version>-<machine id>-<build id>.efi for UEFI
+installations.
 
 dracut creates an initial image used by the kernel for preloading the block
 device modules (such as IDE, SCSI or RAID) which are needed to access the root

--- a/dracut.sh
+++ b/dracut.sh
@@ -773,13 +773,7 @@ if ! [[ $outfile ]]; then
         mkdir -p "$efidir/Linux"
         outfile="$efidir/Linux/linux-$kernel${MACHINE_ID:+-${MACHINE_ID}}${BUILD_ID:+-${BUILD_ID}}.efi"
     else
-        if [[ -e "/boot/vmlinuz-$kernel" ]]; then
-            outfile="/boot/initramfs-$kernel.img"
-        elif [[ $MACHINE_ID ]] && ( [[ -d /boot/${MACHINE_ID} ]] || [[ -L /boot/${MACHINE_ID} ]] ); then
-            outfile="/boot/${MACHINE_ID}/$kernel/initrd"
-        else
-            outfile="/boot/initramfs-$kernel.img"
-        fi
+        outfile="/boot/initramfs-$kernel.img"
     fi
 fi
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1475565.
When 20-grubby.install from systemd created an empty
/boot/<machine-id> directory, dracut would unexpectedly try to create
the initramfs image there. Let's use this output directory only for uefi.
This makes the behaviour match the documentation.

Also update the documentation to say that for uefi, the output directory
is different.