### PR TITLE
network-manager: let the kernel generate a UUID for /etc/machine-id

### DIFF
--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -41,7 +41,9 @@ install() {
     elif ! [[ -e "$initdir/etc/machine-id" ]]; then
         # The internal DHCP client silently fails if we
         # have no machine-id
-        systemd-machine-id-setup --root="$initdir"
+        local UUID=$(< /proc/sys/kernel/random/uuid)
+        UUID=${UUID//-}
+        echo "$UUID" > "$initdir/etc/machine-id"
     fi
 
     # We don't install the ifcfg files from the host automatically.


### PR DESCRIPTION
systemd normally manages /etc/machine-id, but dbus-uuidgen is more
likely to exist on systems that don't have systemd installed.

Bug: https://bugs.gentoo.org/677554