### PR TITLE
dracut.sh: do not invoke fsfreeze on EFI System Partition

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1834,8 +1834,10 @@ command -v restorecon &>/dev/null && restorecon -- "$outfile"
 if ! sync "$outfile" 2> /dev/null; then
     dinfo "dracut: sync operation on newly created initramfs $outfile failed"
     exit 1
+fi
+
 # use fsfreeze only if we're not writing to /
-elif ! [ "$(stat -c %m -- "$outfile")" == "/" ]; then
+if [[ "$(stat -c %m -- "$outfile")" != "/" && "$(stat -f -c %T -- "$outfile")" != "msdos" ]]; then
     if ! $(fsfreeze -f $(dirname "$outfile") 2>/dev/null && fsfreeze -u $(dirname "$outfile") 2>/dev/null); then
         dinfo "dracut: warning: could not fsfreeze $(dirname "$outfile")"
     fi


### PR DESCRIPTION
When the system boots with EFI, then initrd image is stored on EFI System Partition. Thus dracut always warn about the failure to invoke `fsfreeze` on the partition.
This prevents to run `fsfreeze` on ESP and suppress the warning.