### PR TITLE
SUSE fixes for 90multipath

### DIFF
--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -89,6 +89,7 @@ install() {
     fi
 
     inst_hook cleanup   80 "$moddir/multipathd-needshutdown.sh"
+    inst_hook shutdown  20 "$moddir/multipath-shutdown.sh"
 
     inst_rules 40-multipath.rules 56-multipath.rules \
 	62-multipath.rules 65-multipath.rules \

--- a/modules.d/90multipath/multipath-shutdown.sh
+++ b/modules.d/90multipath/multipath-shutdown.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+for i in $(multipath -l -v1); do
+    if ! $(dmsetup table $i | sed -n '/.*queue_if_no_path.*/q1') ; then
+        dmsetup message $i 0 fail_if_no_path
+    fi
+done

--- a/modules.d/90multipath/multipathd-needshutdown.sh
+++ b/modules.d/90multipath/multipathd-needshutdown.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-for i in /dev/mapper/mpath*; do
-    [ -b "$i" ] || continue
-    need_shutdown
-    break
+for i in $(multipath -l -v1); do
+    if $(dmsetup table $i | sed -n '/.*queue_if_no_path.*/q1') ; then
+        need_shutdown
+        break
+    fi
 done

--- a/modules.d/90multipath/multipathd.service
+++ b/modules.d/90multipath/multipathd.service
@@ -6,7 +6,6 @@ Conflicts=shutdown.target
 ConditionKernelCommandLine=!nompath
 ConditionKernelCommandLine=!rd.multipath=0
 ConditionKernelCommandLine=!rd_NO_MULTIPATH
-ConditionPathExists=/etc/multipath.conf
 
 [Service]
 Type=simple

--- a/modules.d/90multipath/multipathd.service
+++ b/modules.d/90multipath/multipathd.service
@@ -8,6 +8,7 @@ Conflicts=shutdown.target
 ConditionKernelCommandLine=!nompath
 ConditionKernelCommandLine=!rd.multipath=0
 ConditionKernelCommandLine=!rd_NO_MULTIPATH
+ConditionKernelCommandLine=!multipath=off
 
 [Service]
 Type=simple

--- a/modules.d/90multipath/multipathd.service
+++ b/modules.d/90multipath/multipathd.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Device-Mapper Multipath Device Controller
 Before=iscsi.service iscsid.service lvm2-activation-early.service
-Wants=systemd-udev-trigger.service systemd-udev-settle.service
+Wants=systemd-udev-trigger.service systemd-udev-settle.service local-fs-pre.target
 After=systemd-udev-trigger.service systemd-udev-settle.service
+Before=local-fs-pre.target
 DefaultDependencies=no
 Conflicts=shutdown.target
 ConditionKernelCommandLine=!nompath

--- a/modules.d/90multipath/multipathd.service
+++ b/modules.d/90multipath/multipathd.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Device-Mapper Multipath Device Controller
 Before=iscsi.service iscsid.service lvm2-activation-early.service
+Wants=systemd-udev-trigger.service systemd-udev-settle.service
+After=systemd-udev-trigger.service systemd-udev-settle.service
 DefaultDependencies=no
 Conflicts=shutdown.target
 ConditionKernelCommandLine=!nompath


### PR DESCRIPTION
Amongst others, this adds support for legacy commandline
options multipath=off. I'd like to maintain this upstream.

If not acceptable, I'll drop this one off the stack and keep it a distro patch.