### PR TITLE
95dcssblk: Add new module for DCSS block devices

### DIFF
--- a/modules.d/95dcssblk/module-setup.sh
+++ b/modules.d/95dcssblk/module-setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+# called by dracut
+check() {
+    local _arch=$(uname -m)
+    [ "$_arch" = "s390" -o "$_arch" = "s390x" ] || return 1
+    return 0
+}
+
+# called by dracut
+installkernel() {
+    if [ -e /sys/devices/dcssblk/*/block/dcssblk* ];then
+	hostonly='' instmods dcssblk
+    fi
+}
+
+# called by dracut
+install() {
+    inst_hook cmdline 30 "$moddir/parse-dcssblk.sh"
+    # If there is a config file which contains avail (best only of root device)
+    # disks to activate add it and use it during boot -> then we do not need
+    # a kernel param anymore
+    #if [[ $hostonly ]]; then
+    #    inst /etc/dcssblk.conf
+    #fi
+}

--- a/modules.d/95dcssblk/parse-dcssblk.sh
+++ b/modules.d/95dcssblk/parse-dcssblk.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+dcssblk_arg=$(getarg rd.dcssblk=)
+if [ $? == 0 ];then
+	info "Loading dcssblk segments=$dcssblk_arg"
+	modprobe dcssblk segments=$dcssblk_arg
+fi


### PR DESCRIPTION
Add s390 dcssblk driver and introduce rd.dcssblk= to pass mounts
that should get activated at initrd stage.

References: FATE#308263

Signed-off-by: Hannes Reinecke <hare@suse.de>