### PR TITLE
Add basic LUKS detached header support

### DIFF
--- a/modules.d/90crypt/cryptroot-ask.sh
+++ b/modules.d/90crypt/cryptroot-ask.sh
@@ -29,9 +29,23 @@ if [ -f /etc/crypttab ] && getargbool 1 rd.luks.crypttab -d -n rd_NO_CRYPTTAB; t
             continue
         fi
 
+        # PARTUUID used in crypttab
+        if [ "${dev%%=*}" = "PARTUUID" ]; then
+            if [ "luks-${dev##PARTUUID=}" = "$luksname" ]; then
+                luksname="$name"
+                break
+            fi
+
         # UUID used in crypttab
-        if [ "${dev%%=*}" = "UUID" ]; then
+        elif [ "${dev%%=*}" = "UUID" ]; then
             if [ "luks-${dev##UUID=}" = "$luksname" ]; then
+                luksname="$name"
+                break
+            fi
+
+        # ID used in crypttab
+        elif [ "${dev%%=*}" = "ID" ]; then
+            if [ "luks-${dev##ID=}" = "$luksname" ]; then
                 luksname="$name"
                 break
             fi
@@ -88,6 +102,10 @@ while [ $# -gt 0 ]; do
             ;;
         allow-discards)
             allowdiscards="--allow-discards"
+            ;;
+        header=*)
+            cryptsetupopts="${cryptsetupopts} --${1}"
+            ;;
     esac
     shift
 done


### PR DESCRIPTION
A LUKS root volume with a detached header on a device without partitioning will not have a UUID and will not have an attribute ENV{ID_FS_TYPE}=="crypto_LUKS".
Therefore, several areas need to be addressed: identification of the LUKS device, inclusion of entries within crypttab, and provision of the detached header file.

- Added support for an option (4th column: "force") in /etc/crypttab to force the inclusion of the entry in the initramfs version (avoiding the fs type test).
- Added support for an option (4th column: "header=/path/to/file") in /etc/crypttab to provide a path to a detached header file embedded within the initramfs.
- Added ID and PARTUUID support to the device (2nd column) in /etc/crypttab (complementing the existing UUID functionality).
- Added cmdline support to indicate LUKS device ("rd.luks.serial=") that refers to the attribute ENV{ID_SERIAL_SHORT}.

Tested successfully on Void Linux (x86_64 musl) (no systemd) with a LUKS root volume accessed with a keyfile and using a detached header (both files embedded within the initramfs using install_items in the dracut configuration file).
Not tested on systemd, or on a LUKS root volume using a passphrase rather than a keyfile.

[1] For background information: https://medium.com/@privb0x23/lose-your-head-attempting-to-boot-from-luks-without-a-header-2d61174df360