### PR TITLE
Avoid executing emergency hooks twice

### DIFF
--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -1084,6 +1084,7 @@ _emergency_shell()
         rm -f -- /.console_lock
     else
         debug_off
+        source_hook "$hook"
         echo
         /sbin/rdsosreport
         echo 'You might want to save "/run/initramfs/rdsosreport.txt" to a USB stick or /boot'
@@ -1136,7 +1137,6 @@ emergency_shell()
 
     echo ; echo
     warn "$*"
-    source_hook "$hook"
     echo
 
     _emergency_action=$(getarg rd.emergency)
@@ -1147,6 +1147,7 @@ emergency_shell()
     if getargbool 1 rd.shell -d -y rdshell || getarg rd.break -d rdbreak; then
         _emergency_shell $_rdshell_name
     else
+        source_hook "$hook"
         warn "$action has failed. To debug this issue add \"rd.shell rd.debug\" to the kernel command line."
         [ -z "$_emergency_action" ] && _emergency_action=halt
     fi


### PR DESCRIPTION
It seems that on systems using _systemd_ in the initrd emergency hooks are executed twice, which is probably not the desired behavior.

### Steps to reproduce
* Create directory _/usr/lib/dracut/modules.d/50emergency-test_
* Add the file _module-setup.sh_ with the following contents:
  ```
  #!/bin/sh
  
  install () {
    inst_hook emergency 50 "$moddir"/emergency-test.sh
    inst date
  }
  ```
* Add the file _emergency-test.sh_ with the following contents:
  ```
  #!/bin/sh
  warn "`date +%s%N`"
  warn "$0"
  ```
* Rebuild initrd
* Reboot and add `rd.break` as a kernel boot parameter
* You can see the date **twice** with **different** timestamps and a different parent: Once on the command line and once in the output of _/run/initramfs/rdsosreport.txt_.

### Analysis
It seems that emergency hooks are executed twice if the initrd is using systemd: First they are sourced in https://github.com/dracutdevs/dracut/blob/643be55570ab6f5b1a7c387123f8f409d44e6c76/modules.d/99base/dracut-lib.sh#L1139 followed by the systemd service itself in https://github.com/dracutdevs/dracut/blob/643be55570ab6f5b1a7c387123f8f409d44e6c76/modules.d/98dracut-systemd/dracut-emergency.sh#L18 called from https://github.com/dracutdevs/dracut/blob/643be55570ab6f5b1a7c387123f8f409d44e6c76/modules.d/99base/dracut-lib.sh#L1082

### Proposed solution
Only execute the hooks if they won't be called by the systemd service anyway.