### PR TITLE
call fsfreeze(8) on /boot to flush initramfs data & metadata to media

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1628,4 +1628,10 @@ else
     exit 1
 fi
 
+if $(mountpoint -q $(dirname "$outfile")); then
+    if ! $(fsfreeze -f $(dirname "$outfile") 2>/dev/null && fsfreeze -u $(dirname "$outfile") 2>/dev/null); then
+        dinfo "dracut: warning: could not fsfreeze $(dirname "$outfile")"
+    fi
+fi
+
 exit 0


### PR DESCRIPTION
Cherry-picked from: 58e3971b920fbb60e5a90edfd30aa887f9818100
As RHEL7 (as of 7.4) does not know how to handle $(sync $PATH)) backporting e316ae0 does not make sense.

If /boot is a journaling file system, the only guarantee after sync(1) is that data has been written to the disk media, but not metadata.
It is necessary to either umount the filesystem or call fsfreeze(8) for metadata to be written to stable disk media (elsewhere than the journal).

Note that I explicitly avoided using fsfreeze(8) if /boot and / belong to the same file system - I think this would be wrong for many reasons.

This is related to rhboot/grubby#28 and part of an on-going effort to fix https://bugzilla.redhat.com/show_bug.cgi?id=1227736 .

