### PR TITLE
ifup.sh: don't wait linkup when set static ip explicitly

### DIFF
--- a/modules.d/40network/ifup.sh
+++ b/modules.d/40network/ifup.sh
@@ -86,7 +86,7 @@ do_ipv6auto() {
 do_static() {
     strglobin $ip '*:*:*' && load_ipv6
 
-    if [ -z "$dev" ] && ! iface_has_carrier "$netif"; then
+    if ! iface_has_carrier "$netif"; then
         warn "No carrier detected on interface $netif"
         return 1
     elif ! linkup "$netif"; then


### PR DESCRIPTION
when set the kernel parameter ```ip=<client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:{none|off|dhcp|on|any|dhcp6|auto6|ibft}[:[<mtu>][:<macaddr>]]```, ```iface_has_carrier``` is skipped. And then fail curl fetch for ```root=live:<url>```.

fix check interface linkup (and delayed) by ```iface_has_carrier``` always.