### PR TITLE
Add a module to support building a space saving initramfs leveraging squashfs

### DIFF
--- a/README.modules
+++ b/README.modules
@@ -70,43 +70,42 @@ HOOKS
 
 init has the following hook points to inject scripts:
 
-/lib/dracut/hooks/cmdline/*.sh
+/var/lib/dracut/hooks/cmdline/*.sh
    scripts for command line parsing
 
-/lib/dracut/hooks/pre-udev/*.sh
+/var/lib/dracut/hooks/pre-udev/*.sh
    scripts to run before udev is started
 
-/lib/dracut/hooks/pre-trigger/*.sh
+/var/lib/dracut/hooks/pre-trigger/*.sh
    scripts to run before the main udev trigger is pulled
 
-/lib/dracut/hooks/initqueue/*.sh
+/var/lib/dracut/hooks/initqueue/*.sh
    runs in parallel to the udev trigger
    Udev events can add scripts here with /sbin/initqueue.
    If /sbin/initqueue is called with the "--onetime" option, the script
    will be removed after it was run.
-   If /lib/dracut/hooks/initqueue/work is created and udev >= 143 then
+   If /var/lib/dracut/hooks/initqueue/work is created and udev >= 143 then
    this loop can process the jobs in parallel to the udevtrigger.
    If the udev queue is empty and no root device is found or no root
    filesystem was mounted, the user will be dropped to a shell after
    a timeout.
    Scripts can remove themselves from the initqueue by "rm $job".
 
-/lib/dracut/hooks/pre-mount/*.sh
+/var/lib/dracut/hooks/pre-mount/*.sh
    scripts to run before the root filesystem is mounted
    Network filesystems like NFS that do not use device files are an
    exception. Root can be mounted already at this point.
 
-/lib/dracut/hooks/mount/*.sh
+/var/lib/dracut/hooks/mount/*.sh
    scripts to mount the root filesystem
    If the udev queue is empty and no root device is found or no root
    filesystem was mounted, the user will be dropped to a shell after
    a timeout.
 
-/lib/dracut/hooks/pre-pivot/*.sh
+/var/lib/dracut/hooks/pre-pivot/*.sh
    scripts to run before latter initramfs cleanups
 
-/lib/dracut/hooks/cleanup/*.sh
+/var/lib/dracut/hooks/cleanup/*.sh
    scripts to run before the real init is executed and the initramfs
    disappears
    All processes started before should be killed here.
-

--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -696,3 +696,24 @@ btrfs_devs() {
         printf -- "%s\n" "$_dev"
         done
 }
+
+resolve_binary() {
+    local binary=$1
+
+    if [[ $binary == */* ]]; then
+        binary=$binary
+    else
+        binary=$(\
+            PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/lib/systemd; \
+            which $binary 2>/dev/null)
+    fi
+    [[ $? != 0 ]] && return 1
+
+    local libs=$(ldd $binary 2>/dev/null)
+    [[ $? != 0 ]] && return 1
+
+    while read lib rest; do
+        [[ $lib == /* ]] && echo $lib | rev | cut -d '/' -f 1 | rev && continue
+        echo $lib
+    done <<< "$libs"
+}

--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -474,7 +474,7 @@ inst_hook() {
         dfatal "No such hook type $1. Aborting initrd creation."
         exit 1
     fi
-    inst_simple "$3" "/lib/dracut/hooks/${1}/${2}-${3##*/}"
+    inst_simple "$3" "/var/lib/dracut/hooks/${1}/${2}-${3##*/}"
 }
 
 # install any of listed files

--- a/dracut.sh
+++ b/dracut.sh
@@ -1433,8 +1433,10 @@ fi
 
 if [[ $kernel_only != yes ]]; then
     mkdir -p "${initdir}/etc/cmdline.d"
+    mkdir -p "${initdir}/lib/dracut"
+    mkdir -p "${initdir}/var/lib/dracut"
     for _d in $hookdirs; do
