### PR TITLE
Update dracut.modules.7.asc

### DIFF
--- a/dracut.modules.7.asc
+++ b/dracut.modules.7.asc
@@ -255,7 +255,9 @@ not lead to an error.
 ==== inst <src> [<dst>]
 
 installs _one_ file <src> either to the same place in the initramfs or to an
-optional <dst>.
+optional <dst>. inst with more than two arguments is treated the same as 
+inst_multiple, all arguments are treated as files to install and none as 
+install destinations.
 
 ==== inst_hook <hookdir> <prio> <src>
 


### PR DESCRIPTION
Update manpage to reflect code behavior for `inst` with >2 args.

Signed-off-by: Michael McCracken <michael.mccracken@gmail.com>