### PR TITLE
95dasd_mod: do not set module parameters if dasd_cio_free is not present

### DIFF
--- a/modules.d/95dasd_mod/parse-dasd-mod.sh
+++ b/modules.d/95dasd_mod/parse-dasd-mod.sh
@@ -7,7 +7,7 @@ done
 
 mod_args="${mod_args#*,}"
 
-if [ -n "$mod_args" ]; then
+if [ -x /sbin/dasd_cio_free -a -n "$mod_args" ]; then
     [ -d /etc/modprobe.d ] || mkdir -m 0755 -p /etc/modprobe.d
     echo "options dasd_mod dasd=$mod_args" >> /etc/modprobe.d/dasd_mod.conf
 fi


### PR DESCRIPTION
We're now parsing the 'rd.dasd' parameter from 95dasd_rules, so
setting the 'dasd_mod' module parameter should be dropped here.

Signed-off-by: Hannes Reinecke <hare@suse.de>