### PR TITLE
fips: add sha3_generic and sm3_generic modules

### DIFF
--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -21,7 +21,8 @@ installkernel() {
         _fipsmodules+="ecb eseqiv fcrypt gcm ghash_generic hmac khazad lzo md4 md5 michael_mic rmd128 "
         _fipsmodules+="rmd160 rmd256 rmd320 rot13 salsa20 seed seqiv serpent sha1 sha224 sha256 sha256_generic "
         _fipsmodules+="sha384 sha512 sha512_generic tcrypt tea tnepres twofish wp256 wp384 wp512 xeta xtea xts zlib "
-        _fipsmodules+="aes_s390 des_s390 prng sha256_s390 sha_common des_check_key ghash_s390 sha1_s390 sha512_s390 cmac authenc "
+        _fipsmodules+="aes_s390 des_s390 prng sha256_s390 sha_common des_check_key ghash_s390 sha1_s390 sha512_s390 "
+        _fipsmodules+="cmac authenc sha3_generic sm3_generic "
     fi
 
     mkdir -m 0755 -p "${initdir}/etc/modprobe.d"


### PR DESCRIPTION
SHA-3 and SM3 have been added to the tcrypt module recently, so without
them the 'modprobe tcrypt' step causes a kernel panic.