### PR TITLE
add mksh support

### DIFF
--- a/modules.d/00mksh/module-setup.sh
+++ b/modules.d/00mksh/module-setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+    require_binaries /bin/mksh
+}
+
+# called by dracut
+depends() {
+    return 0
+}
+
+# called by dracut
+install() {
+    # If another shell is already installed, do not use mksh
+    [[ -x $initdir/bin/sh ]] && return
+
+    # Prefer mksh as /bin/sh if it is available.
+    inst /bin/mksh && ln -sf mksh "${initdir}/bin/sh"
+}

--- a/modules.d/99fs-lib/module-setup.sh
+++ b/modules.d/99fs-lib/module-setup.sh
@@ -69,7 +69,7 @@ install() {
 
     if [[ "$fscks" = "${fscks#*[^ ]*}" ]]; then
         _helpers="\
-            umount mount /sbin/fsck*
+            umount mount /sbin/fsck* /usr/sbin/fsck*
             xfs_db xfs_check xfs_repair xfs_metadump
             e2fsck jfs_fsck reiserfsck btrfsck
         "


### PR DESCRIPTION
Add support for  MirBSD™ Korn Shell, an actively developed free implementation of the Korn Shell programming language and a successor to the Public Domain Korn Shell (pdksh).
http://www.mirbsd.org/mksh.htm