### PR TITLE
remove superfluous quotes in parameter expansion

### DIFF
--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -129,7 +129,7 @@ setup_net() {
     for _p in $(getargs rd.route); do
         route_to_var "$_p" || continue
         [ -n "$route_dev" ] && [ "$route_dev" != "$netif" ] && continue
-        ip route add "$route_mask" ${route_gw:+via "$route_gw"} ${route_dev:+dev "$route_dev"}
+        ip route add "$route_mask" ${route_gw:+via $route_gw} ${route_dev:+dev $route_dev}
         if strstr "$route_mask" ":"; then
             printf -- "%s\n" "$route_mask ${route_gw:+via $route_gw} ${route_dev:+dev $route_dev}" \
                 > /tmp/net.route6."$netif"

--- a/modules.d/95iscsi/mount-lun.sh
+++ b/modules.d/95iscsi/mount-lun.sh
@@ -2,7 +2,7 @@
 if [ -z $iscsi_lun ]; then
     iscsi_lun=0
 fi
-NEWROOT=${NEWROOT:-"/sysroot"}
+NEWROOT=${NEWROOT:-/sysroot}
 
 for disk in /dev/disk/by-path/*-iscsi-*-$iscsi_lun; do
     if mount -t ${fstype:-auto} -o "$rflags" $disk $NEWROOT; then

--- a/modules.d/95virtfs/mount-virtfs.sh
+++ b/modules.d/95virtfs/mount-virtfs.sh
@@ -57,7 +57,7 @@ mount_root() {
 
     # we want rootflags (rflags) to take precedence so prepend rootopts to
     # them; rflags is guaranteed to not be empty
-    rflags="${rootopts:+"${rootopts},"}${rflags}"
+    rflags="${rootopts:+${rootopts},}${rflags}"
 
     umount "$NEWROOT"
 

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -24,7 +24,7 @@ debug_on() {
 
 # returns OK if $1 contains literal string $2 (and isn't empty)
 strstr() {
-    [ "${1##*"$2"*}" != "$1" ]
+    [ "${1##*$2*}" != "$1" ]
 }
 
 # returns OK if $1 matches (completely) glob pattern $2
@@ -43,18 +43,18 @@ strglobin() {
 
 # returns OK if $1 contains literal string $2 at the beginning, and isn't empty
 str_starts() {
-    [ "${1#"$2"*}" != "$1" ]
+    [ "${1#$2*}" != "$1" ]
 }
 
 # returns OK if $1 contains literal string $2 at the end, and isn't empty
 str_ends() {
-    [ "${1%*"$2"}" != "$1" ]
+    [ "${1%*$2}" != "$1" ]
 }
 
 trim() {
     local var="$*"
-    var="${var#"${var%%[![:space:]]*}"}"   # remove leading whitespace characters
-    var="${var%"${var##*[![:space:]]}"}"   # remove trailing whitespace characters
+    var="${var#${var%%[![:space:]]*}}"   # remove leading whitespace characters
+    var="${var%${var##*[![:space:]]}}"   # remove trailing whitespace characters
     printf "%s" "$var"
 }
 
@@ -108,9 +108,9 @@ str_replace() {
     local out=''
 
     while strstr "${in}" "$s"; do
-        chop="${in%%"$s"*}"
+        chop="${in%%$s*}"
         out="${out}${chop}$r"
-        in="${in#*"$s"}"
+        in="${in#*$s}"
     done
     echo "${out}${in}"
 }
@@ -396,7 +396,7 @@ splitsep() {
     while [ -n "$str" -a "$#" -gt 1 ]; do
         tmp="${str%%$sep*}"
         eval "$1='${tmp}'"
-        str="${str#"$tmp"}"
+        str="${str#$tmp}"
         str="${str#$sep}"
         shift
     done


### PR DESCRIPTION
as this breaks busybox hush shell.
offending functions can be found with
grep -r '${[^}]*"[^}]*}'