### PR TITLE
livenet: Enable OverlayFS overlay in sysroot.mount generator.

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -930,7 +930,8 @@ NOTE: There must be enough free RAM available to hold the complete image.
 This method is very suitable for diskless boots.
 
 **root=**live:__<url>__::
-Boots a live image retrieved from __<url>__.  Valid handlers: __http, https, ftp, torrent, tftp__.
+Boots a live image retrieved from __<url>__.  Requires dracut 'livenet' module.
+Valid handlers: __http, https, ftp, torrent, tftp__.
 +
 [listing]
 .Example
@@ -955,7 +956,7 @@ By default, this is __squashfs.img__.
 Copy the complete image to RAM and use this for booting. This is useful
 when the image resides on, i.e., a DVD which needs to be ejected later on.
 
-**rd.live.overlay=**__<devspec>__:__(<pathspec>|auto)__|__none__::
+**rd.live.overlay={**__<devspec>__[:__{<pathspec>|auto}__]|__none__}::
 Allow the usage of a permanent overlay.
 - _<devspec>_ specifies the path to a device with a mountable filesystem.
 - _<pathspec>_ is the path to a file within that filesystem, which shall be
@@ -1005,10 +1006,10 @@ extended attributes and provides a valid d_type in readdir responses, such as
 with ext4 and xfs.  On non-vfat-formatted devices, a persistent OverlayFS
 overlay can extend the available root filesystem storage up to the capacity of
 the LiveOS device.
-
++
 If a persistent overlay is detected at the standard LiveOS path, the overlay &
 overlay type detected (whether OverlayFS or Device-mapper) will be used.
-
++
 The **rd.live.overlay.readonly** option, which allows a persistent overlayfs to
 be mounted read only through a higher level transient overlay directory, has
 been implemented through the multiple lower layers feature of OverlayFS.

--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -376,19 +376,20 @@ if [ -n "$overlayfs" ]; then
         mount -r $FSIMG /run/rootfsbase
     fi
     if [ -z "$DRACUT_SYSTEMD" ]; then
-        #FIXME What to link to /dev/root? Is it even needed?
         printf 'mount -t overlay LiveOS_rootfs -o%s,%s %s\n' "$ROOTFLAGS" \
         'lowerdir=/run/rootfsbase,upperdir=/run/overlayfs,workdir=/run/ovlwork' \
         "$NEWROOT" > $hookdir/mount/01-$$-live.sh
     fi
+    _dev=/run/rootfsbase
 else
-    ln -s /dev/mapper/live-rw /dev/root
+    _dev=/dev/mapper/live-rw
     if [ -z "$DRACUT_SYSTEMD" ]; then
         [ -n "$ROOTFLAGS" ] && ROOTFLAGS="-o $ROOTFLAGS"
         printf 'mount %s /dev/mapper/live-rw %s\n' "$ROOTFLAGS" "$NEWROOT" > $hookdir/mount/01-$$-live.sh
     fi
     ln -s $BASE_LOOPDEV /run/rootfsbase
 fi
+ln -s $_dev /dev/root
 
 need_shutdown
 

--- a/modules.d/90dmsquash-live/parse-dmsquash-live.sh
+++ b/modules.d/90dmsquash-live/parse-dmsquash-live.sh
@@ -57,6 +57,6 @@ info "root was $liveroot, is now $root"
 # make sure that init doesn't complain
 [ -z "$root" ] && root="live"
 
-wait_for_dev -n /run/rootfsbase
+wait_for_dev -n /dev/root
 
 return 0

--- a/modules.d/90livenet/livenet-generator.sh
+++ b/modules.d/90livenet/livenet-generator.sh
@@ -43,19 +43,29 @@ GENERATOR_DIR="$2"
 
 [ -d "$GENERATOR_DIR" ] || mkdir "$GENERATOR_DIR"
 
+getargbool 0 rd.live.overlay.overlayfs && overlayfs="yes"
+[ -e /xor_overlayfs ] && xor_overlayfs="yes"
 ROOTFLAGS="$(getarg rootflags)"
 {
     echo "[Unit]"
     echo "Before=initrd-root-fs.target"
     echo "[Mount]"
     echo "Where=/sysroot"
-    echo "What=/dev/mapper/live-rw"
-    [ -n "$ROOTFLAGS" ] && echo "Options=${ROOTFLAGS}"
+    if [ "$overlayfs$xor_overlayfs" = "yes" ]; then
+        echo "What=LiveOS_rootfs"
+        echo "Options=${ROOTFLAGS},lowerdir=/run/rootfsbase,upperdir=/run/overlayfs,workdir=/run/ovlwork"
+        echo "Type=overlay"
+        _dev=LiveOS_rootfs
+    else
+        echo "What=/dev/mapper/live-rw"
+        [ -n "$ROOTFLAGS" ] && echo "Options=${ROOTFLAGS}"
+        _dev=$'dev-mapper-live\\x2drw'
+    fi
 } > "$GENERATOR_DIR"/sysroot.mount
 
-mkdir -p "$GENERATOR_DIR/dev-mapper-live\x2drw.device.d"
+mkdir -p "$GENERATOR_DIR/$_dev.device.d"
 {
     echo "[Unit]"
     echo "JobTimeoutSec=3000"
     echo "JobRunningTimeoutSec=3000"
-} > "$GENERATOR_DIR/dev-mapper-live\x2drw.device.d/timeout.conf"
+} > "$GENERATOR_DIR/$_dev.device.d/timeout.conf"


### PR DESCRIPTION
Adjust sysroot.mount configuration for rd.live.overlay.overlayfs option.
Use link at /dev/root as a consitent flag for wait_for_dev.
Adjust documentation.

Addresses Issue #432.

Tested by: @GigabyteProductions see https://github.com/dracutdevs/dracut/issues/432#issuecomment-409811868.