### PR TITLE
95resume: Do not resume on iSCSI

### DIFF
--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -9,20 +9,9 @@ check() {
     # If hostonly was requested, fail the check if we are not actually
     # booting from root.
 
-    is_iscsi() {
-        local _dev=$1
-
-        [[ -L "/sys/dev/block/$_dev" ]] || return
-        cd "$(readlink -f "/sys/dev/block/$_dev")"
-        until [[ -d sys || -d iscsi_session ]]; do
-            cd ..
-        done
-        [[ -d iscsi_session ]]
-    }
-
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         pushd . >/dev/null
-        for_each_host_dev_and_slaves is_iscsi
+        for_each_host_dev_and_slaves block_is_iscsi
         local _is_iscsi=$?
         popd >/dev/null
         [[ $_is_iscsi == 0 ]] || return 255
@@ -223,6 +212,7 @@ install() {
     inst_hook cmdline 90 "$moddir/parse-iscsiroot.sh"
     inst_hook cleanup 90 "$moddir/cleanup-iscsi.sh"
     inst "$moddir/iscsiroot.sh" "/sbin/iscsiroot"
+
     if ! dracut_module_included "systemd"; then
         inst "$moddir/mount-lun.sh" "/bin/mount-lun.sh"
     else

--- a/modules.d/95nbd/module-setup.sh
+++ b/modules.d/95nbd/module-setup.sh
@@ -7,11 +7,9 @@ check() {
     # if an nbd device is not somewhere in the chain of devices root is
     # mounted on, fail the hostonly check.
     [[ $hostonly ]] || [[ $mount_needs ]] && {
-        is_nbd() { [[ -b /dev/block/$1 && $1 == 43:* ]] ;}
-
         _rootdev=$(find_root_block_device)
         [[ -b /dev/block/$_rootdev ]] || return 1
-        check_block_and_slaves is_nbd "$_rootdev" || return 255
+        check_block_and_slaves block_is_nbd "$_rootdev" || return 255
     }
     require_binaries nbd-client || return 1
 

--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -2,9 +2,18 @@
 
 # called by dracut
 check() {
+    swap_on_netdevice() {
+        local _dev
+        for _dev in "${swap_devs[@]}"; do
+            block_is_netdevice $_dev && return 0
+        done
+        return 1
+    }
+
     # Only support resume if hibernation is currently on
+    # and no swap is mounted on a net device
     [[ $hostonly ]] || [[ $mount_needs ]] && {
-        [[ "$(cat /sys/power/resume)" == "0:0" ]] && return 255
+        swap_on_netdevice || [[ "$(cat /sys/power/resume)" == "0:0" ]] && return 255
     }
 
     return 0


### PR DESCRIPTION
The iSCSI configuration is started after dracut checks for resume,
so we run into a timeout here. Additionally it's questionable if
resume on iSCSI makes sense (or is even supported on the platform),
so disable it for now.

References: bsc#999663

Signed-off-by: Hannes Reinecke <hare@suse.com>