### PR TITLE
Ensure the AWS ENA driver is in the initrd for cloud images

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -43,6 +43,14 @@ installkernel() {
             virtio virtio_blk virtio_ring virtio_pci virtio_scsi \
             "=drivers/pcmcia" =ide nvme vmd nfit
 
+        if [[ "$(uname -m)" == x86_64 || "$(uname -m)" == aarch64 ]]; then
+            # virtio_net driver for kvm, ENA driver for AWS
+            instmods \
+                "=drivers/net/ethernet/amazon/ena" \
+                virtio_net \
+                ${NULL}
+        fi
+
         if [[ "$(uname -m)" == arm* || "$(uname -m)" == aarch64 ]]; then
             # arm/aarch64 specific modules
             _blockfuncs+='|dw_mc_probe|dw_mci_pltfm_register'


### PR DESCRIPTION
Amazon ENA driver should be in initrd for various init bits. Ensure that's
the case for the supported x86_64 and aarch64 architectures.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>