### PR TITLE
90kernel-modules: Ensure PCI host modules are included

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -17,6 +17,7 @@ installkernel() {
             "=drivers/input/serio" \
             "=drivers/input/keyboard" \
             "=drivers/usb/storage" \
+            "=drivers/pci/host" \
             ${NULL}
 
         instmods \


### PR DESCRIPTION
The includes modules like the Intel Volume Management Device driver,
which is required to boot from disk on some systems.

Reference: boo#1079924