### PR TITLE
10i18n: Fix keymaps not getting included sometimes

### DIFF
--- a/modules.d/10i18n/module-setup.sh
+++ b/modules.d/10i18n/module-setup.sh
@@ -36,7 +36,7 @@ install() {
             MAPS=$(find ${kbddir}/keymaps -type f -name ${MAPNAME} -o -name ${MAPNAME}.map -o -name ${MAPNAME}.map.\*)
 
         for map in $MAPS; do
-            KEYMAPS="$KEYMAPS $map"
+            KEYMAPS="$KEYMAPS $map "
             case $map in
                 *.gz) cmd=zgrep;;
                 *.bz2) cmd=bzgrep;;
@@ -45,7 +45,7 @@ install() {
 
             for INCL in $($cmd "^include " $map | while read a a b || [ -n "$a" ]; do echo ${a//\"/}; done); do
                 for FN in $(find ${kbddir}/keymaps -type f -name $INCL\*); do
-                    strstr "$KEYMAPS" "$FN" || findkeymap $FN
+                    strstr "$KEYMAPS" " $FN " || findkeymap $FN
                 done
             done
         done


### PR DESCRIPTION
Eliminate erroneous substring matches when looking up already processed keymaps to prevent necessary keymaps not getting added to the initramfs sometimes e.g. if there are the files *'compose.latin1'* and *'compose.latin1.add'* the unfixed version would skip processing *'compose.latin1'* if **'find'** returned *'compose.latin1.add'* first due to the directory listing not being in sorted order.