### PR TITLE
spec: remove 81cio_ignore module from non-s390 arch

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -69,7 +69,7 @@ Silvio Fricke <silvio.fricke@gmail.com>
 Stig Telfer <stelfer@cray.com>
 Vasiliy Tolstov <v.tolstov@selfip.ru>
 Wim Muskee <wimmuskee@gmail.com>
-yuwata <watanabe.yu+github@gmail.com>
+Yu Watanabe <watanabe.yu+github@gmail.com>
 Alan Jenkins <alan-jenkins@tuffmail.co.uk>
 Alan Pevec <apevec@redhat.com>
 Alex Harpin <development@landsofshadow.co.uk>

--- a/dracut.spec
+++ b/dracut.spec
@@ -287,6 +287,7 @@ rm -fr -- $RPM_BUILD_ROOT/%{dracutlibdir}/modules.d/98integrity
 %ifnarch s390 s390x
 # remove architecture specific modules
 rm -fr -- $RPM_BUILD_ROOT/%{dracutlibdir}/modules.d/80cms
+rm -fr -- $RPM_BUILD_ROOT/%{dracutlibdir}/modules.d/81cio_ignore
 rm -fr -- $RPM_BUILD_ROOT/%{dracutlibdir}/modules.d/91zipl
 rm -fr -- $RPM_BUILD_ROOT/%{dracutlibdir}/modules.d/95dasd
 rm -fr -- $RPM_BUILD_ROOT/%{dracutlibdir}/modules.d/95dasd_mod
@@ -421,6 +422,7 @@ rm -rf -- $RPM_BUILD_ROOT
 %{dracutlibdir}/modules.d/95virtfs
 %ifarch s390 s390x
 %{dracutlibdir}/modules.d/80cms
+%{dracutlibdir}/modules.d/81cio_ignore
 %{dracutlibdir}/modules.d/91zipl
 %{dracutlibdir}/modules.d/95dasd
 %{dracutlibdir}/modules.d/95dasd_mod


### PR DESCRIPTION
Follow-up for b925f7f5d97259dd81e9d562fd1c6433e4b04f30.