### PR TITLE
Set TaskMax=inifinite for the emergency shell

### DIFF
--- a/modules.d/98dracut-systemd/dracut-emergency.service
+++ b/modules.d/98dracut-systemd/dracut-emergency.service
@@ -22,6 +22,7 @@ StandardOutput=inherit
 StandardError=inherit
 KillMode=process
 IgnoreSIGPIPE=no
+TasksMax=infinity
 
 # Bash ignores SIGTERM, so we send SIGHUP instead, to ensure that bash
 # terminates cleanly.


### PR DESCRIPTION
Certain rescue/recovery operations, e.g. xfs_repair need
that liberty (bsc#1019938).