### PR TITLE
00systemd: check if systemd version is a number

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -5,6 +5,11 @@ check() {
     [[ $mount_needs ]] && return 1
     if require_binaries $systemdutildir/systemd; then
         SYSTEMD_VERSION=$($systemdutildir/systemd --version | { read a b a; echo $b; })
+        # Check if the systemd version is a valid number
+        if ! [[ $SYSTEMD_VERSION =~ ^[0-9]+$ ]]; then
+            dfatal "systemd version is not a number ($SYSTEMD_VERSION)"
+            exit 1
+        fi
         (( $SYSTEMD_VERSION >= 198 )) && return 0
        return 255
     fi


### PR DESCRIPTION
The recent systemd upstream introduced a slightly modified version
string which included information about a git commit, which however
broke the version check in dracut. Unfortunately, the (( )) bash syntax
went along with it in certain cases and introduced a pretty nasty issue,
when the systemd would boot up but with slightly changed environment.

To prevent this from happening in the future, let's at least check if
the version parsed from the `systemd --version` output is a comparable
number.

---

Few days ago, a certain commit in systemd introduced change into the systemd version schema, which changed `systemd 240` to `systemd 240-63-g4199f68+`. This change was merged, as the CIs, including the CentOS CI with dracut, were passing.

Moving two days forward, the CentOS CI started suddenly failing for all PRs, as, for some strange reason, the `/dev/shm` mount had `noexec` flag set after reboot. After several hours of debugging I discovered that the initrd image generated by dracut has different `init` file, i.e. it was a [bash script](https://github.com/dracutdevs/dracut/blob/master/modules.d/99base/init.sh) instead of a symlink to the systemd binary. Thanks to nature of this script though, which looks for an init binary, the system booted successfully.

All this was caused by the version comparison, which has some unexpected results when given a non-numeric argument:

Version string when the offending commit was merged:
```bash
$ (( 240-27-g6f791ae >= 198 )); echo $?
0
```

and when I started bisecting the systemd tree:
```bash
$ (( 239-3560-g4802097 >= 198 )); echo $?
1
```
https://github.com/systemd/systemd/issues/11330

To prevent such issues in the future, I added at least a check if the parsed version is a number. Other possible solution would be replacing the `(( ))` syntax with `[ "$SYSTEMD_VERSION" -ge 198 ]`, as this would at least throw an error in case of a non-numeric argument.