### PR TITLE
dracut.modules.7.asc: typo correction

### DIFF
--- a/dracut.modules.7.asc
+++ b/dracut.modules.7.asc
@@ -266,7 +266,7 @@ installs an executable/script <src> in the dracut hook <hookdir> with priority
 
 ==== inst_rules <udevrule> [ <udevrule> ...]
 
-installs one ore more udev rules. Non-existant udev rules are reported, but do
+installs one or more udev rules. Non-existant udev rules are reported, but do
 not let dracut fail.
 
 ==== instmods <kernelmodule> [ <kernelmodule> ... ]


### PR DESCRIPTION
Correct simple typo in .7 manpage for dracut.

Signed-off-by: Bruno E. O. Meneguele <bmeneg@redhat.com>