### PR TITLE
Fix warning about multipath if not needed

### DIFF
--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -10,12 +10,13 @@ is_mpath() {
 # called by dracut
 check() {
     local _rootdev
-    # if there's no multipath binary, no go.
-    require_binaries multipath || return 1
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         for_each_host_dev_and_slaves is_mpath || return 255
     }
+
+    # if there's no multipath binary, no go.
+    require_binaries multipath || return 1
 
     return 0
 }


### PR DESCRIPTION
Although no device uses multipath, the module checks
for presence of the multipath binary first, printing a
warning if not present. This patch fixes the wrong ordering.