### PR TITLE
crypt: correct s390 arch to include arch-specific crypto modules

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -27,6 +27,7 @@ installkernel() {
     hostonly="" instmods drbg
     arch=$(arch)
     [[ $arch == x86_64 ]] && arch=x86
+    [[ $arch == s390x ]] && arch=s390
     instmods dm_crypt =crypto =drivers/crypto =arch/$arch/crypto
 }
 


### PR DESCRIPTION
Convert the s390x into s390 to also include s390-specific crypto
modules, for example, aes_s390 into the initramfs.

Signed-off-by: Hendrik Brueckner <brueckner@linux.ibm.com>