### PR TITLE
90dmsquash-live-ntfs: fix depends()

### DIFF
--- a/modules.d/90dmsquash-live-ntfs/module-setup.sh
+++ b/modules.d/90dmsquash-live-ntfs/module-setup.sh
@@ -8,7 +8,7 @@ check() {
 }
 
 depends() {
-    echo 90dmsquash-live
+    echo dmsquash-live
     return 0
 }
 


### PR DESCRIPTION
Dependencies should not include module number.