### PR TITLE
Sync initramfs after creation

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1806,4 +1806,10 @@ fi
 
 command -v restorecon &>/dev/null && restorecon -- "$outfile"
 
+sync $outfile 2> /dev/null
+if [ $? -ne 0 ] ; then
+    dinfo "dracut: sync operartion on newly created initramfs $outfile failed"
+    exit 1
+fi
+
 exit 0


### PR DESCRIPTION
If we trigger crash just after creating initramfs, sometimes it is
observed that initramfs is not written to disk causing the subsequent
boot to fail. A sync should resolve this.

Signed-off-by: Ankit Kumar <ankit@linux.vnet.ibm.com>