### PR TITLE
Give --persistent_policy precedence over /dev/mapper names

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -223,14 +223,20 @@ get_devpath_block() {
 
 # get a persistent path from a device
 get_persistent_dev() {
-    local i _tmp _dev
+    local i _tmp _dev _pol
 
     _dev=$(get_maj_min "$1")
     [ -z "$_dev" ] && return
 
+    if [[ -n "$persistent_policy" ]]; then
+	_pol="/dev/disk/${persistent_policy}/*"
+    else
+	_pol=
+    fi
+
     for i in \
+        $_pol \
         /dev/mapper/* \
-        /dev/disk/${persistent_policy:-by-uuid}/* \
         /dev/disk/by-uuid/* \
         /dev/disk/by-label/* \
         /dev/disk/by-partuuid/* \


### PR DESCRIPTION
There is currently no way to override dracut's preference for
/dev/mapper device names. But using these is problematic in
different scenarios: For example, if a user has a multipath-
enabled system but wants to disable multipath, or if the
names of multipath maps change because of configuration changes
(e.g. toggling user_friendly_names in /etc/multipath.conf).

This patch makes dracut prefer the user-specified
--persistent_policy names over /dev/mapper names.

It might be worthwhile to discuss why dracut prefers /dev/mapper
of /dev/disk/by-uuid at all. This preference was introduced
in 9037b63e with the argument "dm devices maintain /dev/mapper/* as
persistent names", but that's wrong for the scenarios mentioned
above, and is not a compelling reason for preferring /dev/mapper
over /dev/disk/by-uuid.

References: bsc#908143

Signed-off-by: Martin Wilck <mwilck@suse.de>