### PR TITLE
make failing installation of drm modules nonfatal

### DIFF
--- a/modules.d/50drm/module-setup.sh
+++ b/modules.d/50drm/module-setup.sh
@@ -40,6 +40,6 @@ installkernel() {
             fi
         done
     else
-        dracut_instmods -s "drm_crtc_init" "=drivers/gpu/drm" "=drivers/staging"
+        dracut_instmods -o -s "drm_crtc_init" "=drivers/gpu/drm" "=drivers/staging"
     fi
 }


### PR DESCRIPTION
During dracut runs users of VoidLinux reported ERROR messages. After some investigation I concluded that those errors are non-fatal and can be ignored. Nontheless, to prevent further confusion, let's make the installation of those drm modules optional so no error is occuring.