-        mkdir -m 0755 -p ${initdir}/lib/dracut/hooks/$_d
+        mkdir -m 0755 -p ${initdir}/var/lib/dracut/hooks/$_d
     done
     if [[ "$EUID" = "0" ]]; then
         [ -c ${initdir}/dev/null ] || mknod ${initdir}/dev/null c 1 3

--- a/modules.d/95resume/parse-resume.sh
+++ b/modules.d/95resume/parse-resume.sh
@@ -75,7 +75,7 @@ if ! getarg noresume; then
             printf -- ' cancel_wait_for_dev /dev/resume; rm -f -- "$job" "%s/initqueue/settled/resume.sh";\n' "$hookdir"
         } >> $hookdir/initqueue/timeout/resume.sh
 
-        mv /lib/dracut/resume.sh /lib/dracut/hooks/pre-mount/10-resume.sh
+        mv /lib/dracut/resume.sh /var/lib/dracut/hooks/pre-mount/10-resume.sh
     else
         {
             if [ -x /usr/sbin/resume ]; then

--- a/modules.d/98dracut-systemd/dracut-cmdline.service
+++ b/modules.d/98dracut-systemd/dracut-cmdline.service
@@ -11,7 +11,7 @@ After=systemd-journald.socket
 Wants=systemd-journald.socket
 ConditionPathExists=/usr/lib/initrd-release
 ConditionPathExistsGlob=|/etc/cmdline.d/*.conf
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/cmdline
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/cmdline
 ConditionKernelCommandLine=|rd.break=cmdline
 ConditionKernelCommandLine=|resume
 ConditionKernelCommandLine=|noresume

--- a/modules.d/98dracut-systemd/dracut-cmdline.sh
+++ b/modules.d/98dracut-systemd/dracut-cmdline.sh
@@ -9,6 +9,10 @@ type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 [ -n "$VERSION" ] && info "dracut-$VERSION"
 
 if ! getargbool 1 'rd.hostonly'; then
+    if [ -e /init.squash ]; then
+        warn "*** You can't set rd.hostonly=0 when squash module is enabled, as filesystem is partly read-only ***"
+        return
+    fi
     [ -f /etc/cmdline.d/99-cmdline-ask.conf ] && mv /etc/cmdline.d/99-cmdline-ask.conf /tmp/99-cmdline-ask.conf
     remove_hostonly_files
     [ -f /tmp/99-cmdline-ask.conf ] && mv /tmp/99-cmdline-ask.conf /etc/cmdline.d/99-cmdline-ask.conf

--- a/modules.d/98dracut-systemd/dracut-mount.service
+++ b/modules.d/98dracut-systemd/dracut-mount.service
@@ -8,7 +8,7 @@ Documentation=man:dracut-mount.service(8)
 After=initrd-root-fs.target initrd-parse-etc.service
 After=dracut-initqueue.service dracut-pre-mount.service
 ConditionPathExists=/usr/lib/initrd-release
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/mount
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/mount
 ConditionKernelCommandLine=|rd.break=mount
 DefaultDependencies=no
 Conflicts=shutdown.target emergency.target

--- a/modules.d/98dracut-systemd/dracut-pre-mount.service
+++ b/modules.d/98dracut-systemd/dracut-pre-mount.service
@@ -9,7 +9,7 @@ DefaultDependencies=no
 Before=initrd-root-fs.target sysroot.mount systemd-fsck-root.service
 After=dracut-initqueue.service cryptsetup.target
 ConditionPathExists=/usr/lib/initrd-release
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/pre-mount
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/pre-mount
 ConditionKernelCommandLine=|rd.break=pre-mount
 Conflicts=shutdown.target emergency.target
 

--- a/modules.d/98dracut-systemd/dracut-pre-pivot.service
+++ b/modules.d/98dracut-systemd/dracut-pre-pivot.service
@@ -12,8 +12,8 @@ Before=initrd-cleanup.service
 Wants=remote-fs.target
 After=remote-fs.target
 ConditionPathExists=/usr/lib/initrd-release
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/pre-pivot
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/cleanup
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/pre-pivot
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/cleanup
 ConditionKernelCommandLine=|rd.break=pre-pivot
 ConditionKernelCommandLine=|rd.break=cleanup
 ConditionKernelCommandLine=|rd.break

--- a/modules.d/98dracut-systemd/dracut-pre-trigger.service
+++ b/modules.d/98dracut-systemd/dracut-pre-trigger.service
@@ -10,7 +10,7 @@ Before=systemd-udev-trigger.service dracut-initqueue.service
 After=dracut-pre-udev.service systemd-udevd.service systemd-tmpfiles-setup-dev.service
 Wants=dracut-pre-udev.service systemd-udevd.service
 ConditionPathExists=/usr/lib/initrd-release
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/pre-trigger
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/pre-trigger
 ConditionKernelCommandLine=|rd.break=pre-trigger
 Conflicts=shutdown.target emergency.target
 

--- a/modules.d/98dracut-systemd/dracut-pre-udev.service
+++ b/modules.d/98dracut-systemd/dracut-pre-udev.service
@@ -10,7 +10,7 @@ Before=systemd-udevd.service dracut-pre-trigger.service
 After=dracut-cmdline.service
 Wants=dracut-cmdline.service
 ConditionPathExists=/usr/lib/initrd-release
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/pre-udev
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/pre-udev
 ConditionKernelCommandLine=|rd.break=pre-udev
 ConditionKernelCommandLine=|rd.driver.blacklist
 ConditionKernelCommandLine=|rd.driver.pre

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -437,7 +437,7 @@ export hookdir
 source_hook() {
     local _dir
     _dir=$1; shift
-    source_all "/lib/dracut/hooks/$_dir" "$@"
+    source_all "$hookdir/$_dir" "$@"
 }
 
 check_finished() {

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -1085,7 +1085,7 @@ _emergency_shell()
         > /.console_lock
         echo "PS1=\"$_name:\\\${PWD}# \"" >/etc/profile
         systemctl start dracut-emergency.service
-        rm -f -- /etc/profile
+        > /etc/profile
         rm -f -- /.console_lock
     else
         debug_off

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -431,7 +431,7 @@ source_all() {
     for f in "/$_dir"/*.sh; do [ -e "$f" ] && . "$f" "$@"; done
 }
 
-hookdir=/lib/dracut/hooks
+hookdir=/var/lib/dracut/hooks
 export hookdir
 
 source_hook() {

--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -125,6 +125,10 @@ if getarg "rd.cmdline=ask"; then
 fi
 
 if ! getargbool 1 'rd.hostonly'; then
+    if [ -e /init.squash ]; then
+        warn "*** You can't set rd.hostonly=0 when squash module is enabled, as filesystem is partly read-only ***"
+        return
+    fi
     [ -f /etc/cmdline.d/99-cmdline-ask.conf ] && mv /etc/cmdline.d/99-cmdline-ask.conf /tmp/99-cmdline-ask.conf
     remove_hostonly_files
     [ -f /tmp/99-cmdline-ask.conf ] && mv /tmp/99-cmdline-ask.conf /etc/cmdline.d/99-cmdline-ask.conf

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -39,7 +39,7 @@ install() {
 
     [ -e "${initdir}/lib" ] || mkdir -m 0755 -p ${initdir}/lib
     mkdir -m 0755 -p ${initdir}/lib/dracut
-    mkdir -m 0755 -p ${initdir}/lib/dracut/hooks
+    mkdir -m 0755 -p ${initdir}/var/lib/dracut/hooks
 
     mkdir -p ${initdir}/tmp
 

--- a/modules.d/99shutdown/module-setup.sh
+++ b/modules.d/99shutdown/module-setup.sh
@@ -19,9 +19,9 @@ install() {
     inst "$moddir/shutdown.sh" "$prefix/shutdown"
     [ -e "${initdir}/lib" ] || mkdir -m 0755 -p ${initdir}/lib
     mkdir -m 0755 -p ${initdir}/lib/dracut
-    mkdir -m 0755 -p ${initdir}/lib/dracut/hooks
+    mkdir -m 0755 -p ${initdir}/var/lib/dracut/hooks
     for _d in $hookdirs shutdown shutdown-emergency; do
-        mkdir -m 0755 -p ${initdir}/lib/dracut/hooks/$_d
+        mkdir -m 0755 -p ${initdir}/var/lib/dracut/hooks/$_d
     done
 }
 

--- a/modules.d/99squash/init.squash.sh
+++ b/modules.d/99squash/init.squash.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+PATH=/bin:/sbin
+SQUASH_IMG=/init.squash.sqsh
+SQUASH_MNT=/dev/.squash-initramfs
+SQUASH_INIT_ROOT=/dev/.squash-init-root
+
+# Following mount points are neccessary for mounting a squash image
+mount -t proc -o nosuid,noexec,nodev proc /proc >/dev/null
+mount -t sysfs -o nosuid,noexec,nodev sysfs /sys >/dev/null
+mount -t devtmpfs -o mode=0755,noexec,nosuid,strictatime devtmpfs /dev >/dev/null
+
+# Need a loop device backend, and squashfs module
+modprobe loop
+if [[ $? != 0 ]]; then
+    echo "Unable to setup loop device"
+    exit 1
+fi
+
+modprobe squashfs
+if [[ $? != 0 ]]; then
+    echo "Unable to setup squashfs"
+    exit 1
+fi
+
+mkdir -m 0755 -p ${SQUASH_MNT}
+mkdir -m 0755 -p ${SQUASH_INIT_ROOT}
+mount -t squashfs -o ro,loop $SQUASH_IMG $SQUASH_MNT
+
+# Mount and replace
+if [[ $? != 0 ]]; then
+    echo "Unable to mount squashed initramfs image"
+    exit 1
+fi
+
+# Close all fds before exec
+fd_path=/proc/self/fd
+for fd in ${fd_path}/*; do
+    fd=${fd#${fd_path}/}
+    [[ $fd -gt 2 ]] && eval "exec ${fd}>&-"
+done
+
+# Create a bind mount of old root so symlinks inside squash image
+# can resolve
+mount --bind --make-private / ${SQUASH_INIT_ROOT}
+
+mount --bind ${SQUASH_MNT}/etc /etc
+mount --bind ${SQUASH_MNT}/usr /usr
+
+exec /init.orig
+
+echo "Something went wrong when trying to start origin init executable"
+exit 1

--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+check() {
+    return 255
+}
+
+depends() {
+    echo "bash"
+    return 0
+}
+
+installkernel() {
+    hostonly="" instmods squashfs loop
+}
+
+install() {
+    inst_multiple kmod modprobe mount mkdir ln echo
+    inst ${moddir}/init.squash.sh /init.squash
+}


### PR DESCRIPTION
Add support for building a squashed initramfs

With all files stored in ramfs, and most of them are not compressed,
the initramfs will take up a lot of memory. This becomes much worse
with larger page size, as page cache will allocate a minimum of one
page to cache the content of one file however small it is.

One approach to reducing the memory usage and shrink initramfs size
is to put most files into a read-only squash image and keep a minimum
set of executable and libraries outside as the loader for the squash
image. Once the squash image is mounted, the real init inside will be
executed and then everything behaves as usual.

This patch will introduce a 99squash module which will never be included
by default. User can force add it, and if it is included, dracut
will perform some extra steps before creating the final image.

For now, /etc and /usr will be moved into the squashfs image. /init
will be renamed to /init.orig and replaced by /init.squash.
Files and folders need to be accessible before mounting the image will
be kept at their original place, not moving into the squashfs. A symlink
will be created inside the squashfs instead, pointing to the file
location at boot time, so no redundant binary or libraries are added.

/init.squash is now the init loader of the initramfs. It will do some
mounting and bind-mounting job, and call the original /init.orig,
then everything works as usual.

This is very helpful when mem resource is very limited, like Kdump.
According to my tests, with initramfs built with mkdumprd (which is
already a smaller image than usual), this can save about 40MB of
memory with 64K page size, or about 20MB with 4K page size.

Won't change any behavior if 99squash module is not enabled.

This pull request also contains some related commits for this new module to work properly.