### PR TITLE
40network: introduce ip=either6 option

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -480,7 +480,7 @@ USB Android phone::
 * enp0s29u1u2
 =====================
 
-**ip=**__{dhcp|on|any|dhcp6|auto6}__::
+**ip=**__{dhcp|on|any|dhcp6|auto6|either6}__::
     dhcp|on|any::: get ip from dhcp server from all interfaces. If root=dhcp,
     loop sequentially through all interfaces (eth0, eth1, ...) and use the first
     with a valid DHCP root-path.
@@ -488,6 +488,8 @@ USB Android phone::
     auto6::: IPv6 autoconfiguration
 
     dhcp6::: IPv6 DHCP
+
+    either6::: if auto6 fails, then dhcp6
 
 **ip=**__<interface>__:__{dhcp|on|any|dhcp6|auto6}__[:[__<mtu>__][:__<macaddr>__]]::
     This parameter can be specified multiple times.

--- a/modules.d/40network/ifup.sh
+++ b/modules.d/40network/ifup.sh
@@ -70,16 +70,18 @@ load_ipv6() {
 }
 
 do_ipv6auto() {
+    local ret
     load_ipv6
     echo 0 > /proc/sys/net/ipv6/conf/$netif/forwarding
     echo 1 > /proc/sys/net/ipv6/conf/$netif/accept_ra
     echo 1 > /proc/sys/net/ipv6/conf/$netif/accept_redirects
     linkup $netif
     wait_for_ipv6_auto $netif
+    ret=$?
 
     [ -n "$hostname" ] && echo "echo $hostname > /proc/sys/kernel/hostname" > /tmp/net.$netif.hostname
 
-    return 0
+    return $ret
 }
 
 # Handle static ip configuration
@@ -416,6 +418,8 @@ for p in $(getargs ip=); do
                 do_dhcp -6 ;;
             auto6)
                 do_ipv6auto ;;
+            either6)
+                do_ipv6auto || do_dhcp -6 ;;
             *)
                 do_static ;;
         esac

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -458,7 +458,7 @@ ip_to_var() {
     fi
 
     if [ $# -eq 1 ]; then
-        # format: ip={dhcp|on|any|dhcp6|auto6}
+        # format: ip={dhcp|on|any|dhcp6|auto6|either6}
         # or
         #         ip=<ipv4-address> means anaconda-style static config argument cluster
         autoconf="$1"
@@ -485,7 +485,7 @@ ip_to_var() {
         return 0
     fi
 
-    if [ "$2" = "dhcp" -o "$2" = "on" -o "$2" = "any" -o "$2" = "dhcp6" -o "$2" = "auto6" ]; then
+    if [ "$2" = "dhcp" -o "$2" = "on" -o "$2" = "any" -o "$2" = "dhcp6" -o "$2" = "auto6" -o "$2" = "either6" ]; then
         # format: ip=<interface>:{dhcp|on|any|dhcp6|auto6}[:[<mtu>][:<macaddr>]]
         [ -n "$1" ] && dev="$1"
         [ -n "$2" ] && autoconf="$2"

--- a/modules.d/40network/parse-ip-opts.sh
+++ b/modules.d/40network/parse-ip-opts.sh
@@ -76,6 +76,7 @@ for p in $(getargs ip=); do
                     die "Sorry, automatic calculation of netmask is not yet supported"
                 ;;
             auto6);;
+            either6);;
             dhcp|dhcp6|on|any) \
                 [ -n "$NEEDBOOTDEV" ] && [ -z "$dev" ] && \
                     die "Sorry, 'ip=$p' does not make sense for multiple interface configurations"


### PR DESCRIPTION
In kdump, if dump-target is ssh on ipv6, we need to sync until ipv6 addr
is ready. Currently ip=auto6/dhcp6 provides such function. But in 1st kernel,
it is hard to know whether the ipv6 addr is got by dhcpv6 or SLAAC.
E.g ifcfg-eth* contains DHCPV6C=yes direction, but there is no dhcpv6
server in the network, and then after the system is up, the user
echo 1 > /proc/sys/net/ipv6/conf/eth0/autoconf && accept_ra by manual
to obtain a ipv6 addr. Or vice.
So this patch suggests to make dhcpv6 as auto6 fallback

Signed-off-by: Pingfan Liu <piliu@redhat.com>