### PR TITLE
99base: enable initqueue if extra devices are added

### DIFF
--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -94,6 +94,9 @@ install() {
 
     ## save host_devs which we need bring up
     if [[ $hostonly_cmdline == "yes" ]]; then
+        if [[ -n $add_device ]]; then
+            dracut_need_initqueue
+        fi
         if [[ -f "$initdir/lib/dracut/need-initqueue" ]] || ! dracut_module_included "systemd"; then
             (
                 if dracut_module_included "systemd"; then


### PR DESCRIPTION
When extra devices are added, initqueue should be enabled to make sure
those devices are present, so following services and routines could
use those devices.

See PR #442 for more detail.