### PR TITLE
99squash: fail early if can't install require modules in initramfs

### DIFF
--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -10,7 +10,7 @@ depends() {
 }
 
 installkernel() {
-    hostonly="" instmods squashfs loop overlay
+    hostonly="" instmods -c squashfs loop overlay
 }
 
 install() {


### PR DESCRIPTION
insmods will consider all arguments as optional modules by default, but
for squash module, all listed modules are required, if any of them is
missing the initramfs won't boot. So pass the '-c' argument to let instmos
know all those modules are mandatory, it will fail and give an error if
it failed to install any of those modules.