### PR TITLE
dracut.install: call dracut with --force

### DIFF
--- a/50-dracut.install
+++ b/50-dracut.install
@@ -49,7 +49,7 @@ case "$COMMAND" in
                 break
             fi
         done
-	dracut ${noimageifnotneeded:+--noimageifnotneeded} "$BOOT_DIR_ABS/$INITRD" "$KERNEL_VERSION"
+	dracut -f ${noimageifnotneeded:+--noimageifnotneeded} "$BOOT_DIR_ABS/$INITRD" "$KERNEL_VERSION"
         ret=$?
 	;;
     remove)

--- a/51-dracut-rescue.install
+++ b/51-dracut-rescue.install
@@ -98,7 +98,7 @@ case "$COMMAND" in
         fi
 
         if [[ ! -f "$BOOT_DIR_ABS/$INITRD" ]]; then
-            dracut --no-hostonly -a "rescue" "$BOOT_DIR_ABS/$INITRD" "$KERNEL_VERSION"
+            dracut -f --no-hostonly -a "rescue" "$BOOT_DIR_ABS/$INITRD" "$KERNEL_VERSION"
             ((ret+=$?))
         fi
 


### PR DESCRIPTION
The kernel-install is called even if you run make install.
Since we don't call dracut with -f a second make install will fail
because initrd with same version is already there.
This makes kernel developers feel miserable.

https://bugzilla.redhat.com/show_bug.cgi?id=1642402