### PR TITLE
95iscsi: /sys/devices/platform/*/flashnode_sess-*/is_boot_target some…

### DIFF
--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -86,6 +86,7 @@ install_iscsiroot() {
     iscsi_host=${host##*/}
 
     for flash in ${host}/flashnode_sess-* ; do
+        [ ! -e "$flash/is_boot_target" ] && continue
         is_boot=$(cat $flash/is_boot_target)
         if [ $is_boot -eq 1 ] ; then
             # qla4xxx flashnode session; skip iBFT discovery


### PR DESCRIPTION
…times does not exist

cat: '/sys/devices/platform/host2/flashnode_sess-*/is_boot_target': No such file or directory
/usr/lib/dracut/modules.d/95iscsi/module-setup.sh: line 90: [: -eq: unary operator expected