### PR TITLE
Fix MTU on bond interface.

### DIFF
--- a/modules.d/40network/ifup.sh
+++ b/modules.d/40network/ifup.sh
@@ -257,7 +257,7 @@ if [ -z "$NO_BOND_MASTER" ]; then
             done
 
             # Set mtu on bond master
-            [ -n "$bondmtu" ] && ip link set mtu $bondmtu dev $netif
+            [ -n "$bondmtu" ] && ip link set mtu $bondmtu dev $bondname
 
             # add the bits to setup the needed post enslavement parameters
             for arg in $bondoptions ; do


### PR DESCRIPTION
The MTU is only being set on the slave devices and the MTU of the
bonding master is not being updated. This updates the bonding master and
also changes the MTU on the slaves as expected.

Signed-Off-By: Robert LeBlanc <robert@leblancnet.us>