### PR TITLE
dmsquash-live-root: Manage absent overlayfs module better.

### DIFF
--- a/modules.d/90dmsquash-live/apply-live-updates.sh
+++ b/modules.d/90dmsquash-live/apply-live-updates.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -L /run/rootfsbase ] && [ -d /run/initramfs/live/updates -o -d /updates ]; then
+if [ -h /dev/root ] && [ -d /run/initramfs/live/updates -o -d /updates ]; then
     info "Applying updates to live image..."
     mount -o bind /run $NEWROOT/run
     # avoid overwriting symlinks (e.g. /lib -> /usr/lib) with directories

--- a/modules.d/90dmsquash-live/dmsquash-generator.sh
+++ b/modules.d/90dmsquash-live/dmsquash-generator.sh
@@ -18,12 +18,12 @@ fi
 case "$liveroot" in
     live:LABEL=*|LABEL=*) \
         root="${root#live:}"
-        root="$(echo $root | sed 's,/,\\x2f,g')"
+        root="${root//\//\\x2f}"
         root="live:/dev/disk/by-label/${root#LABEL=}"
         rootok=1 ;;
     live:CDLABEL=*|CDLABEL=*) \
         root="${root#live:}"
-        root="$(echo $root | sed 's,/,\\x2f,g')"
+        root="${root//\//\\x2f}"
         root="live:/dev/disk/by-label/${root#CDLABEL=}"
         rootok=1 ;;
     live:UUID=*|UUID=*) \

--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -146,10 +146,10 @@ do_live_overlay() {
                     [ -d /run/initramfs/overlayfs/ovlwork ]; then
                     ln -s /run/initramfs/overlayfs/overlayfs /run/overlayfs$opt
                     ln -s /run/initramfs/overlayfs/ovlwork /run/ovlwork$opt
-                    if [ -z "$overlayfs" ]; then
-                        overlayfs="yes"
-                        [ -n "$DRACUT_SYSTEMD" ] && reloadsysrootmountunit=":>/xor_overlayfs;"
+                    if [ -z "$overlayfs" ] && [ -n "$DRACUT_SYSTEMD" ]; then
+                        reloadsysrootmountunit=":>/xor_overlayfs;"
                     fi
+                    overlayfs="required"
                     setup="yes"
                 fi
             fi
@@ -157,18 +157,24 @@ do_live_overlay() {
             [ -d /run/initramfs/overlayfs$pathspec/../ovlwork ]; then
             ln -s /run/initramfs/overlayfs$pathspec /run/overlayfs$opt
             ln -s /run/initramfs/overlayfs$pathspec/../ovlwork /run/ovlwork$opt
-            if [ -z "$overlayfs" ]; then
-                overlayfs="yes"
-                [ -n "$DRACUT_SYSTEMD" ] && reloadsysrootmountunit=":>/xor_overlayfs;"
+            if [ -z "$overlayfs" ] && [ -n "$DRACUT_SYSTEMD" ]; then
+                reloadsysrootmountunit=":>/xor_overlayfs;"
             fi
+            overlayfs="required"
             setup="yes"
         fi
     fi
     if [ -n "$overlayfs" ]; then
         modprobe overlay
         if [ $? != 0 ]; then
+            if [ "$overlayfs" = required ]; then
+                die "OverlayFS is required but not available."
+                exit 1
+            fi
+            [ -n "$DRACUT_SYSTEMD" ] && reloadsysrootmountunit=":>/xor_overlayfs;"
             m='OverlayFS is not available; using temporary Device-mapper overlay.'
-            unset -v overlayfs setup reloadsysrootmountunit
+            info $m
+            unset -v overlayfs setup
         fi
     fi
 
@@ -302,10 +308,10 @@ if [ -e "$SQUASHED" ]; then
         fi
     elif [ -d /run/initramfs/squashfs/proc ]; then
         FSIMG=$SQUASHED
-        if [ -z "$overlayfs" ]; then
-            overlayfs="yes"
-            [ -n "$DRACUT_SYSTEMD" ] && reloadsysrootmountunit=":>/xor_overlayfs;"
+        if [ -z "$overlayfs" ] && [ -n "$DRACUT_SYSTEMD" ]; then
+            reloadsysrootmountunit=":>/xor_overlayfs;"
         fi
+        overlayfs="required"
     else
         die "Failed to find a root filesystem in $SQUASHED."
         exit 1

--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -109,15 +109,15 @@ do_live_overlay() {
 
     if [ -z "$overlay" ]; then
         pathspec="/${live_dir}/overlay-$l-$u"
-    elif ( echo $overlay | grep -q ":" ); then
+    elif strstr $overlay ":"; then
         # pathspec specified, extract
-        pathspec=$( echo $overlay | sed -e 's/^.*://' )
+        pathspec=${overlay##*:}
     fi
 
     if [ -z "$pathspec" -o "$pathspec" = "auto" ]; then
         pathspec="/${live_dir}/overlay-$l-$u"
     fi
-    devspec=$( echo $overlay | sed -e 's/:.*$//' )
+    devspec=${overlay%%:*}
 
     # need to know where to look for the overlay
     if [ -z "$setup" -a -n "$devspec" -a -n "$pathspec" -a -n "$overlay" ]; then

--- a/modules.d/90dmsquash-live/module-setup.sh
+++ b/modules.d/90dmsquash-live/module-setup.sh
@@ -22,7 +22,7 @@ installkernel() {
 
 # called by dracut
 install() {
-    inst_multiple umount dmsetup blkid dd losetup grep blockdev find
+    inst_multiple umount dmsetup blkid dd losetup blockdev find
     inst_multiple -o checkisomd5
     inst_hook cmdline 30 "$moddir/parse-dmsquash-live.sh"
     inst_hook cmdline 31 "$moddir/parse-iso-scan.sh"

--- a/modules.d/90dmsquash-live/parse-dmsquash-live.sh
+++ b/modules.d/90dmsquash-live/parse-dmsquash-live.sh
@@ -20,12 +20,12 @@ modprobe -q loop
 case "$liveroot" in
     live:LABEL=*|LABEL=*) \
         root="${root#live:}"
-        root="$(echo $root | sed 's,/,\\x2f,g')"
+        root="${root//\//\\x2f}"
         root="live:/dev/disk/by-label/${root#LABEL=}"
         rootok=1 ;;
     live:CDLABEL=*|CDLABEL=*) \
         root="${root#live:}"
-        root="$(echo $root | sed 's,/,\\x2f,g')"
+        root="${root//\//\\x2f}"
         root="live:/dev/disk/by-label/${root#CDLABEL=}"
         rootok=1 ;;
     live:UUID=*|UUID=*) \


### PR DESCRIPTION
die when required; systemctl reload otherwise.

Also:
### dmsquash-live: Avoid grep and sed in this module.

strstr and variable string manipulations suffice.

Also:
### dmsquash-live/apply-live-updates: Test proper file link.

Update flag link to /dev/root as required by commit
789668d.
This should fix issue #455 