### PR TITLE
Delay argument "-d" requires number

### DIFF
--- a/modules.d/99shutdown/shutdown.sh
+++ b/modules.d/99shutdown/shutdown.sh
@@ -112,17 +112,17 @@ getarg 'rd.break=shutdown' && emergency_shell --shutdown shutdown "Break before 
 
 case "$ACTION" in
     reboot|poweroff|halt)
-        $ACTION -f -d -n
+        $ACTION -f -n
         warn "$ACTION failed!"
         ;;
     kexec)
         kexec -e
         warn "$ACTION failed!"
-        reboot -f -d -n
+        reboot -f -n
         ;;
     *)
         warn "Shutdown called with argument '$ACTION'. Rebooting!"
-        reboot -f -d -n
+        reboot -f -n
         ;;
 esac
 


### PR DESCRIPTION
Arguments "-f -d -n" fails with "invalid number -n", because -d delay expects number of seconds.