### PR TITLE
95lunmask: Add module to handle LUN masking

### DIFF
--- a/modules.d/95lunmask/fc_transport_scan_lun.sh
+++ b/modules.d/95lunmask/fc_transport_scan_lun.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# fc_transport_lun_scan
+#
+# Selectively enable individual LUNs behind an FC remote port
+#
+# ACTION=="add", SUBSYSTEM=="fc_transport", ATTR{port_name}=="wwpn", \
+#    PROGRAM="fc_transport_lun_scan lun"
+#
+
+[ -z $DEVPATH ] && exit 1
+
+if [ -n "$1" ] ; then
+    LUN=$1
+else
+    LUN=-
+fi
+ID=${DEVPATH##*/rport-}
+HOST=${ID%%:*}
+CHANNEL=${ID%%-*}
+CHANNEL=${CHANNEL#*:}
+if [ -f /sys$DEVPATH/scsi_target_id ] ; then
+    TARGET=$(cat /sys$DEVPATH/scsi_target_id)
+fi
+[ -z "$TARGET" ] && exit 1
+echo $CHANNEL $TARGET $LUN > /sys/class/scsi_host/host$HOST/scan

--- a/modules.d/95lunmask/module-setup.sh
+++ b/modules.d/95lunmask/module-setup.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+# called by dracut
+cmdline() {
+    get_lunmask() {
+        local _dev=$1
+        local _devpath=$(cd -P /sys/dev/block/$_dev ; echo $PWD)
+        local _sdev _lun _rport _end_device _classdev _wwpn _sas_address
+
+        [ "${_devpath#*/sd}" == "$_devpath" ] && return 1
+        _sdev="${_devpath%%/block/*}"
+        _lun="${_sdev##*:}"
+        # Check for FibreChannel
+        _rport="${_devpath##*/rport-}"
+        if [ "$_rport" != "$_devpath" ] ; then
+            _rport="${_rport%%/*}"
+            _classdev="/sys/class/fc_remote_ports/rport-${_rport}"
+            [ -d "$_classdev" ] || return 1
+            _wwpn=$(cat ${_classdev}/port_name)
+            echo "rd.lunmask=fc,${_wwpn},${_lun}"
+            return 0
+        fi
+        # Check for SAS
+        _end_device="${_devpath##*/end_device-}"
+        if [ "$_end_device" != "$_devpath" ] ; then
+            _end_device="${_end_device%%/*}"
+            _classdev="/sys/class/sas_device/end_device-${_end_device}"
+            [ -e "$_classdev" ] || return 1
+            _sas_address=$(cat ${_classdev}/sas_address)
+            echo "rd.lunmask=sas,${_sas_address},${_lun}"
+            return 0
+        fi
+        return 1
+    }
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
+        for_each_host_dev_and_slaves_all get_lunmask
+    } | sort | uniq
+}
+
+# called by dracut
+check() {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
+        [ -w /sys/module/scsi_mod/parameters/scan ] || return 255
+        scan_type=$(cat /sys/module/scsi_mod/parameters/scan)
+        [ "$scan_type" = "manual" ] && return 0
+        return 255
+    }
+    return 0
+}
+
+# called by dracut
+depends() {
+    return 0
+}
+
+# called by dracut
+install() {
+    inst_script "$moddir/fc_transport_scan_lun.sh" /usr/lib/udev/fc_transport_scan_lun.sh
+    inst_script "$moddir/sas_transport_scan_lun.sh" /usr/lib/udev/sas_transport_scan_lun.sh
+    inst_hook cmdline 30 "$moddir/parse-lunmask.sh"
+    if [[ $hostonly_cmdline == "yes" ]] ; then
+        local _lunmask
+
+        for _lunmask in $(cmdline) ; do
+            printf "%s\n" "$_lunmask" >> "${initdir}/etc/cmdline.d/95lunmask.conf"
+        done
+    fi
+}

--- a/modules.d/95lunmask/parse-lunmask.sh
+++ b/modules.d/95lunmask/parse-lunmask.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+create_udev_rule() {
+    local transport=$1
+    local tgtid=$2
+    local lun=$3
+    local _rule=/etc/udev/rules.d/51-${transport}-lunmask-${tgtid}.rules
+    local _cu_type _dev_type
+
+    [ -e ${_rule} ] && return 0
+
+    if [ ! -f "$_rule" ] ; then
+        if [ "$transport" = "fc" ] ; then
+            cat > $_rule <<EOF
+ACTION=="add", SUBSYSTEM=="fc_remote_ports", ATTR{port_name}=="$tgtid", PROGRAM="fc_transport_scan_lun.sh $lun"
+EOF
+        elif [ "$transport" = "sas" ] ; then
+            cat > $_rule <<EOF
+ACTION=="add", SUBSYSTEM=="sas_device", ATTR{sas_address}=="$tgtid", PROGRAM="sas_transport_scan_lun.sh $lun"
+EOF
+        fi
+    fi
+}
+
+for lunmask_arg in $(getargs rd.lunmask); do
+    (
+        local OLDIFS="$IFS"
+        local IFS=","
+        set $lunmask_arg
+        IFS="$OLDIFS"
+        if [ -d /sys/module/scsi_mod ] ; then
+            printf "manual" > /sys/module/scsi_mod/parameters/scan
+        elif [ ! -f /etc/modprobe.d/95lunmask.conf ] ; then
+            echo "options scsi_mod scan=manual" > /etc/modprobe.d/95lunmask.conf
+        fi
+        create_udev_rule $1 $2 $3
+    )
+done

--- a/modules.d/95lunmask/sas_transport_scan_lun.sh
+++ b/modules.d/95lunmask/sas_transport_scan_lun.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# sas_transport_lun_scan
+#
+# Selectively enable individual LUNs behind a SAS end device
+#
+# ACTION=="add", SUBSYSTEM=="sas_transport", ATTR{sas_address}=="sas_addr", \
+#    PROGRAM="sas_transport_lun_scan lun"
+#
+
+[ -z $DEVPATH ] && exit 1
+
+if [ -n "$1" ] ; then
+    LUN=$1
+else
+    LUN=-
+fi
+ID=${DEVPATH##*/end_device-}
+HOST=${ID%%:*}
+CHANNEL=${ID%%-*}
+CHANNEL=${CHANNEL#*:}
+if [ -f /sys$DEVPATH/scsi_target_id ] ; then
+    TARGET=$(cat /sys$DEVPATH/scsi_target_id)
+fi
+[ -z "$TARGET" ] && exit 1
+echo 0 $TARGET $LUN > /sys/class/scsi_host/host$HOST/scan


### PR DESCRIPTION
Using the module option 'scsi_mod.scan=manual' this implements LUN masking by
selectively enable only those devices required for booting.

References: bsc#954600,FATE#319786

Signed-off-by: Hannes Reinecke <hare@suse.de>