### PR TITLE
install: avoid non-portable __WORDSIZE

### DIFF
--- a/install/util.h
+++ b/install/util.h
@@ -167,7 +167,7 @@ int safe_atoi(const char *s, int *ret_i);
 int safe_atollu(const char *s, unsigned long long *ret_u);
 int safe_atolli(const char *s, long long int *ret_i);
 
-#if __WORDSIZE == 32
+#if LONG_MAX == INT_MAX
 static inline int safe_atolu(const char *s, unsigned long *ret_u) {
         assert_cc(sizeof(unsigned long) == sizeof(unsigned));
         return safe_atou(s, (unsigned*) ret_u);


### PR DESCRIPTION
Lets not unnecessarily rely on __WORDSIZE, which is not clearly specified
by any spec. Use explicit size comparisons if we're not interested in the
WORDSIZE, anyway.

Patch ported from systemd.
(commit https://github.com/systemd/systemd/commit/8507eb20b64010b26f23822cbf442bb0bf96511c)

Original-patch-by: Emil Renner Berthing <systemd@esmil.dk>
Bug: https://bugs.gentoo.org/602122