### PR TITLE
IMA policy and key loading improvements

### DIFF
--- a/modules.d/98integrity/ima-keys-load.sh
+++ b/modules.d/98integrity/ima-keys-load.sh
@@ -17,7 +17,7 @@ load_x509_keys()
         IMAKEYSDIR="/etc/keys/ima"
     fi
 
-    PUBKEY_LIST=`ls ${NEWROOT}${IMAKEYSDIR}/*`
+    PUBKEY_LIST="$(ls ${NEWROOT}${IMAKEYSDIR}/*)"
     for PUBKEY in ${PUBKEY_LIST}; do
         # check for public key's existence
         if [ ! -f "${PUBKEY}" ]; then
@@ -38,7 +38,7 @@ load_x509_keys()
     fi
 
     # listing the keyring prints out 'keyring is empty' if no keys have been loaded
-    if [ "$(keyctl list ${KEYRING_ID})" == 'keyring is empty' ]; then
+    if [ "$(keyctl list ${KEYRING_ID})" == "keyring is empty" ]; then
         if [ "${RD_DEBUG}" = "yes" ]; then
             info "integrity: failed to load keys to keyring: ${KEYRING_ID}"
         fi
@@ -61,9 +61,9 @@ line=$(keyctl describe %keyring:.ima)
 if [ $? -eq 0 ]; then
     _ima_id=${line%%:*}
 else
-    _ima_id=`keyctl search @u keyring _ima`
+    _ima_id="$(keyctl search @u keyring _ima)"
     if [ -z "${_ima_id}" ]; then
-        _ima_id=`keyctl newring _ima @u`
+        _ima_id="$(keyctl newring _ima @u)"
     fi
 fi
 

--- a/modules.d/98integrity/ima-keys-load.sh
+++ b/modules.d/98integrity/ima-keys-load.sh
@@ -81,4 +81,5 @@ if [ $? -ne 0 ]; then
         if [ "${RD_DEBUG}" = "yes" ]; then
             info "integrity: IMA key load failed"
         fi
+    fi
 fi

--- a/modules.d/98integrity/ima-keys-load.sh
+++ b/modules.d/98integrity/ima-keys-load.sh
@@ -34,33 +34,17 @@ load_x509_keys()
     done
 
     if [ "${RD_DEBUG}" = "yes" ]; then
-        keyctl show  ${KEYRING_ID}
+        keyctl show ${KEYRING_ID}
+    fi
+
+    # listing the keyring prints out 'keyring is empty' if no keys have been loaded
+    if [ "$(keyctl list ${KEYRING_ID})" == 'keyring is empty' ]; then
+        if [ "${RD_DEBUG}" = "yes" ]; then
+            info "integrity: failed to load keys to keyring: ${KEYRING_ID}"
+        fi
+        return 1
     fi
     return 0
-}
-
-ensure_key_loading() {
-    # load to the untrusted _ima keyring if the system tried and failed to load to the trusted .ima keyring
-    
-    # if a keyring is empty, keyctl will print 'keyring is empty'. The below check only returns true if 
-    #       1) the .ima keyring exists (in which case, we have already tried to load to it), and
-    #       2) the .ima keyring is empty (loading keys failed)
-    # piping of stderr to /dev/null hides the keyctl error "Can't find 'keyring:.ima'" if the keyring doesn't exist
-    [[ "$(keyctl list %keyring:.ima 2> /dev/null)" != 'keyring is empty' ]] && return 0
-
-    if [ "${RD_DEBUG}" = "yes" ]; then
-        info "integrity: failed to load to .ima keyring. Attempting to load to _ima keyring"
-    fi
-
-    local _ima_untrusted_id="$(keyctl search @u keyring _ima)"
-    if [ -z "${_ima_id}" ]; then
-        _ima_untrusted_id="$(keyctl newring _ima @u)"
-    fi
-
-    # retry loading keys onto _ima keyring
-    load_x509_keys ${_ima_untrusted_id}
-
-    [[ "$(keyctl list %keyring:_ima 2> /dev/null)" == 'keyring is empty' ]] && info "integrity: failed to load to _ima keyring. No IMA keys loaded"
 }
 
 
@@ -84,5 +68,17 @@ else
 fi
 
 # load the IMA public key(s)
-load_x509_keys ${_ima_id}
-ensure_key_loading
+load_x509_keys "${_ima_id}"
+
+if [ $? -ne 0 ]; then
+    # load to the untrusted _ima keyring if the system tried and failed to load to the trusted .ima keyring
+    local _ima_untrusted_id="$(keyctl search @u keyring _ima)"
+    if [ -z "${_ima_untrusted_id}" ]; then
+        _ima_untrusted_id="$(keyctl newring _ima @u)"
+    fi
+    load_x509_keys "${_ima_untrusted_id}"
+    if [ $? -ne 0 ]; then
+        if [ "${RD_DEBUG}" = "yes" ]; then
+            info "integrity: IMA key load failed"
+        fi
+fi

--- a/modules.d/98integrity/ima-keys-load.sh
+++ b/modules.d/98integrity/ima-keys-load.sh
@@ -39,6 +39,18 @@ load_x509_keys()
     return 0
 }
 
+ensure_loading() {
+    # load to the untrusted _ima keyring if the system tried and failed to load to the trusted .ima keyring
+    if [[ "$(keyctl list %keyring:.ima 2> /dev/null)" == 'keyring is empty' ]]; then
+        local _ima_untrusted_id="$(keyctl search @u keyring _ima)"
+        if [ -z "${_ima_id}" ]; then
+            _ima_untrusted_id="$(keyctl newring _ima @u)"
+        fi
+        load_x509_keys ${_ima_untrusted_id}
+    fi
+}
+
+
 # check kernel support for IMA
 if [ ! -e "${IMASECDIR}" ]; then
     if [ "${RD_DEBUG}" = "yes" ]; then
@@ -60,3 +72,4 @@ fi
 
 # load the IMA public key(s)
 load_x509_keys ${_ima_id}
+ensure_loading

--- a/modules.d/98integrity/ima-policy-load.sh
+++ b/modules.d/98integrity/ima-policy-load.sh
@@ -24,6 +24,16 @@ load_ima_policy()
     [ -f "${IMACONFIG}" ] && \
         . ${IMACONFIG}
 
+    # check whether the IMA policy should be loaded
+    [ -z "${IMAPOLICYLOAD}" ] && \
+        IMAPOLICYLOAD="YES"
+
+    if [ "${IMAPOLICYLOAD}" = "NO" ]; then
+        if [ "${RD_DEBUG}" = "yes" ]; then
+            info "integrity: IMA policy will not be loaded"
+        fi
+    fi
+
     # set the IMA policy path name
     IMAPOLICYPATH="${NEWROOT}${IMAPOLICY}"
 


### PR DESCRIPTION
This pull request changes two things about how dracut loads IMA policies and keys. See #435 and #436 

- Attempt to load to the _ima keyring when loading to the .ima keying fails. I added a return value to the function which actually loads keys onto an IMA keyring. If you try and fail to load the keys to the keyring (almost certainly due to a permission error arising from not rebuilding your kernel with an IMA certificate), try loading to a different keyring
- Allows for disabling of IMA policy using the IMAPOLICYLOAD keyword, which can be specified in the IMA config file that dracut sources. There is a need for the ability to disable policy loading, since if the IMA policy contains SELinux labels, the policy can't be loaded by IMA.