### PR TITLE
dracut-install: fix kernel module lookup path in "updates" "extra" dir

### DIFF
--- a/install/dracut-install.c
+++ b/install/dracut-install.c
@@ -1532,13 +1532,13 @@ static int install_modules(int argc, char **argv)
                                 exit(EXIT_FAILURE);
                         }
 
-                        r = asprintf(&path1, "%s/extra/%s", kerneldir, &argv[i][1]);
+                        r = asprintf(&path1, "%s/extra", kerneldir);
                         if (r < 0) {
                                 log_error("Out of memory!");
                                 exit(EXIT_FAILURE);
                         }
 
-                        r = asprintf(&path3, "%s/updates/%s", kerneldir, &argv[i][1]);
+                        r = asprintf(&path3, "%s/updates", kerneldir);
                         if (r < 0) {
                                 log_error("Out of memory!");
                                 exit(EXIT_FAILURE);


### PR DESCRIPTION
Kernel modules in “kernel” directory are stored in subdirectories like "drivers/block";
but in "updates" and "extra" directory, it's stored directly in the root directory.

The original implementation will only include kernel modules in “kernel” directory to initramfs, and won't include kernel modules in  "updates" and "extra".