### PR TITLE
dracut-function.sh:get_loaded_kernel_modules() Fix missing newline

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -683,7 +683,7 @@ get_loaded_kernel_modules ()
     local modules=( )
     while read _module _size _used _used_by; do
         modules+=( "$_module" )
-    done <<< $(lsmod | sed -n '1!p')
+    done <<< "$(lsmod | sed -n '1!p')"
     printf '%s\n' "${modules[@]}" | sort
 }
 


### PR DESCRIPTION
On newer bash, here string will preserve newline just like here doc,
while this is not true on older bash (<=4.3).

With bash 4.4:
bash-4.4# read va <<< $(echo -e "a\nb")
bash-4.4# echo $va
a       # Only first line got read.

With bash 4.3:
bash-4.3# read va <<< $(echo -e "a\nb")
bash-4.3# echo $va
a b     # Newline is missing.

bash-4.3# read va <<< "$(echo -e "a\nb")"
bash-4.3# echo $va
a       # Works fine now

Double quotes the command substitution to avoid inconsistent bash
behavior.