### PR TITLE
call fsfreeze(8) on /boot to flush initramfs data & metadata to media

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1828,8 +1828,13 @@ fi
 command -v restorecon &>/dev/null && restorecon -- "$outfile"
 
 if ! sync "$outfile" 2> /dev/null; then
-    dinfo "dracut: sync operartion on newly created initramfs $outfile failed"
+    dinfo "dracut: sync operation on newly created initramfs $outfile failed"
     exit 1
+# use fsfreeze only if we're not writing to /
+elif ! [ "$(stat -c %m -- "$outfile")" == "/" ]; then
+    if ! $(fsfreeze -f $(dirname "$outfile") 2>/dev/null && fsfreeze -u $(dirname "$outfile") 2>/dev/null); then
+        dinfo "dracut: warning: could not fsfreeze $(dirname "$outfile")"
+    fi
 fi
 
 exit 0


### PR DESCRIPTION
If /boot is a journaling file system, the only guarantee after sync(1) is that data has been written to the disk media, but not metadata.
It is necessary to either umount the filesystem or call fsfreeze(8) for metadata to be written to stable disk media (elsewhere than the journal).
As grub2 does not know how to handle a journaled filesystem, e316ae0e4309726b2c067a70ac41f7b22011c063 alone does not ensure consistency.

Note that I explicitly avoided using fsfreeze(8) if /boot and / belong to the same file system - I think this would be wrong for many reasons.

This is related to https://github.com/rhboot/grubby/pull/28 and part of an on-going effort to fix https://bugzilla.redhat.com/show_bug.cgi?id=1227736 .