### PR TITLE
dracut-functions: fix the word splitting

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -683,7 +683,7 @@ get_loaded_kernel_modules ()
     local modules=( )
     while read _module _size _used _used_by; do
         modules+=( "$_module" )
-    done <<< $(lsmod | sed -n '1!p')
+    done <<< "$(lsmod | sed -n '1!p')"
     printf '%s\n' "${modules[@]}" | sort
 }
 


### PR DESCRIPTION
I have no idea why, but on Fedora the original code works just fine, but on rhel7 the loop is only executed for the first line. The double apostrophe seems to fix it.