### PR TITLE
Fix misspellings in man pages and usage

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -601,7 +601,7 @@ NFS
     mount nfs share from <server-ip>:/<root-dir>, if no server-ip is given, use
     dhcp next_server. If server-ip is an IPv6 address it has to be put in
     brackets, e.g. [2001:DB8::1]. NFS options can be appended with the prefix
-    ":" or "," and are seperated by ",".
+    ":" or "," and are separated by ",".
 
 **root=**nfs:\[_<server-ip>_:]__<root-dir>__[:__<nfs-options>__], **root=**nfs4:\[_<server-ip>_:]__<root-dir>__[:__<nfs-options>__], **root=**__{dhcp|dhcp6}__::
     root=dhcp alone directs initrd to look at the DHCP root-path where NFS

--- a/dracut.modules.7.asc
+++ b/dracut.modules.7.asc
@@ -212,7 +212,7 @@ check() should return with:
 
 0:: Include the dracut module in the initramfs.
 
-1:: Do not include the dracut module. The requirements are not fullfilled
+1:: Do not include the dracut module. The requirements are not fulfilled
 (missing tools, etc.)
 
 255:: Only include the dracut module, if another module requires it or if
@@ -255,8 +255,8 @@ not lead to an error.
 ==== inst <src> [<dst>]
 
 installs _one_ file <src> either to the same place in the initramfs or to an
-optional <dst>. inst with more than two arguments is treated the same as 
-inst_multiple, all arguments are treated as files to install and none as 
+optional <dst>. inst with more than two arguments is treated the same as
+inst_multiple, all arguments are treated as files to install and none as
 install destinations.
 
 ==== inst_hook <hookdir> <prio> <src>

--- a/dracut.usage.asc
+++ b/dracut.usage.asc
@@ -243,7 +243,7 @@ If your root partition is on a network drive, you have to have the network
 dracut modules installed to create a network aware initramfs image.
 
 If you specify ip=dhcp on the kernel command line, then dracut asks a dhcp
-server about the ip adress for the machine. The dhcp server can also serve an
+server about the ip address for the machine. The dhcp server can also serve an
 additional root-path, which will set the root device for dracut. With this
 mechanism, you have static configuration on your client machine and a
 centralized boot configuration on your TFTP/DHCP server. If you can't pass a
@@ -252,7 +252,7 @@ method described in <<Injecting>>.
 
 ==== Reducing the Image Size
 
-To reduce the size of the initramfs, you should create it with by ommitting all
+To reduce the size of the initramfs, you should create it with by omitting all
 dracut modules, which you know, you don't need to boot the machine.
 
 You can also specify the exact dracut and kernel modules to produce a very tiny

--- a/mkinitrd-suse.8.asc
+++ b/mkinitrd-suse.8.asc
@@ -18,7 +18,7 @@ DESCRIPTION
 version <kernel-version> by calling *dracut*.
 
 [IMPORTANT]
-This version of mkinitrd is provided for compability with older
+This version of mkinitrd is provided for compatibility with older
 versions of mkinitrd. If a more fine grained control over the
 resulting image is needed, *dracut* should be called directly.
 
@@ -30,7 +30,7 @@ OPTIONS
 **-k** _<kernel_list>_::
     List of kernel images for which initrd files are created (relative
     to _boot_dir_), Image name should begin with the following string,
-    defaults to _vmlinux_ on ppc/ppc64, _image_ on s390/s390x and _vmlinuz_ 
+    defaults to _vmlinux_ on ppc/ppc64, _image_ on s390/s390x and _vmlinuz_
     for everything else.
 
 **-i** _<initrd_list>_::
@@ -51,7 +51,7 @@ OPTIONS
 
 **-d** _<root_device>_::
     Root device, defaults to the device from which the root_dir is
-    mounted; overwrites the rootdev enviroment variable if set
+    mounted; overwrites the rootdev environment variable if set
 
 **-s** _<size>_::
     Add splash animation and bootscreen to initrd.


### PR DESCRIPTION
Also remove some trailing whitespaces from the same files.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>