### PR TITLE
network-manager: call the online hook for connected devices

### DIFF
--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -9,8 +9,9 @@ fi
 for _i in /sys/class/net/*/
 do
     state=/run/NetworkManager/devices/$(cat $_i/ifindex)
-    grep -q managed=true $state 2>/dev/null || continue
+    grep -q connection-uuid= $state 2>/dev/null || continue
     ifname=$(basename $_i)
     sed -n 's/root-path/new_root_path/p' <$state >/tmp/dhclient.$ifname.dhcpopts
+    source_hook initqueue/online $ifname
     /sbin/netroot $ifname
 done


### PR DESCRIPTION
Look for "connection-uuid" instead of "managed" to determine the devices
that are actually activated with a connection and call the online hook.

This fixes the anaconda-net root mount, which utilizes the online hook.
Needed to address https://bugzilla.redhat.com/show_bug.cgi?id=1641832