### PR TITLE
99squash: Don't clean up squahfs on isolate

### DIFF
--- a/modules.d/99squash/squash-mnt-clear.service
+++ b/modules.d/99squash/squash-mnt-clear.service
@@ -9,6 +9,7 @@ After=dracut-initqueue.service dracut-pre-pivot.service
 Before=initrd-cleanup.service
 ConditionPathExists=/squash/root
 Conflicts=initrd-switch-root.target
+IgnoreOnIsolate=true
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The only time we need to cleanup squahfs manually is on switch root, to
release resource and memory. We've covered that by setting
"Conflicts=initrd-switch-root.target" for squash cleanup service.
On shutdown systemd will take care of squahfs mounts. But for other
isolate, files in initramfs are most likely still required, so don't
clean up squahfs. For example, kdump's emergency handler will isolate
into its own target, if squahfs is cleaned up it will fail.

Signed-off-by: Kairui Song <kasong@redhat.com>