### PR TITLE
dracut-emergency: optionally print fs help

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -261,6 +261,12 @@ inst_script() {
     (($? != 0)) && derror FAILED: $DRACUT_INSTALL ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${DRACUT_RESOLVE_DEPS:+-l}  ${DRACUT_FIPS_MODE:+-f} "$@" || :
 }
 
+inst_fsck_help() {
+    local _helper="/run/dracut/fsck/fsck_help_$1.txt"
+    $DRACUT_INSTALL ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${DRACUT_RESOLVE_DEPS:+-l} ${DRACUT_FIPS_MODE:+-f} "$2" $_helper
+    (($? != 0)) && derror $DRACUT_INSTALL ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${DRACUT_RESOLVE_DEPS:+-l}  ${DRACUT_FIPS_MODE:+-f} "$2" $_helper || :
+}
+
 mark_hostonly() {
     for i in "$@"; do
         echo "$i" >> "$initdir/lib/dracut/hostonly-files"

--- a/modules.d/98dracut-systemd/dracut-emergency.sh
+++ b/modules.d/98dracut-systemd/dracut-emergency.sh
@@ -14,6 +14,7 @@ export _rdshell_name="dracut" action="Boot" hook="emergency"
 _emergency_action=$(getarg rd.emergency)
 
 if getargbool 1 rd.shell -d -y rdshell || getarg rd.break -d rdbreak; then
+    FSTXT="/run/dracut/fsck/fsck_help_$fstype.txt"
     source_hook "$hook"
     echo
     rdsosreport
@@ -25,6 +26,7 @@ if getargbool 1 rd.shell -d -y rdshell || getarg rd.break -d rdbreak; then
     echo 'after mounting them and attach it to a bug report.'
     echo
     echo
+    [ -f "$FSTXT" ] && cat "$FSTXT"
     [ -f /etc/profile ] && . /etc/profile
     [ -z "$PS1" ] && export PS1="$_name:\${PWD}# "
     exec sh -i -l


### PR DESCRIPTION
Allow filesystem modules to install a fs-specific text file with instructions
on what to do when mount fails. This is printed when we go into an emergency
shell.

Signed-off-by: Mark Fasheh <mfasheh@suse.de>