### PR TITLE
99base: enable the initqueue in both 'dracut --add-device' and 'dracut --mount' cases

### DIFF
--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -97,7 +97,7 @@ install() {
 
     ## save host_devs which we need bring up
     if [[ $hostonly_cmdline == "yes" ]]; then
-        if [[ -n $add_device ]]; then
+        if [[ -n "${host_devs[@]}" ]]; then
             dracut_need_initqueue
         fi
         if [[ -f "$initdir/lib/dracut/need-initqueue" ]] || ! dracut_module_included "systemd"; then


### PR DESCRIPTION
…n time

Recently, we have encountered some kdump failures of virtual machines.
Although the device driver has been added to kdump initrd, the driver
is not loaded because the device isn't present yet, it's not brought up
in time. Which causes the kdump failure.

Therefore, the initqueue mechanism is still necessary for all devices
that need to be brought up in time.

Signed-off-by: Lianbo Jiang <lijiang@redhat.com>