### PR TITLE
Harden dracut against BASH_ENV environment variable

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --norc
+#!/bin/bash -p
 #
 # Generator script for a dracut initramfs
 # Tries to retain some degree of compatibility with the command line
@@ -22,6 +22,8 @@
 #
 
 # store for logging
+
+unset BASH_ENV
 
 # Verify bash version, current minimum is 4
 if (( BASH_VERSINFO[0] < 4 )); then


### PR DESCRIPTION
When dracut silently produces a broken initramfs, then the system will
likely not boot and this can be very problematic. Typical use case is
after the kernel has been updated.

It appears that dracut is not protected against the **BASH_ENV** variable,
causing various scripts called by dracut to possibly fail or provide
wrong output (e.g. `ldd` is one of these).
Having a broken output for `ldd` makes the generated initramfs be not
usable, typically because vital binaries will be missing (e.g.
`awk`, `udevadm`, ...).

Note: because the shebang line cannot contain more than one argument,
the `--norc` option had to be removed. IMHO, it was useless anyway.

Signed-off-by: Renaud Métrich <rmetrich@redhat.com>