### PR TITLE
90dmraid: do not delete partitions

### DIFF
--- a/modules.d/90dmraid/61-dmraid-imsm.rules
+++ b/modules.d/90dmraid/61-dmraid-imsm.rules
@@ -23,9 +23,6 @@ ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="1", GOTO="dm_end"
 PROGRAM=="/bin/sh -c 'for i in $sys/$devpath/holders/dm-[0-9]*; do [ -e $$i ] && exit 0; done; exit 1;' ", \
     GOTO="dm_end"
 
-ENV{DEVTYPE}!="partition", \
-    RUN+="/sbin/partx -d --nr 1-1024 $env{DEVNAME}"
-
 RUN+="/sbin/initqueue --onetime --unique --settled /sbin/dmraid_scan $env{DEVNAME}"
 
 LABEL="dm_end"


### PR DESCRIPTION
There is no point trying to delete partitions; dmraid works
happily even with them. On the contrary trying to delete partitions
can even be harmful when eg dmraid should _not_ be started.

References: bsc#998860

Signed-off-by: Hannes Reinecke <hare@suse.com>