### PR TITLE
dmsquash-generator.sh: properly escape backslash in path

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-generator.sh
+++ b/modules.d/90dmsquash-live/dmsquash-generator.sh
@@ -70,7 +70,7 @@ ROOTFLAGS="$(getarg rootflags)"
     else
         echo "What=/dev/mapper/live-rw"
         [ -n "$ROOTFLAGS" ] && echo "Options=${ROOTFLAGS}"
-        _dev=dev-mapper-live\x2drw
+        _dev=$'dev-mapper-live\\x2drw'
     fi
 } > "$GENERATOR_DIR"/sysroot.mount
 


### PR DESCRIPTION
We need an actual bashslash in the filename on disk.

https://bugzilla.redhat.com/show_bug.cgi?id=1508794

Tested by doing 'systemctl cat /dev/mapper/live-rw' after rd.break.