### PR TITLE
network: configure NetworkManager to use dhclient

### DIFF
--- a/modules.d/40network/ifup.sh
+++ b/modules.d/40network/ifup.sh
@@ -41,6 +41,12 @@ do_dhcp() {
         return 1
     fi
 
+    if [ ! -e /run/NetworkManager/conf.d/10-dracut-dhclient.conf ]; then
+        mkdir -p /run/NetworkManager/conf.d
+        echo '[main]' > /run/NetworkManager/conf.d/10-dracut-dhclient.conf
+        echo 'dhcp=dhclient' >>/run/NetworkManager/conf.d/10-dracut-dhclient.conf
+    fi
+
     while [ $_COUNT -lt $_DHCPRETRY ]; do
         info "Starting dhcp for interface $netif"
         dhclient "$@" \


### PR DESCRIPTION
If the network module obtained a lease using dhclient, NetworkManager
must be configured to use it too, otherwise it would obtain a different
lease (and could potentially break a connection to the network volume).