### PR TITLE
81cio_ignore: handle cio_ignore commandline

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -1015,6 +1015,21 @@ ZIPL
 rd.zipl=UUID=0fb28157-99e3-4395-adef-da3f7d44835a
 --
 
+CIO_IGNORE
+~~~~~~~~~~
+**rd.cio_accept=**__<device-ids>__::
+    Remove the devices listed in <device-ids> from the default
+    cio_ignore kernel command-line settings.
+    <device-ids> is a list of comma-separated CCW device ids.
+    The default for this value is taken from the
+    _/boot/zipl/active_devices.txt_ file.
++
+[listing]
+.Example
+--
+rd.cio_accept=0.0.0180,0.0.0800,0.0.0801,0.0.0802
+--
+
 Plymouth Boot Splash
 ~~~~~~~~~~~~~~~~~~~~
 **plymouth.enable=0**::

--- a/modules.d/81cio_ignore/module-setup.sh
+++ b/modules.d/81cio_ignore/module-setup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+# called by dracut
+check() {
+# do not add this module by default
+    local arch=$(uname -m)
+    [ "$arch" = "s390" -o "$arch" = "s390x" ] || return 1
+    return 0
+}
+
+cmdline() {
+    local cio_accept
+
+    if [ -e /boot/zipl/active_devices.txt ] ; then
+        while read dev etc ; do
+            [ "$dev" = "#" -o "$dev" = "" ] && continue;
+            if [ -z "$cio_accept" ] ; then
+                cio_accept="$dev"
+            else
+                cio_accept="${cio_accept},${dev}"
+            fi
+        done < /boot/zipl/active_devices.txt
+    fi
+    if [ -n "$cio_accept" ] ; then
+	echo "rd.cio_accept=${cio_accept}"
+    fi
+}
+
+# called by dracut
+install() {
+    if [[ $hostonly_cmdline == "yes" ]] ; then
+        local _cio_accept=$(cmdline)
+        [[ $_cio_accept ]] && printf "%s\n" "$_cio_accept" >> "${initdir}/etc/cmdline.d/01cio_accept.conf"
+    fi
+
+    inst_hook cmdline 20 "$moddir/parse-cio_accept.sh"
+    inst_multiple cio_ignore
+}

--- a/modules.d/81cio_ignore/parse-cio_accept.sh
+++ b/modules.d/81cio_ignore/parse-cio_accept.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+CIO_IGNORE=$(getarg cio_ignore)
+CIO_ACCEPT=$(getarg rd.cio_accept)
+
+if [ -z $CIO_IGNORE ] ; then
+    info "cio_ignored disabled on commandline"
+    return
+fi
+if [ -n "$CIO_ACCEPT" ] ; then
+    OLDIFS="$IFS"
+    IFS=,
+    set -- $CIO_ACCEPT
+    while (($# > 0)) ; do
+        info "Enabling device $1"
+        cio_ignore --remove $1
+        shift
+    done
+    IFS="$OLDIFS"
+fi


### PR DESCRIPTION
References: bnc#874902

Incorporates following on-top patches/fixes:
----------------------------
Subject: 81cio_ignore: skip module if cio_ignore is not active

When cio_ignore is not active we should skip the entire module
during boot; otherwise it'll lead to adverse effects.

References: bnc#882685
----------------------------
Subject: 81cio_ignore: rewrite module

Rewrite cio_ignore module to rely on the dracut commandline
parameter 'rd.cio_accept', which takes a comma-separated list
of CCW IDs. Each of those IDs are being removed from the
list of devices from cio_ignore.

The default values for rd.cio_accept are taken from
/boot/zipl/active_devices.txt.

References: bnc#882685
-----------------------------
Subject: More empty cmdline fixes

This fixes up some more modules which might print out empty
commandline files.

Signed-off-by: Thomas Renninger <trenn@suse.de>