### PR TITLE
spec: use if-undefined instead of empty if-defined block

### DIFF
--- a/dracut.spec
+++ b/dracut.spec
@@ -370,8 +370,7 @@ rm -rf -- $RPM_BUILD_ROOT
 %{_mandir}/man5/dracut.conf.5*
 %endif
 
-%if %{defined _unitdir}
-%else
+%if %{undefined _unitdir}
 %{dracutlibdir}/modules.d/00bootchart
 %endif
 %{dracutlibdir}/modules.d/00bash


### PR DESCRIPTION
Follow-up for 68cbbae33adc65452ee234940f668151f65cc043.