### PR TITLE
Make dracut work well with pmem device

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -41,7 +41,7 @@ installkernel() {
             yenta_socket scsi_dh_rdac scsi_dh_emc scsi_dh_alua \
             atkbd i8042 usbhid firewire-ohci pcmcia hv-vmbus \
             virtio virtio_blk virtio_ring virtio_pci virtio_scsi \
-            "=drivers/pcmcia" =ide nvme vmd
+            "=drivers/pcmcia" =ide nvme vmd nfit
 
         if [[ "$(uname -m)" == arm* || "$(uname -m)" == aarch64 ]]; then
             # arm/aarch64 specific modules


### PR DESCRIPTION
Include "nfit" module so that pmem device could work.