### PR TITLE
Fix a missing space in example configs

### DIFF
--- a/dracut.conf.d/gentoo.conf.example
+++ b/dracut.conf.d/gentoo.conf.example
@@ -12,4 +12,4 @@ ro_mnt=yes
 i18n_vars="/etc/conf.d/keymaps:keymap-KEYMAP,extended_keymaps-EXT_KEYMAPS /etc/conf.d/consolefont:consolefont-FONT,consoletranslation-FONT_MAP /etc/rc.conf:unicode-UNICODE"
 i18n_default_font="LatArCyrHeb-16"
 
-omit_drivers+=" i2o_scsi"
+omit_drivers+=" i2o_scsi "

--- a/dracut.conf.d/suse.conf.example
+++ b/dracut.conf.d/suse.conf.example
@@ -10,7 +10,7 @@ hostonly_cmdline="yes"
 compress="xz -0 --check=crc32 --memlimit-compress=50%"
 
 i18n_vars="/etc/sysconfig/language:RC_LANG-LANG,RC_LC_ALL-LC_ALL /etc/sysconfig/console:CONSOLE_UNICODEMAP-FONT_UNIMAP,CONSOLE_FONT-FONT,CONSOLE_SCREENMAP-FONT_MAP /etc/sysconfig/keyboard:KEYTABLE-KEYMAP"
-omit_drivers+=" i2o_scsi"
+omit_drivers+=" i2o_scsi "
 
 # Below adds additional tools to the initrd which are not urgently necessary to
 # bring up the system, but help to debug problems.


### PR DESCRIPTION
It has

omit_drivers+=" i2o_scsi"

which would break the next omit_drivers+="foo " if it's
missing a space at the beginning.

Reference: boo#1121251