### PR TITLE
Skip iscsi attachment if no info

### DIFF
--- a/modules.d/95iscsi/iscsiroot.sh
+++ b/modules.d/95iscsi/iscsiroot.sh
@@ -44,8 +44,9 @@ fi
 handle_firmware()
 {
     if ! iscsistart -f; then
-        warn "iscistart: Could not get list of targets from firmware."
-        return 1
+        warn "iscistart: Could not get list of targets from firmware. Skipping."
+        echo 'skipped' > "/tmp/iscsistarted-firmware"
+        return 0
     fi
 
     for p in $(getargs rd.iscsi.param -d iscsi_param); do


### PR DESCRIPTION
If no iscsi session information can be retrieved from the firmware
then skip the iscsi attachment and allow the boot process to continue.
Ensure the timeout scripts don't hit their timeout waiting for
/tmp/iscsistarted-firmware to be created.
This will allow a common image to be used for servers with both a
local and iscsi root with rd.iscsi.firmware set.