### PR TITLE
Use pattern matching function

### DIFF
--- a/modules.d/99fs-lib/fs-lib.sh
+++ b/modules.d/99fs-lib/fs-lib.sh
@@ -100,7 +100,7 @@ fsck_drv_com() {
     local _ret
     local _out
 
-    if ! strstr "$_fop" "-[ynap]"; then
+    if ! strglobin "$_fop" "-[ynap]"; then
         _fop="-a ${_fop}"
     fi
 


### PR DESCRIPTION
The needle argument in this specific case is a pattern, which cannot be
matched by the "literal" string matcher strstr.

This can result in fsck calls like:

    e2fsck -a -y /dev/sda1

Which will then exit with an error like:

    e2fsck: Only one of the options -p/-a, -n or -y may be specified.

Hence, it is necessary to use the strglobin function to correctly match
the pattern.