### PR TITLE
51-dracut-rescue.install: fix for initramfs not generated in /boot

### DIFF
--- a/51-dracut-rescue.install
+++ b/51-dracut-rescue.install
@@ -63,7 +63,7 @@ if ! [[ ${BOOT_OPTIONS[*]} ]]; then
     exit 1
 fi
 
-if [[ -d "$BOOT_DIR_ABS" ]]; then
+if [[ -d "${BOOT_DIR_ABS%/*}" ]]; then
     BOOT_DIR="/${MACHINE_ID}/0-rescue"
     BOOT_ROOT=${BOOT_DIR_ABS%$BOOT_DIR}
     LOADER_ENTRY="$BOOT_ROOT/loader/entries/${MACHINE_ID}-0-rescue.conf"
@@ -106,7 +106,7 @@ case "$COMMAND" in
             ((ret+=$?))
         fi
 
-        if [[ -d "$BOOT_DIR" ]]; then
+        if [[ "${BOOT_DIR_ABS}" != "/boot" ]]; then
             {
                 echo "title      $PRETTY_NAME - Rescue Image"
                 echo "version    $KERNEL_VERSION"


### PR DESCRIPTION
Commit 5e574046e76e ("5?-dracut*.install: Allow scripts to install
the initramfs in /boot dir") added support to generate initramfs
images in the /boot directory and copy the respective BLS files.

Unfortunately, it broke the rescue initramfs generation when it's
not installed on /boot due checking for wrong conditions. Fix it.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>