### PR TITLE
Add gpio and pinctrl drivers for arm*/aarch64

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -25,7 +25,7 @@ installkernel() {
             ohci-hcd ohci-pci \
             uhci-hcd \
             xhci-hcd xhci-pci xhci-plat-hcd \
-            pinctrl-cherryview \
+            "=drivers/pinctrl" \
             ${NULL}
 
         hostonly=$(optional_hostonly) instmods \
@@ -50,6 +50,7 @@ installkernel() {
                 "=drivers/clk" \
                 "=drivers/dma" \
                 "=drivers/extcon" \
+                "=drivers/gpio" \
                 "=drivers/hwspinlock" \
                 "=drivers/i2c/busses" \
                 "=drivers/mfd" \


### PR DESCRIPTION
This is needed since few gpio/pinctrl can be built as modules and are
useful on early boot.

One example is jetson-tx1 where sata and external mmc can work only
after loading pinctrl-max77620 and gpio-max77620 modules.

Having theses kind of drivers bundled into the initramfs will also
avoid some deferred probes.

Signed-off-by: Nicolas Chauvet <kwizart@gmail.com>