### PR TITLE
dracut.sh: for_each_host_xx() function should indicate the empty case

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -468,7 +468,8 @@ for_each_host_dev_fs()
     local _dev
     local _ret=1
 
-    [[ "${#host_fs_types[@]}" ]] || return 0
+    [[ "${#host_fs_types[@]}" ]] || return 2
+
 
     for _dev in "${!host_fs_types[@]}"; do
         $_func "$_dev" "${host_fs_types[$_dev]}" && _ret=0
@@ -527,7 +528,7 @@ for_each_host_dev_and_slaves_all()
     local _dev
     local _ret=1
 
-    [[ "${host_devs[@]}" ]] || return 0
+    [[ "${host_devs[@]}" ]] || return 2
 
     for _dev in "${host_devs[@]}"; do
         [[ -b "$_dev" ]] || continue
@@ -543,7 +544,7 @@ for_each_host_dev_and_slaves()
     local _func="$1"
     local _dev
 
-    [[ "${host_devs[@]}" ]] || return 0
+    [[ "${host_devs[@]}" ]] || return 2
 
     for _dev in "${host_devs[@]}"; do
         [[ -b "$_dev" ]] || continue


### PR DESCRIPTION
The caller of "for_each_host_xx func" needs to tell three cases:
func success/ fail / not be called.
E.g, in kdump case, host_devs can be empty, and we want to know it.

Signed-off-by: Pingfan Liu <piliu@redhat.com>