### PR TITLE
emergency mode: use sulogin

### DIFF
--- a/modules.d/98dracut-systemd/module-setup.sh
+++ b/modules.d/98dracut-systemd/module-setup.sh
@@ -59,5 +59,7 @@ install() {
     done
 
     inst_simple "$moddir/dracut-tmpfiles.conf" "$tmpfilesdir/dracut-tmpfiles.conf"
+
+    inst_multiple sulogin
 }
 

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -26,9 +26,13 @@ install() {
         (ln -s bash "${initdir}/bin/sh" || :)
     fi
 
-    #add common users in /etc/passwd, it will be used by nfs/ssh currently
-    grep '^root:' "$initdir/etc/passwd" 2>/dev/null || echo  'root:x:0:0::/root:/bin/sh' >> "$initdir/etc/passwd"
+    # add common users in /etc/passwd, it will be used by nfs/ssh currently
+    # use password for hostonly images to facilitate secure sulogin in emergency console
+    [[ $hostonly ]] && pwshadow='x'
+    grep '^root:' "$initdir/etc/passwd" 2>/dev/null || echo  "root:$pwshadow:0:0::/root:/bin/sh" >> "$initdir/etc/passwd"
     grep '^nobody:' /etc/passwd >> "$initdir/etc/passwd"
+
+    [[ $hostonly ]] && grep '^root:' /etc/shadow >> "$initdir/etc/shadow"
 
     # install our scripts and hooks
     inst_script "$moddir/init.sh" "/init"


### PR DESCRIPTION
- allow emergency login on every console
  specified in the kernel cmdline
- require password for hostonly images
- emergency mode: Manually multiplex emergency infos

This will bring all vital information to all ttys specified
as console devices, regardless of wether they hold the C flag.

Reference: FATE#325386
Reference: #449