### PR TITLE
plymouth: fix detection of plymouth directory

### DIFF
--- a/modules.d/50plymouth/module-setup.sh
+++ b/modules.d/50plymouth/module-setup.sh
@@ -6,7 +6,7 @@ pkglib_dir() {
         _dirs+=" /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/plymouth"
     fi
     for _dir in $_dirs; do
-        if [ -d $_dir ]; then
+        if [ -x $_dir/plymouth-populate-initrd ]; then
             echo $_dir
             return
         fi


### PR DESCRIPTION
Some distros have both /usr/lib/plymouth and /usr/libexec/plymouth
directorirs, so we should check the existance of plymouth-populate-initrd
script.

Fixes: 421b46f8ae89cfe2b62e880a8a5079ee8c1b3aae