### PR TITLE
fips: check fips integrity just before mounting local filesystems in /sysroot

### DIFF
--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -52,7 +52,7 @@ installkernel() {
 # called by dracut
 install() {
     local _dir
-    inst_hook pre-trigger 01 "$moddir/fips-boot.sh"
+    inst_hook pre-mount 01 "$moddir/fips-boot.sh"
     inst_hook pre-pivot 01 "$moddir/fips-noboot.sh"
     inst_script "$moddir/fips.sh" /sbin/fips.sh
 


### PR DESCRIPTION
When booting a system with **/** and **/boot** on iSCSI, mounting /boot early in the initramfs (`x-initrd.mount`) and enabling FIPS, the system cannot boot because `fips.sh` doesn't find the `.hmac` file for the kernel.

The root cause is `01-fips-noboot.sh` runs in `pre-pivot`, which happens after `systemd-mount.service` was executed.

Due to having `x-initrd.mount` for **/boot**, systemd mounts the partition to **/sysroot/boot**.
Then in `pre-pivot`, `01-fips-noboot.sh` mounts the partition to **/boot** which fails since it is already mounted on **/sysroot/boot**.

Additionally, 20 seconds are lost during boot because `pre-trigger/01-fips-boot.sh` tries to mount **/boot** but at this step, there is no network and no iscsi yet.

I don't understand why FIPS check runs at this step, I do not see any reason for that.

Moving the check to `pre-mount` instead fixes all the issues:
- no delay anymore since devices are now present
- mount of **/boot** happens before systemd does the mounts under **/sysroot/** hierarchy

See also [RHBZ 1640981](https://bugzilla.redhat.com/show_bug.cgi?id=1640981)

Signed-off-by: Renaud Métrich <rmetrich@redhat.com>