### PR TITLE
Add 91zipl, which adds support for indirect booting on s390.

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -1001,6 +1001,20 @@ be mounted read only through a higher level transient overlay directory, has
 been implemented through the multiple lower layers feature of OverlayFS.
 
 
+ZIPL
+~~~~
+**rd.zipl=**__<path to blockdevice>__::
+    Update the dracut commandline with the values found in the
+    _dracut-cmdline.conf_ file on the given device.
+    The values are merged into the existing commandline values
+    and the udev events are regenerated.
++
+[listing]
+.Example
+--
+rd.zipl=UUID=0fb28157-99e3-4395-adef-da3f7d44835a
+--
+
 Plymouth Boot Splash
 ~~~~~~~~~~~~~~~~~~~~
 **plymouth.enable=0**::

--- a/dracut.sh
+++ b/dracut.sh
@@ -1172,6 +1172,7 @@ if [[ $hostonly ]] && [[ "$hostonly_default_device" != "no" ]]; then
         "/usr/lib64" \
         "/boot" \
         "/boot/efi" \
+        "/boot/zipl" \
         ;
     do
         mp=$(readlink -f "$mp")

--- a/modules.d/91zipl/install_zipl_cmdline.sh
+++ b/modules.d/91zipl/install_zipl_cmdline.sh
@@ -22,6 +22,13 @@ if [ -f ${MNT}/dracut-cmdline.conf ] ; then
     cp ${MNT}/dracut-cmdline.conf /etc/cmdline.d/99zipl.conf
 fi
 
+if [ -f ${MNT}/active_devices.txt ] ; then
+    while read dev etc ; do
+        [ "$dev" = "#" -o "$dev" = "" ] && continue;
+        cio_ignore -r $dev
+    done < ${MNT}/active_devices.txt
+fi
+
 umount ${MNT}
 
 if [ -f /etc/cmdline.d/99zipl.conf ] ; then

--- a/modules.d/91zipl/install_zipl_cmdline.sh
+++ b/modules.d/91zipl/install_zipl_cmdline.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DEV=$1
+DEV="$1"
 MNT=/boot/zipl
 
 if [ -z "$DEV" ] ; then

--- a/modules.d/91zipl/install_zipl_cmdline.sh
+++ b/modules.d/91zipl/install_zipl_cmdline.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+DEV=$1
+MNT=/boot/zipl
+
+if [ -z "$DEV" ] ; then
+    echo "No IPL device given"
+    > /tmp/install.zipl.cmdline-done
+    exit 1
+fi
+
+[ -d ${MNT} ] || mkdir -p ${MNT}
+
+mount -o ro ${DEV} ${MNT}
+if [ "$?" != "0" ] ; then
+    echo "Failed to mount ${MNT}"
+    > /tmp/install.zipl.cmdline-done
+    exit 1
+fi
+
+if [ -f ${MNT}/dracut-cmdline.conf ] ; then
+    cp ${MNT}/dracut-cmdline.conf /etc/cmdline.d/99zipl.conf
+fi
+
+umount ${MNT}
+
+if [ -f /etc/cmdline.d/99zipl.conf ] ; then
+    systemctl restart dracut-cmdline.service
+    systemctl restart systemd-udev-trigger.service
+fi
+> /tmp/install.zipl.cmdline-done
+
+exit 0

--- a/modules.d/91zipl/module-setup.sh
+++ b/modules.d/91zipl/module-setup.sh
@@ -42,7 +42,7 @@ install() {
     if [[ $hostonly_cmdline == "yes" ]] ; then
         local _zipl=$(cmdline)
 
-        [[ $_zipl ]] && printf "%s\n" "$_zipl"
+        [[ $_zipl ]] && printf "%s\n" "$_zipl" > "${initdir}/etc/cmdline.d/91zipl.conf"
     fi
     dracut_need_initqueue
 }

--- a/modules.d/91zipl/module-setup.sh
+++ b/modules.d/91zipl/module-setup.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+# called by dracut
+check() {
+    local _arch=$(uname -m)
+    # Only for systems on s390 using indirect booting via userland grub
+    [ "$_arch" = "s390" -o "$_arch" = "s390x" ] || return 1
+    # /boot/zipl contains a first stage kernel used to launch grub in initrd
+    [ -d /boot/zipl ] || return 1
+    return 0
+}
+
+# called by dracut
+depends() {
+    echo grub2
+    return 0
+}
+
+# called by dracut
+installkernel() {
+    instmods ext2
+}
+
+# called by dracut
+cmdline() {
+    local _boot_zipl
+
+    _boot_zipl=$(sed -n 's/\(.*\)\w*\/boot\/zipl.*/\1/p' /etc/fstab)
+    if [ -n "$_boot_zipl" ] ; then
+        echo "rd.zipl=${_boot_zipl}"
+    fi
+}
+
+# called by dracut
+install() {
+    inst_multiple mount umount
+
+    inst_hook cmdline 91 "$moddir/parse-zipl.sh"
+    inst "${moddir}/install_zipl_cmdline.sh" /sbin/install_zipl_cmdline.sh
+    if [[ $hostonly_cmdline == "yes" ]] ; then
+        local _zipl=$(cmdline)
+
+        [[ $_zipl ]] && printf "%s\n" "$_zipl"
+    fi
+    dracut_need_initqueue
+}

