### PR TITLE
51-dracut-rescue.install: Don't install BLS fragment in /boot/efi on EFI

### DIFF
--- a/51-dracut-rescue.install
+++ b/51-dracut-rescue.install
@@ -71,10 +71,6 @@ if [[ -d "${BOOT_DIR_ABS%/*}" ]]; then
     INITRD="initrd"
 else
     BLS_DIR="/boot/loader/entries"
-    if [ -d /sys/firmware/efi ]; then
-	BLS_DIR="/boot/efi/EFI/${ID}/loader/entries"
-    fi
-
     BOOT_DIR_ABS="/boot"
     LOADER_ENTRY="$BLS_DIR/${MACHINE_ID}-0-rescue.conf"
     KERNEL="vmlinuz-0-rescue-${MACHINE_ID}"


### PR DESCRIPTION
For EFI systems, the BLS fragments were stored in the EFI System Partition
(ESP) while in non-EFI systems it was stored in /boot.

For consistency, it's better to always store the BLS fragments in the same
path regardless of the firmware interface used.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>