### PR TITLE
Two fixes related to host_only behavior

### DIFF
--- a/modules.d/95dasd_rules/module-setup.sh
+++ b/modules.d/95dasd_rules/module-setup.sh
@@ -54,6 +54,8 @@ install() {
     if [[ $hostonly ]] ; then
         inst_rules_wildcard 51-dasd-*.rules
         inst_rules_wildcard 41-s390x-dasd-*.rules
+        mark_hostonly /etc/udev/rules.d/51-dasd-*.rules
+        mark_hostonly /etc/udev/rules.d/41-s390x-dasd-*.rules
     fi
     inst_rules 59-dasd.rules
 }

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -1327,7 +1327,7 @@ show_memstats()
 remove_hostonly_files() {
     rm -fr /etc/cmdline /etc/cmdline.d/*.conf "$hookdir/initqueue/finished"
     if [ -f /lib/dracut/hostonly-files ]; then
-        while read line || [ -n "$line" ]; do
+        while read -r line || [ -n "$line" ]; do
             [ -e "$line" ] || [ -h "$line" ] || continue
             rm -f "$line"
         done < /lib/dracut/hostonly-files


### PR DESCRIPTION
Triggered on 390x, but the backslash read fix
is useful on all platforms.