### PR TITLE
01fips: Fix creating path to .hmac of kernel based on BOOT_IMAGE

### DIFF
--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -110,13 +110,19 @@ do_fips()
         do_rhevh_check /run/initramfs/live/isolinux/vmlinuz0 || return 1
     else
         BOOT_IMAGE="$(getarg BOOT_IMAGE)"
-        [ -e "/boot/.${BOOT_IMAGE}.hmac" ] || BOOT_IMAGE="vmlinuz-${KERNEL}"
+        if ! [ -e "/boot/${BOOT_IMAGE}" ]; then
+            #if /boot is not a separate partition BOOT_IMAGE might start with /boot
+            BOOT_IMAGE=${BOOT_IMAGE#"/boot"}
+            [ -e "/boot/${BOOT_IMAGE}" ] || BOOT_IMAGE="vmlinuz-${KERNEL}"
+        fi
+        
+        BOOT_IMAGE_HMAC="/boot/${BOOT_IMAGE%/*}/.${BOOT_IMAGE##*/}.hmac"
 
-        if ! [ -e "/boot/.${BOOT_IMAGE}.hmac" ]; then
-            warn "/boot/.${BOOT_IMAGE}.hmac does not exist"
+        if ! [ -e "${BOOT_IMAGE_HMAC}" ]; then
+            warn "${BOOT_IMAGE_HMAC} does not exist"
             return 1
         fi
-        sha512hmac -c "/boot/.${BOOT_IMAGE}.hmac" || return 1
+        sha512hmac -c "${BOOT_IMAGE_HMAC}" || return 1
     fi
 
     info "All initrd crypto checks done"


### PR DESCRIPTION
Old code did not work for two most common use-cases.
On most machines BOOT_IMAGE is set to something like
/vmlinuz-4.11.3-202.fc25.x86_64. So if we just add prefix "/boot/."
it won't work. Also on machines without /boot on separate partition
BOOT_IMAGE already has the /boot/ prefix (/boot/vmlinuz-3.10.0-799.el7.x86_64).
So let's strip it in such case.

https://bugzilla.redhat.com/show_bug.cgi?id=1415032