### PR TITLE
10i18n: Load all keymaps for a given locale

### DIFF
--- a/modules.d/10i18n/module-setup.sh
+++ b/modules.d/10i18n/module-setup.sh
@@ -29,21 +29,24 @@ install() {
 
     # This is from 10redhat-i18n.
     findkeymap () {
-        local MAP=$1
+        local MAPS=$1
         local MAPNAME=${1%.map*}
-        [[ ! -f $MAP ]] && \
-            MAP=$(find ${kbddir}/keymaps -type f -name ${MAPNAME} -o -name ${MAPNAME}.map -o -name ${MAPNAME}.map.\* | head -n1)
-        [[ " $KEYMAPS " = *" $MAP "* ]] && return
-        KEYMAPS="$KEYMAPS $MAP"
-        case $MAP in
-            *.gz) cmd=zgrep;;
-            *.bz2) cmd=bzgrep;;
-            *) cmd=grep ;;
-        esac
+        local map
+        [[ ! -f $MAPS ]] && \
+            MAPS=$(find ${kbddir}/keymaps -type f -name ${MAPNAME} -o -name ${MAPNAME}.map -o -name ${MAPNAME}.map.\*)
 
-        for INCL in $($cmd "^include " $MAP | while read a a b || [ -n "$a" ]; do echo ${a//\"/}; done); do
-            for FN in $(find ${kbddir}/keymaps -type f -name $INCL\*); do
-                findkeymap $FN
+        for map in $MAPS; do
+            KEYMAPS="$KEYMAPS $map"
+            case $map in
+                *.gz) cmd=zgrep;;
+                *.bz2) cmd=bzgrep;;
+                *) cmd=grep ;;
+            esac
+
+            for INCL in $($cmd "^include " $map | while read a a b || [ -n "$a" ]; do echo ${a//\"/}; done); do
+                for FN in $(find ${kbddir}/keymaps -type f -name $INCL\*); do
+                    findkeymap $FN
+                done
             done
         done
     }
@@ -191,7 +194,9 @@ install() {
             findkeymap ${map}
         done
 
-        inst_opt_decompress ${KEYMAPS}
+        for keymap in ${KEYMAPS}; do
+            inst_opt_decompress ${keymap}
+        done
 
         inst_opt_decompress ${kbddir}/consolefonts/${DEFAULT_FONT}.*
 


### PR DESCRIPTION
Previously, dracut would only copy the first one found. However,
with legacy maps for some locales around, there is a chance we
pick the wrong one. Pick all matching keymaps instead

Reference: boo#1065058