### PR TITLE
support kernels with built-in modules

### DIFF
--- a/modules.d/90multipath/multipathd.service
+++ b/modules.d/90multipath/multipathd.service
@@ -13,7 +13,7 @@ ConditionKernelCommandLine=!multipath=off
 
 [Service]
 Type=simple
-ExecStartPre=/sbin/modprobe dm-multipath
+ExecStartPre=-/sbin/modprobe dm-multipath
 ExecStart=/sbin/multipathd -s -d
 ExecReload=/sbin/multipathd reconfigure
 ExecStop=/sbin/multipathd shutdown


### PR DESCRIPTION
Don't fail if modprobe fails to load a module, the kernel could have it
statically compiled in.

Signed-off-by: Matthew Thode <mthode@mthode.org>