### PR TITLE
systemd: fix setting of timeouts for device units

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-generator.sh
+++ b/modules.d/90dmsquash-live/dmsquash-generator.sh
@@ -78,4 +78,5 @@ mkdir -p "$GENERATOR_DIR/$_dev.device.d"
 {
     echo "[Unit]"
     echo "JobTimeoutSec=3000"
+    echo "JobRunningTimeoutSec=3000"
 } > "$GENERATOR_DIR/$_dev.device.d/timeout.conf"

--- a/modules.d/90livenet/livenet-generator.sh
+++ b/modules.d/90livenet/livenet-generator.sh
@@ -57,4 +57,5 @@ mkdir -p "$GENERATOR_DIR/dev-mapper-live\x2drw.device.d"
 {
     echo "[Unit]"
     echo "JobTimeoutSec=3000"
+    echo "JobRunningTimeoutSec=3000"
 } > "$GENERATOR_DIR/dev-mapper-live\x2drw.device.d/timeout.conf"

--- a/modules.d/98dracut-systemd/rootfs-generator.sh
+++ b/modules.d/98dracut-systemd/rootfs-generator.sh
@@ -32,6 +32,7 @@ generator_wait_for_dev()
         {
             echo "[Unit]"
             echo "JobTimeoutSec=$_timeout"
+            echo "JobRunningTimeoutSec=$_timeout"
         } > "$GENERATOR_DIR"/${_name}.device.d/timeout.conf
     fi
 }

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -938,6 +938,7 @@ set_systemd_timeout_for_dev()
             {
                 echo "[Unit]"
                 echo "JobTimeoutSec=$_timeout"
+                echo "JobRunningTimeoutSec=$_timeout"
             } > ${PREFIX}/etc/systemd/system/${_name}.device.d/timeout.conf
             type mark_hostonly >/dev/null 2>&1 && mark_hostonly /etc/systemd/system/${_name}.device.d/timeout.conf
             _needreload=1


### PR DESCRIPTION
JobRunningTimeoutSec now affects how long can start jobs for device
units stay in the "running" state. Disabling default job timeout via
JobTimeoutSec=0 doesn't disable running state timeout. We need to set
running state timeout as well.

Note that doing this the other way around has effect on generic timeout,
i.e. disabling running state timeout disables generic timeout. But doing
it this way we would create implicit dependency on fairly new
systemd-234. However, by setting both options we don't create dependency
on specific systemd version.