### PR TITLE
dracut.spec: reintroduce 51-dracut-rescue-postinst.sh script

### DIFF
--- a/51-dracut-rescue-postinst.sh
+++ b/51-dracut-rescue-postinst.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+export LANG=C
+
+KERNEL_VERSION="$1"
+KERNEL_IMAGE="$2"
+
+[[ -f /etc/os-release ]] && . /etc/os-release
+
+if [[ ! -f /etc/machine-id ]] || [[ ! -s /etc/machine-id ]]; then
+    systemd-machine-id-setup
+fi
+
+[[ -f /etc/machine-id ]] && read MACHINE_ID < /etc/machine-id
+
+[[ $MACHINE_ID ]] || exit 1
+[[ -f $KERNEL_IMAGE ]] || exit 1
+
+INITRDFILE="/boot/initramfs-0-rescue-${MACHINE_ID}.img"
+NEW_KERNEL_IMAGE="${KERNEL_IMAGE%/*}/vmlinuz-0-rescue-${MACHINE_ID}"
+
+[[ -f $INITRDFILE ]] && [[ -f $NEW_KERNEL_IMAGE ]] && exit 0
+
+dropindirs_sort()
+{
+    suffix=$1; shift
+    args=("$@")
+    files=$(
+        while (( $# > 0 )); do
+            for i in ${1}/*${suffix}; do
+                [[ -f $i ]] && echo ${i##*/}
+            done
+            shift
+        done | sort -Vu
+    )
+
+    for f in $files; do
+        for d in "${args[@]}"; do
+            if [[ -f "$d/$f" ]]; then
+                echo "$d/$f"
+                continue 2
+            fi
+        done
+    done
+}
+
+# source our config dir
+for f in $(dropindirs_sort ".conf" "/etc/dracut.conf.d" "/usr/lib/dracut/dracut.conf.d"); do
+    [[ -e $f ]] && . "$f"
+done
+
+[[ $dracut_rescue_image != "yes" ]] && exit 0
+
+if [[ ! -f $INITRDFILE ]]; then
+    dracut --no-hostonly -a "rescue" "$INITRDFILE" "$KERNEL_VERSION"
+    ((ret+=$?))
+fi
+
+if [[ ! -f $NEW_KERNEL_IMAGE ]]; then
+    cp --reflink=auto "$KERNEL_IMAGE" "$NEW_KERNEL_IMAGE"
+    ((ret+=$?))
+fi
+
+new-kernel-pkg --install "$KERNEL_VERSION" --kernel-image "$NEW_KERNEL_IMAGE" --initrdfile "$INITRDFILE" --banner "$NAME $VERSION_ID Rescue $MACHINE_ID"
+
+((ret+=$?))
+
+exit $ret

--- a/dracut.spec
+++ b/dracut.spec
@@ -257,6 +257,9 @@ rm -f -- $RPM_BUILD_ROOT%{_bindir}/lsinitrd
 %endif
 
 %if 0%{?fedora} || 0%{?rhel}
+mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/kernel/postinst.d
+install -m 0755 51-dracut-rescue-postinst.sh $RPM_BUILD_ROOT%{_sysconfdir}/kernel/postinst.d/51-dracut-rescue-postinst.sh
+
 echo 'hostonly="no"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/02-generic-image.conf
 echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/02-rescue.conf
 %endif
@@ -452,6 +455,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/dracut.conf.d/02-rescue.conf
 %if 0%{?fedora} || 0%{?rhel}
 %{_prefix}/lib/kernel/install.d/51-dracut-rescue.install
+%{_sysconfdir}/kernel/postinst.d/51-dracut-rescue-postinst.sh
 %endif
 
 %changelog


### PR DESCRIPTION
Commit 0bb9a683d4d ("spec: drop support for legacy distributions") dropped
the 51-dracut-rescue-postinst.sh script, but this is used by Fedora during
installation to create the kernel and initramfs images and on a new kernel
install if these images don't exist, when using grubby (which seems to be
the case on a Fedora system upgrade).

So this commit partially reverts 0bb9a683d4d, to bring the script again.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>