### PR TITLE
Use eurlatgr as default console font

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -242,7 +242,7 @@ rd.vconsole.keymap=de-latin1-nodeadkeys
 [listing]
 .Example
 --
-rd.vconsole.font=LatArCyrHeb-16
+rd.vconsole.font=eurlatgr
 --
 
 **rd.vconsole.font.map=**__<console map base file name>__::

--- a/dracut.conf.5.asc
+++ b/dracut.conf.5.asc
@@ -187,7 +187,7 @@ provide a valid _/etc/fstab_.
 
 *i18n_default_font=*"__<fontname>__"::
     The font <fontname> to install, if not specified otherwise.
-    Default is "LatArCyrHeb-16".
+    Default is "eurlatgr".
 
 *i18n_install_all=*"__{yes|no}__"::
     Install everything regardless of generic or hostonly mode.

--- a/dracut.usage.asc
+++ b/dracut.usage.asc
@@ -153,7 +153,7 @@ the keyboard layout and specify a display font.
 
 A typical german kernel command would contain:
 ----
-rd.vconsole.font=latarcyrheb-sun16 rd.vconsole.keymap=de-latin1-nodeadkeys rd.locale.LANG=de_DE.UTF-8
+rd.vconsole.font=eurlatgr rd.vconsole.keymap=de-latin1-nodeadkeys rd.locale.LANG=de_DE.UTF-8
 ----
 
 Setting these options can override the setting stored on your system, if you use

--- a/modules.d/10i18n/console_init.sh
+++ b/modules.d/10i18n/console_init.sh
@@ -8,7 +8,7 @@ fi
 
 [ -e /etc/vconsole.conf ] && . /etc/vconsole.conf
 
-DEFAULT_FONT=LatArCyrHeb-16
+DEFAULT_FONT=eurlatgr
 DEFAULT_KEYMAP=/etc/sysconfig/console/default.kmap
 
 set_keyboard() {

--- a/modules.d/10i18n/module-setup.sh
+++ b/modules.d/10i18n/module-setup.sh
@@ -23,7 +23,7 @@ install() {
     fi
 
     KBDSUBDIRS=consolefonts,consoletrans,keymaps,unimaps
-    DEFAULT_FONT="${i18n_default_font:-LatArCyrHeb-16}"
+    DEFAULT_FONT="${i18n_default_font:-eurlatgr}"
     I18N_CONF="/etc/locale.conf"
     VCONFIG_CONF="/etc/vconsole.conf"
 

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -173,14 +173,13 @@ EOF
         inst /usr/lib/systemd/system/dbus.service
 
         (
-            echo "FONT=latarcyrheb-sun16"
+            echo "FONT=eurlatgr"
             echo "KEYMAP=us"
         ) >$initrd/etc/vconsole.conf
 
         # install basic keyboard maps and fonts
         for i in \
             /usr/lib/kbd/consolefonts/eurlatgr* \
-            /usr/lib/kbd/consolefonts/latarcyrheb-sun16* \
             /usr/lib/kbd/keymaps/{legacy/,/}include/* \
             /usr/lib/kbd/keymaps/{legacy/,/}i386/include/* \
             /usr/lib/kbd/keymaps/{legacy/,/}i386/qwerty/us.*; do


### PR DESCRIPTION
Fedora and others have used eurlatgr as the default console font
for some time now, or suggested using it:

https://fedoraproject.org/wiki/Changes/NewDefaultConsoleFont
https://wiki.archlinux.org/index.php/Linux_console#Fonts

The Fedora Change page lists some of the benefits and this file
lists all the characters (glyphs) supported by the font:

http://git.altlinux.org/people/legion/packages/kbd.git?p=kbd.git;a=blob;f=data/consolefonts/README.eurlatgr

The notable downside is that the font does not support Arabic,
Cyrillic or Hebrew as LatArCyrHeb-16 (partially) does, so in cases
where support for languages using them is needed a non-default
console font should be used. Fedora, for instance, uses langtable
to decide the console font to use based on installation language:

https://bugzilla.redhat.com/show_bug.cgi?id=1209460