### PR TITLE
retry image download forever

### DIFF
--- a/modules.d/90livenet/livenetroot.sh
+++ b/modules.d/90livenet/livenetroot.sh
@@ -30,7 +30,7 @@ do
     if [ ! -z "$imgfile" -a -s "$imgfile" ]; then
         break
     else
-        if [ $i -eq $RETRIES ]; then
+        if [ $i -ge $RETRIES ]; then
             warn "failed to download live image after $i attempts."
             exit 1
         fi

--- a/modules.d/90livenet/livenetroot.sh
+++ b/modules.d/90livenet/livenetroot.sh
@@ -6,8 +6,8 @@ type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 . /lib/url-lib.sh
 
 PATH=/usr/sbin:/usr/bin:/sbin:/bin
-RETRIES={$RETRIES:-100}
-SLEEP={$SLEEP:-5}
+RETRIES=${RETRIES:-100}
+SLEEP=${SLEEP:-5}
 
 [ -e /tmp/livenet.downloaded ] && exit 0
 

--- a/modules.d/90livenet/livenetroot.sh
+++ b/modules.d/90livenet/livenetroot.sh
@@ -18,7 +18,8 @@ info "fetching $liveurl"
 
 imgfile=
 #retry until the imgfile is populated with data or the max retries
-for (( i=1; i<=$RETRIES; i++))
+i=1
+while [ "$i" -le $RETRIES ]
 do
     imgfile=$(fetch_url "$liveurl")
 
@@ -37,6 +38,8 @@ do
 
         sleep $SLEEP
     fi
+
+    i=$((i + 1))
 done > /tmp/livenet.downloaded
 
 # TODO: couldn't dmsquash-live-root handle this?

--- a/modules.d/90livenet/livenetroot.sh
+++ b/modules.d/90livenet/livenetroot.sh
@@ -6,8 +6,8 @@ type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 . /lib/url-lib.sh
 
 PATH=/usr/sbin:/usr/bin:/sbin:/bin
-RETRIES={RETRIES:-100}
-SLEEP={SLEEP:-5}
+RETRIES={$RETRIES:-100}
+SLEEP={$SLEEP:-5}
 
 [ -e /tmp/livenet.downloaded ] && exit 0
 
@@ -30,6 +30,11 @@ do
     if [ ! -z "$imgfile" -a -s "$imgfile" ]; then
         break
     else
+        if [ $i -eq $RETRIES ]; then
+            warn "failed to download live image after $i attempts."
+            exit 1
+        fi
+
         sleep $SLEEP
     fi
 done > /tmp/livenet.downloaded

--- a/modules.d/90livenet/livenetroot.sh
+++ b/modules.d/90livenet/livenetroot.sh
@@ -13,14 +13,17 @@ PATH=/usr/sbin:/usr/bin:/sbin:/bin
 netroot="$2"
 liveurl="${netroot#livenet:}"
 info "fetching $liveurl"
-imgfile=$(fetch_url "$liveurl")
 
-if [ $? != 0 ]; then
-	warn "failed to download live image: error $?"
-	exit 1
-fi
+imgfile=
+until [ ! -z "$imgfile" -a -s "$imgfile" ]
+do
+    imgfile=$(fetch_url "$liveurl")
 
-> /tmp/livenet.downloaded
+    if [ $? != 0 ]; then
+            warn "failed to download live image: error $?"
+            imgfile=
+    fi
+done > /tmp/livenet.downloaded
 
 # TODO: couldn't dmsquash-live-root handle this?
 if [ ${imgfile##*.} = "iso" ]; then


### PR DESCRIPTION
When we are using livenetroot image, we want dracut to try until it succeeds. Current setup will have the node fail to boot if there are transient network issues on the first failure. This patch will make it try forever which is usually long enough for transient issues to get worked out.