### PR TITLE
90multipath: load dm_multipath module during startup

### DIFF
--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -30,7 +30,7 @@ depends() {
 
 # called by dracut
 cmdline() {
-    for m in scsi_dh_alua scsi_dh_emc scsi_dh_rdac ; do
+    for m in scsi_dh_alua scsi_dh_emc scsi_dh_rdac dm_multipath; do
         if grep -m 1 -q "$m" /proc/modules ; then
             printf 'rd.driver.pre=%s ' "$m"
         fi


### PR DESCRIPTION
As the 'multipath' program will be triggered directly from
udev events it will be called before the multipath service
unit has started up. Which means we cannot rely on the
service unit to load the module for us, but we rather
have to do it early before udev is started.

References: bsc#986734

Signed-off-by: Hannes Reinecke <hare@suse.com>