### PR TITLE
95iscsi: handle qedi like bnx2i

### DIFF
--- a/modules.d/95iscsi/cleanup-iscsi.sh
+++ b/modules.d/95iscsi/cleanup-iscsi.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
-[ -z "${DRACUT_SYSTEMD}" ] && [ -e /sys/module/bnx2i ] && killproc iscsiuio
-
+if [[ -z "${DRACUT_SYSTEMD}" ]] && ( [[ -e /sys/module/bnx2i ]] || [[ -e /sys/module/qedi ]] ) ; then
+      killproc iscsiuio
+fi

--- a/modules.d/95iscsi/iscsiroot.sh
+++ b/modules.d/95iscsi/iscsiroot.sh
@@ -36,9 +36,12 @@ iroot=${iroot#:}
 # figured out a way how to check whether this is built-in or not
 modprobe crc32c 2>/dev/null
 
-if [ -z "${DRACUT_SYSTEMD}" ] && [ -e /sys/module/bnx2i ] && ! [ -e /tmp/iscsiuio-started ]; then
-        iscsiuio
-        > /tmp/iscsiuio-started
+# start iscsiuio if needed
+if [[ -z "${DRACUT_SYSTEMD}" ]] && \
+      ( [[ -e /sys/module/bnx2i ]] || [[ -e /sys/module/qedi ]] ) && \
+       ! [ -e /tmp/iscsiuio-started ]; then
+      iscsiuio
+      > /tmp/iscsiuio-started
 fi
 
 


### PR DESCRIPTION
The new qedi driver needs to be handled just like
the bnx2i driver, so update 95iscsi scripts to do this.

References: bsc#1113712

Signed-off-by: Lee Duncan <lduncan@suse.com>