### PR TITLE
Fix possible hang in dracut

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1466,7 +1466,7 @@ if [[ $no_kernel != yes ]]; then
         hostonly='' instmods $drivers
     fi
 
-    if [[ $add_drivers ]]; then
+    if [[ -n "${add_drivers// }" ]]; then
         hostonly='' instmods -c $add_drivers
     fi
     if [[ $force_drivers ]]; then


### PR DESCRIPTION
- Caused by add_drivers+=" " in dracut.conf (bsc#923116)

Signed-off-by: Fabian Vogt <fvogt@suse.com>