### PR TITLE
50plymouth: improve distro compatibility

### DIFF
--- a/modules.d/50plymouth/plymouth-populate-initrd.sh
+++ b/modules.d/50plymouth/plymouth-populate-initrd.sh
@@ -4,8 +4,9 @@ PLYMOUTH_LOGO_FILE="/usr/share/pixmaps/system-logo-white.png"
 PLYMOUTH_THEME=$(plymouth-set-default-theme)
 
 inst_multiple plymouthd plymouth \
-    "${PLYMOUTH_LOGO_FILE}" \
     /etc/system-release
+
+test -e "${PLYMOUTH_LOGO_FILE}" && inst_simple "${PLYMOUTH_LOGO_FILE}"
 
 mkdir -m 0755 -p "${initdir}/usr/share/plymouth"
 


### PR DESCRIPTION
The existence of dpkg-achitecture is not indicative of a debian
installation. It may well be installed on systems of people who
package for both distros. The previous code path did not take
that into account.

We now traverse all known plymouth directories, locking on the first
existing one, and try to work with it.

At the same time, we do not include the module if the plymouth directory
could not be found.

This obsoletes 0300-dracut_dont_use_dpkg_defaults_on_SUSE.patch.

Also: 90plymouth: logo file is optional and may not exist