### PR TITLE
add mksh support v2

### DIFF
--- a/dracut.spec
+++ b/dracut.spec
@@ -222,6 +222,9 @@ rm -fr -- $RPM_BUILD_ROOT/%{dracutlibdir}/modules.d/00bootchart
 # we do not support dash in the initramfs
 rm -fr -- $RPM_BUILD_ROOT/%{dracutlibdir}/modules.d/00dash
 
+# we do not support mksh in the initramfs
+rm -fr -- $RPM_BUILD_ROOT/%{dracutlibdir}/modules.d/00mksh
+
 # remove gentoo specific modules
 rm -fr -- $RPM_BUILD_ROOT/%{dracutlibdir}/modules.d/50gensplash
 

--- a/modules.d/00mksh/module-setup.sh
+++ b/modules.d/00mksh/module-setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+    require_binaries /bin/mksh
+}
+
+# called by dracut
+depends() {
+    return 0
+}
+
+# called by dracut
+install() {
+    # If another shell is already installed, do not use mksh
+    [[ -x $initdir/bin/sh ]] && return
+
+    # Prefer mksh as /bin/sh if it is available.
+    inst /bin/mksh && ln -sf mksh "${initdir}/bin/sh"
+}
+


### PR DESCRIPTION
Add support for MirBSD™ Korn Shell, an actively developed free implementation of the Korn Shell programming language and a successor to the Public Domain Korn Shell (pdksh).
http://www.mirbsd.org/mksh.htm

@haraldh please review