### PR TITLE
95iscsi: Replace iscsistart with iscsid

### DIFF
--- a/modules.d/95iscsi/cleanup-iscsi.sh
+++ b/modules.d/95iscsi/cleanup-iscsi.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-[ -e /sys/module/bnx2i ] && killproc iscsiuio
+[ -z "${DRACUT_SYSTEMD}" ] && [ -e /sys/module/bnx2i ] && killproc iscsiuio
 

--- a/modules.d/95iscsi/iscsistart-flocked.sh
+++ b/modules.d/95iscsi/iscsistart-flocked.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-{
-    flock -e 9
-    iscsistart "$@"
-} 9>/tmp/.iscsi_lock

--- a/modules.d/95iscsi/parse-iscsiroot.sh
+++ b/modules.d/95iscsi/parse-iscsiroot.sh
@@ -96,7 +96,7 @@ fi
 
 initqueue --unique --onetime --timeout /sbin/iscsiroot timeout "$netroot" "$NEWROOT"
 
-initqueue --onetime modprobe --all -b -q qla4xxx cxgb3i cxgb4i bnx2i be2iscsi
+initqueue --onetime modprobe --all -b -q qla4xxx cxgb3i cxgb4i bnx2i be2iscsi qedi
 
 # ISCSI actually supported?
 if ! [ -e /sys/module/iscsi_tcp ]; then
@@ -116,6 +116,11 @@ if arg=$(getarg rd.iscsi.initiator -d iscsi_initiator=) && [ -n "$arg" ] && ! [ 
     if ! [ -e /etc/iscsi/initiatorname.iscsi ]; then
         mkdir -p /etc/iscsi
         ln -fs /run/initiatorname.iscsi /etc/iscsi/initiatorname.iscsi
+        if [ -n "$DRACUT_SYSTEMD" ]; then
+            systemctl try-restart iscsid
+            # FIXME: iscsid is not yet ready, when the service is :-/
+            sleep 1
+        fi
     fi
 fi
 
@@ -128,6 +133,11 @@ if [ -z $iscsi_initiator ] && [ -f /sys/firmware/ibft/initiator/initiator-name ]
         mkdir -p /etc/iscsi
         ln -fs /run/initiatorname.iscsi /etc/iscsi/initiatorname.iscsi
         > /tmp/iscsi_set_initiator
+        if [ -n "$DRACUT_SYSTEMD" ]; then
+            systemctl try-restart iscsid
+            # FIXME: iscsid is not yet ready, when the service is :-/
+            sleep 1
+        fi
     fi
 fi
 


### PR DESCRIPTION
This allows to setup multiple paths to targets, which is
required for iscsi multipath.