### PR TITLE
crypt: actually put block_uuid.map into initramfs

### DIFF
--- a/modules.d/90crypt/crypt-lib.sh
+++ b/modules.d/90crypt/crypt-lib.sh
@@ -16,13 +16,13 @@ crypttab_contains() {
                     [ "$dev" -ef "$_dev" ] && return 0
                 done
             fi
-            if [ -e /usr/lib/dracut/modules.d/90crypt/block_uuid.map ]; then
+            if [ -e /etc/block_uuid.map ]; then
                 # search for line starting with $d
-                _line=$(sed -n "\,^$d .*$,{p}" /usr/lib/dracut/modules.d/90crypt/block_uuid.map)
+                _line=$(sed -n "\,^$d .*$,{p}" /etc/block_uuid.map)
                 [ -z "$_line" ] && continue
                 # get second column with uuid
                 _uuid="$(echo $_line | sed 's,^.* \(.*$\),\1,')"
-	        strstr "$_uuid" "${luks##luks-}" && return 0
+                strstr "$_uuid" "${luks##luks-}" && return 0
             fi
         done < /etc/crypttab
     fi

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -81,7 +81,7 @@ install() {
             [[ $_dev == ID=* ]] && \
                 _dev="/dev/disk/by-id/${_dev#ID=}"
 
-            echo "$_dev $(blkid $_dev -s UUID -o value)" >> /usr/lib/dracut/modules.d/90crypt/block_uuid.map
+            echo "$_dev $(blkid $_dev -s UUID -o value)" >> "${initdir}/etc/block_uuid.map"
 
             # loop through the options to check for the force option
             luksoptions=${_luksoptions}


### PR DESCRIPTION
Also change path to /etc/block_uuid.map.

Fixes: c3b6970394ad677f05a42bef420bf34b1d0652e0

I hope /etc/block_uuid.map will not clash with any standard config files.