### PR TITLE
95iscsi: drop systemd dracut service dependencies for iscsid

### DIFF
--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -257,14 +257,6 @@ install() {
             ; do
             ln_r "$systemdsystemunitdir/${i}" "$systemdsystemunitdir/basic.target.wants/${i}"
         done
-
-        # Make sure iscsid is started after dracut-cmdline and ready for the initqueue
-        mkdir -p "${initdir}/$systemdsystemunitdir/iscsid.service.d"
-        (
-            echo "[Unit]"
-            echo "After=dracut-cmdline.service"
-            echo "Before=dracut-initqueue.service"
-        ) > "${initdir}/$systemdsystemunitdir/iscsid.service.d/dracut.conf"
     fi
     inst_dir /var/lib/iscsi
     dracut_need_initqueue


### PR DESCRIPTION
These dependencies cause an odd issue where swap devices specified
by resume= on the kernel command line will cause systemd device
timeouts to occur on boot. According to @haraldh these lines aren't
needed because the socket activiation will take care of it for us.
Removing these lines now as it fixes the resume= device timeout issue.

Fixes #480
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1641268