### PR TITLE
40network: Don't include 40network by default

### DIFF
--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 # called by dracut
+check() {
+    return 255
+}
+
+# called by dracut
 depends() {
     echo -n "kernel-network-modules "
     if ! dracut_module_included "network-legacy" && [ -x "/usr/libexec/nm-initrd-generator" ] ; then


### PR DESCRIPTION
commit 7347391 ('network-legacy: split off from network module')
splitted network function to network-legacy and removed check() function
of 40network. This caused 40network to be included even if network is
not needed.
