### PR TITLE
fips: removed false-positive 'FATAL: Module xxx not found' error message when kernel provides a generic algo for module

### DIFF
--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -84,7 +84,7 @@ do_fips()
     mv /etc/modprobe.d/fips.conf /etc/modprobe.d/fips.conf.bak
     for _module in $FIPSMODULES; do
         if [ "$_module" != "tcrypt" ]; then
-            if ! modprobe "${_module}"; then
+            if ! modprobe "${_module}" 2>/tmp/fips.modprobe_err; then
                 # check if kernel provides generic algo
                 _found=0
                 while read _k _s _v || [ -n "$_k" ]; do
@@ -93,7 +93,7 @@ do_fips()
                     _found=1
                     break
                 done </proc/crypto
-                [ "$_found" = "0" ] && return 1
+                [ "$_found" = "0" ] && cat /tmp/fips.modprobe_err >&2 && return 1
             fi
         fi
     done


### PR DESCRIPTION
When booting a RHEL7.6 system with FIPS, the journal records the following messages:

~~~
# journalctl -b | grep FATAL
Nov 14 13:14:05 vm-fips7 dracut-pre-trigger[241]: modprobe: FATAL: Module sha1 not found.
Nov 14 13:14:05 vm-fips7 dracut-pre-trigger[241]: modprobe: FATAL: Module sha256 not found.
~~~

These are due to the initramfs not containing the **sha1** and **sha256** modules because they are blacklisted in `/lib/modprobe.d/dist-blacklist.conf`:

~~~
# crypto algorithms
blacklist sha1-mb

# see bz #1562114
blacklist sha256-mb
~~~

This causes dracut's **instmods** to just ignore these.

Because the kernel provides a generic algo for these, there is no need to output these misleading and confusing messages.