### PR TITLE
drm: Look for DRM drivers in the staging directory

### DIFF
--- a/modules.d/50drm/module-setup.sh
+++ b/modules.d/50drm/module-setup.sh
@@ -40,6 +40,6 @@ installkernel() {
             fi
         done
     else
-        dracut_instmods -s "drm_crtc_init" "=drivers/gpu/drm"
+        dracut_instmods -s "drm_crtc_init" "=drivers/gpu/drm" "=drivers/staging"
     fi
 }


### PR DESCRIPTION
The recently upstreamed virtualbox video driver (vboxvideo) is shipped
in the staging directory. We need to probe it before Xorg is loaded to
avoid a corrupted X.

In general it is a good practice to look also in the staging directory
for DRM drivers.

Signed-off-by: Carlo Caione <carlo@endlessm.com>