### PR TITLE
40network: introduce auto6-dhcp6 option

### DIFF
--- a/modules.d/40network/ifup.sh
+++ b/modules.d/40network/ifup.sh
@@ -70,16 +70,17 @@ load_ipv6() {
 }
 
 do_ipv6auto() {
+    local ret
     load_ipv6
     echo 0 > /proc/sys/net/ipv6/conf/$netif/forwarding
     echo 1 > /proc/sys/net/ipv6/conf/$netif/accept_ra
     echo 1 > /proc/sys/net/ipv6/conf/$netif/accept_redirects
     linkup $netif
-    wait_for_ipv6_auto $netif
+    ret=$(wait_for_ipv6_auto $netif)
 
     [ -n "$hostname" ] && echo "echo $hostname > /proc/sys/kernel/hostname" > /tmp/net.$netif.hostname
 
-    return 0
+    return $ret
 }
 
 # Handle static ip configuration
@@ -416,6 +417,9 @@ for p in $(getargs ip=); do
                 do_dhcp -6 ;;
             auto6)
                 do_ipv6auto ;;
+            auto6-dhcp6)
+                ret=do_ipv6auto ;;
+                [ $ret -ne 0 ] && do_dhcp -6
             *)
                 do_static ;;
         esac


### PR DESCRIPTION
In kdump, if dump-target is ssh on ipv6, we need to sync until ipv6 addr
is ready. Currently ip=auto6/dhcp6 provides such function. But in 1st kernel,
it is hard to know whether the ipv6 addr is got by dhcpv6 or SLAAC.
E.g ifcfg-eth* contains DHCPV6C=yes direction, but there is no dhcpv6
server in the network, and then after the system is up, the user
echo 1 > /proc/sys/net/ipv6/conf/eth0/autoconf && accept_ra by manual
to obtain a ipv6 addr. Or vice.
So this patch suggests to make auto6 and dhcpv6 as fallback of each
other

Signed-off-by: Pingfan Liu <piliu@redhat.com>