### PR TITLE
0202-dracut_dmraid_use_udev

### DIFF
--- a/modules.d/90dmraid/dmraid.sh
+++ b/modules.d/90dmraid/dmraid.sh
@@ -33,8 +33,6 @@ if [ -n "$DM_RAIDS" ] || getargbool 0 rd.auto; then
                 if [ "${s##$r}" != "$s" ]; then
                     info "Activating $s"
                     dmraid -ay -i -p --rm_partitions "$s" 2>&1 | vinfo
-                    [ -e "/dev/mapper/$s" ] && kpartx -a "/dev/mapper/$s" 2>&1 | vinfo
-                    udevsettle
                 fi
             done
         done

--- a/modules.d/90dmraid/module-setup.sh
+++ b/modules.d/90dmraid/module-setup.sh
@@ -74,6 +74,8 @@ install() {
 
     inst "$moddir/dmraid.sh" /sbin/dmraid_scan
 
+    inst_rules 66-kpartx.rules 67-kpartx-compat.rules
+
     inst_libdir_file "libdmraid-events*.so*"
 
     inst_rules "$moddir/61-dmraid-imsm.rules"


### PR DESCRIPTION
Use udev rules to create dmraid /dev/mapper/ devices

https://bugzilla.opensuse.org/show_bug.cgi?id=905746