--- a/modules.d/91zipl/module-setup.sh
+++ b/modules.d/91zipl/module-setup.sh
@@ -20,7 +20,20 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods ext2
+    local _boot_zipl
+
+    _boot_zipl=$(sed -n 's/\(.*\)\w*\/boot\/zipl.*/\1/p' /etc/fstab)
+    if [ -n "$_boot_zipl" ] ; then
+        eval $(blkid -s TYPE -o udev ${_boot_zipl})
+        if [ -n "$ID_FS_TYPE" ] ; then
+            case "$ID_FS_TYPE" in
+                ext?)
+                    ID_FS_TYPE=ext4
+                    ;;
+            esac
+            instmods ${ID_FS_TYPE}
+        fi
+    fi
 }
 
 # called by dracut

--- a/modules.d/91zipl/module-setup.sh
+++ b/modules.d/91zipl/module-setup.sh
@@ -51,7 +51,7 @@ install() {
     inst_multiple mount umount
 
     inst_hook cmdline 91 "$moddir/parse-zipl.sh"
-    inst "${moddir}/install_zipl_cmdline.sh" /sbin/install_zipl_cmdline.sh
+    inst_script "${moddir}/install_zipl_cmdline.sh" /sbin/install_zipl_cmdline.sh
     if [[ $hostonly_cmdline == "yes" ]] ; then
         local _zipl=$(cmdline)
 

--- a/modules.d/91zipl/parse-zipl.sh
+++ b/modules.d/91zipl/parse-zipl.sh
@@ -31,7 +31,7 @@ if [ -n "$zipl_arg" ] ; then
     esac
     if [ "$zipl_env" ] ; then
         {
-            printf 'ACTION=="add|change", SUBSYSTEM=="block", %s=="%s", RUN+="/sbin/initqueue --settled --onetime --unique /sbin/install_zipl_cmdline.sh %s"\n' \
+            printf 'ACTION=="add|change", SUBSYSTEM=="block", %s=="%s", RUN+="/sbin/initqueue --settled --onetime --unique --name install_zipl_cmdline /sbin/install_zipl_cmdline.sh %s"\n' \
                 ${zipl_env} ${zipl_val} ${zipl_arg}
             echo "[ -f /tmp/install.zipl.cmdline-done ]" >$hookdir/initqueue/finished/wait-zipl-conf.sh
         } >> /etc/udev/rules.d/99zipl-conf.rules

--- a/modules.d/91zipl/parse-zipl.sh
+++ b/modules.d/91zipl/parse-zipl.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+zipl_arg=$(getarg rd.zipl)
+
+if [ -n "$zipl_arg" ] ; then
+    case "$zipl_arg" in
+    LABEL=*) \
+        zipl_env="ENV{ID_FS_LABEL}"
+        zipl_val=${zipl_arg#LABEL=}
+        zipl_arg="/dev/disk/by-label/${zipl_val}"
+        ;;
+    UUID=*) \
+        zipl_env="ENV{ID_FS_UUID}"
+        zipl_val=${zipl_arg#UUID=}
+        zipl_arg="/dev/disk/by-uuid/${zipl_val}"
+        ;;
+    /dev/mapper/*) \
+        zipl_env="ENV{DM_NAME}"
+        zipl_val=${zipl_arg#/dev/mapper/}
+        ;;
+    /dev/disk/by-*) \
+        zipl_env="SYMLINK"
+        zipl_val=${zipl_arg#/dev/}
+        ;;
+    /dev/*) \
+        zipl_env="KERNEL"
+        zipl_val=${zipl_arg}
+        ;;
+    esac
+    if [ "$zipl_env" ] ; then
+        {
+            printf 'ACTION=="add|change", SUBSYSTEM=="block", %s=="%s", RUN+="/sbin/initqueue --settled --onetime --unique /sbin/install_zipl_cmdline.sh %s"\n' \
+                ${zipl_env} ${zipl_val} ${zipl_arg}
+            echo "[ -f /tmp/install.zipl.cmdline-done ]" >$hookdir/initqueue/finished/wait-zipl-conf.sh
+        } >> /etc/udev/rules.d/99zipl-conf.rules
+        cat /etc/udev/rules.d/99zipl-conf.rules
+    fi
+    wait_for_dev -n "$zipl_arg"
+fi


### PR DESCRIPTION
The s390 zipl bootloader is not capable of reading from certain
more advanced filesystems such as btrfs. We therefore need an indirect
chaining process to boot systems like SLES. This works by letting ZIPL
boot a kernel from an ext partition, which loads a dracut-generated initrd
containing an ELF-based GRUB. This grub then loads the effective kernel
and userland via kexec.