### PR TITLE
Introduce tri-state hostonly mode

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -267,6 +267,18 @@ inst_fsck_help() {
     (($? != 0)) && derror $DRACUT_INSTALL ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${DRACUT_RESOLVE_DEPS:+-l}  ${DRACUT_FIPS_MODE:+-f} "$2" $_helper || :
 }
 
+# Use with form hostonly="$(optional_hostonly)" inst_xxxx <args>
+# If hosotnly mode is set to "strict", hostonly restrictions will still
+# be applied, else will ignore hostonly mode and try to install all
+# given modules.
+optional_hostonly() {
+    if [[ $hostonly_mode = "strict" ]]; then
+        printf -- "$hostonly"
+    else
+        printf ""
+    fi
+}
+
 mark_hostonly() {
     for i in "$@"; do
         echo "$i" >> "$initdir/lib/dracut/hostonly-files"

--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -12,6 +12,9 @@ installkernel() {
             uhci-hcd \
             xhci-hcd xhci-pci xhci-plat-hcd \
             pinctrl-cherryview \
+            ${NULL}
+
+        hostonly=$(optional_hostonly) instmods \
             "=drivers/hid" \
             "=drivers/tty/serial" \
             "=drivers/input/serio" \


### PR DESCRIPTION
Now --hostonly accept a optional <mode> parameter, so we have
a tri-state hostonly mode:

    * generic (non-hostonly): by passing "--no-hostonly" or not
                              passing anything
    * sloppy: by passing "--hostonly sloppy" or just "--hostonly"
    * strict: by passing "--hostonly strict"

Sloppy mode is the original hostonly mode, the new introduced strict
mode will allow modules to ignore more drivers or do some extra job to
save memory and disk space, while making the image less portable.

Also introduced a helper function "optional_hostonly" to make it
easier for modules to leverage new hostonly mode.

To force install modules only in sloppy hostonly mode, use the form:

hostonly="$(optional_hostonly)" instmods <modules>