### PR TITLE
Include virtio DRM drivers in hostonly initramfs

### DIFF
--- a/modules.d/50drm/module-setup.sh
+++ b/modules.d/50drm/module-setup.sh
@@ -31,7 +31,7 @@ installkernel() {
     # as we could e.g. be in the installer; nokmsboot boot parameter will disable
     # loading of the driver if needed
     if [[ $hostonly ]]; then
-        for i in /sys/bus/{pci/devices,soc/devices/soc?}/*/modalias; do
+        for i in /sys/bus/{pci/devices,virtio/devices,soc/devices/soc?}/*/modalias; do
             [[ -e $i ]] || continue
             if hostonly="" dracut_instmods --silent -s "drm_crtc_init" -S "iw_handler_get_spy" $(<$i); then
                 if strstr "$(modinfo -F filename $(<$i) 2>/dev/null)" radeon.ko; then


### PR DESCRIPTION
The code in 50drm which tries to include all DRM drivers for
hardware attached to the system did not look for virtio devices.
So if the system is a VM using the 'virtio' graphics adapter,
the 'virtio-gpu' module which should be included is not. This
extends the code to also look for virtio devices.

https://bugzilla.redhat.com/show_bug.cgi?id=1593028

Signed-off-by: Adam Williamson <awilliam@redhat.com>