### PR TITLE
Fix loading of modules in modules-load.d

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -160,7 +160,7 @@ install() {
     }
 
     _mods=$(modules_load_get /usr/lib/modules-load.d)
-    [[ $_mods ]] && instmods $_mods
+    [[ $_mods ]] && hostonly='' instmods $_mods
 
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
@@ -180,7 +180,7 @@ install() {
             ${NULL}
 
         _mods=$(modules_load_get /etc/modules-load.d)
-        [[ $_mods ]] && instmods $_mods
+        [[ $_mods ]] && hostonly='' instmods $_mods
     fi
 
     if ! [[ -e "$initdir/etc/machine-id" ]]; then


### PR DESCRIPTION
With hostonly enabled, only modules that are currently
loaded are included in the initrd. Modules which are
explicitly listed in modules-load.d do not need to
be filtered that way. Fix for boo#962224.