### PR TITLE
Fix the device nodes are not created in kdump kernel for "raw" device…

### DIFF
--- a/modules.d/90qemu/module-setup.sh
+++ b/modules.d/90qemu/module-setup.sh
@@ -35,3 +35,8 @@ installkernel() {
             spapr-vscsi \
             qemu_fw_cfg
 }
+
+# called by dracut
+install() {
+    dracut_need_initqueue
+}


### PR DESCRIPTION
… dump

When using the raw device dump, the target devices could not be ready in
kdump kernel. It needs a mechanism to ensure that all current events are
handled when udev is triggered by calling udevadm trigger. The Initqueue
settled is a good choice.

Signed-off-by: Lianbo Jiang <lijiang@redhat.com>