### PR TITLE
ifcfg/write-ifcfg.sh: aggregate resolv.conf

### DIFF
--- a/modules.d/45ifcfg/module-setup.sh
+++ b/modules.d/45ifcfg/module-setup.sh
@@ -14,6 +14,7 @@ depends() {
 
 # called by dracut
 install() {
+    inst_binary sort
     inst_hook pre-pivot 85 "$moddir/write-ifcfg.sh"
 }
 

--- a/modules.d/45ifcfg/write-ifcfg.sh
+++ b/modules.d/45ifcfg/write-ifcfg.sh
@@ -286,7 +286,10 @@ echo "files /etc/sysconfig/network-scripts" >> /run/initramfs/rwtab
 echo "files /var/lib/dhclient" >> /run/initramfs/rwtab
 {
     cp /tmp/net.* /run/initramfs/
-    cp /tmp/net.$netif.resolv.conf /run/initramfs/state/etc/resolv.conf
+    for i in /tmp/net.*.resolv.conf; do
+             [ -f "$i" ] && cat "$i"
+    done | sort -u > /run/initramfs/state/etc/resolv.conf
+    [ -s /run/initramfs/state/etc/resolv.conf ] || rm -f /run/initramfs/state/etc/resolv.conf
     copytree /tmp/ifcfg /run/initramfs/state/etc/sysconfig/network-scripts
     cp /tmp/ifcfg-leases/* /run/initramfs/state/var/lib/dhclient
 } > /dev/null 2>&1


### PR DESCRIPTION
The old code used /tmp/net.$netif.resolv.conf with $netif being randomly
chosen.

As it is not known which nameserver have which priority, just sort them
and deduplicate.

Fixes https://github.com/dracutdevs/dracut/issues/410