### PR TITLE
[wip] fix weird issues around iscsid dependencies

### DIFF
--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -265,6 +265,23 @@ install() {
             echo "After=dracut-cmdline.service"
             echo "Before=dracut-initqueue.service"
         ) > "${initdir}/$systemdsystemunitdir/iscsid.service.d/dracut.conf"
+
+        # The iscsi deamon does not need to wait for any storage inside initrd
+        mkdir -p "${initdir}/$systemdsystemunitdir/iscsid.socket.d"
+        (
+            echo "[Unit]"
+            echo "DefaultDependencies=no"
+            echo "Conflicts=shutdown.target"
+            echo "Before=shutdown.target sockets.target"
+        ) > "${initdir}/$systemdsystemunitdir/iscsid.socket.d/dracut.conf"
+        mkdir -p "${initdir}/$systemdsystemunitdir/iscsuio.socket.d"
+        (
+            echo "[Unit]"
+            echo "DefaultDependencies=no"
+            echo "Conflicts=shutdown.target"
+            echo "Before=shutdown.target sockets.target"
+        ) > "${initdir}/$systemdsystemunitdir/iscsuio.socket.d/dracut.conf"
+
     fi
     inst_dir /var/lib/iscsi
     dracut_need_initqueue

--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -257,6 +257,14 @@ install() {
             ; do
             ln_r "$systemdsystemunitdir/${i}" "$systemdsystemunitdir/basic.target.wants/${i}"
         done
+
+        # Make sure iscsid is started after dracut-cmdline and ready for the initqueue
+        mkdir -p "${initdir}/$systemdsystemunitdir/iscsid.service.d"
+        (
+            echo "[Unit]"
+            echo "After=dracut-cmdline.service"
+            echo "Before=dracut-initqueue.service"
+        ) > "${initdir}/$systemdsystemunitdir/iscsid.service.d/dracut.conf"
     fi
     inst_dir /var/lib/iscsi
     dracut_need_initqueue


### PR DESCRIPTION
I don't think that 765b203 was a correct fix for the issues we saw in https://github.com/dracutdevs/dracut/issues/480. You would still hit that issue, if you have a swap on the iscsi disk (but probably nobody uses such setup).

The original fix removed the systemd dependency there, but the ordering is more or less still the same. I think that a bigger issue is that iscsi sockets have a default dependency on sysinit.target, which is pretty late (after local-fs.target). So I think we should break the cycle there.