### PR TITLE
Prevent environment leaking into initrd-release

### DIFF
--- a/modules.d/01systemd-initrd/module-setup.sh
+++ b/modules.d/01systemd-initrd/module-setup.sh
@@ -38,13 +38,12 @@ install() {
 
     ln_r "${systemdsystemunitdir}/initrd.target" "${systemdsystemunitdir}/default.target"
 
+    local VERSION=""
+    local PRETTY_NAME=""
     if [ -e /etc/os-release ]; then
         . /etc/os-release
-        VERSION+=" "
-        PRETTY_NAME+=" "
-    else
-        VERSION=""
-        PRETTY_NAME=""
+        [[ -n ${VERSION} ]] && VERSION+=" "
+        [[ -n ${PRETTY_NAME} ]] && PRETTY_NAME+=" "
     fi
     NAME=dracut
     ID=dracut

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -63,13 +63,12 @@ install() {
         echo ro >> "${initdir}/etc/cmdline.d/base.conf"
     fi
 
+    local VERSION=""
+    local PRETTY_NAME=""
     if [ -e /etc/os-release ]; then
         . /etc/os-release
-        VERSION+=" "
-        PRETTY_NAME+=" "
-    else
-        VERSION=""
-        PRETTY_NAME=""
+        [[ -n ${VERSION} ]] && VERSION+=" "
+        [[ -n ${PRETTY_NAME} ]] && PRETTY_NAME+=" "
     fi
     NAME=dracut
     ID=dracut


### PR DESCRIPTION
Prevent environment leaking into initrd-release

On my system the following initrd-release is generated:
...
VERSION="4 dracut-048 dracut-048"
...

VERSION is not defined in /etc/os-release, so the variable is
concatenated with its previous value:

* "4" comes from the kernel build system since dracut is called from the
  kernel install hook ("4" is a major kernel version);
* first "dracut-048" comes from the "systemd-initrd" module;
* second "dracut-048" comes from the "base" module.