### PR TITLE
fcoe-uefi: Add check for usage

### DIFF
--- a/modules.d/95fcoe-uefi/module-setup.sh
+++ b/modules.d/95fcoe-uefi/module-setup.sh
@@ -12,6 +12,11 @@ check() {
     }
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         [ -d /sys/firmware/efi ] || return 255
+        for c in /sys/bus/fcoe/devices/ctlr_* ; do
+            [ -L $c ] || continue
+            fcoe_ctlr=$c
+        done
+        [ -z "$fcoe_ctlr" ] && return 255
     }
     require_binaries dcbtool fipvlan lldpad ip readlink || return 1
     return 0


### PR DESCRIPTION
References: boo#965477

fcoe-uefi gets included by default on EFI systems,
as it does not do the same check that fcoe does,
therefore needlessly pulling in network modules.
This patch copies the check from fcoe to fcoe-uefi.