### PR TITLE
dracut-install: simplify ldd parsing logic

### DIFF
--- a/install/dracut-install.c
+++ b/install/dracut-install.c
@@ -479,11 +479,7 @@ static int resolve_deps(const char *src)
                 if (strstr(buf, destrootdir))
                         break;
 
-                p = strstr(buf, "=>");
-                if (!p)
-                        p = buf;
-
-                p = strchr(p, '/');
+                p = strchr(buf, '/');
                 if (p) {
                         char *q;
 


### PR DESCRIPTION
The previous logic would not handle absolute paths on the left side of
the "=>" properly. For example, on Gentoo ARM64, ldd outputs this:

	/lib/ld-linux-aarch64.so.1 => /lib64/ld-linux-aarch64.so.1

At runtime, the kernel tries to load the file from /lib, and fails if we
only provide it in /lib64.

Instead of looking for the first slash after the "=>", just look for the
first slash, period. This would fail if we somehow had a relative path
on the left side (foo/libbar.so), but I'm not aware of any binaries that
would contain such an entry in DT_NEEDED.

Bug: https://bugs.gentoo.org/667752
Signed-off-by: Mike Gilbert