### PR TITLE
dracut: let module handling function accept optional path option

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -150,6 +150,10 @@ dracut_module_included() {
     [[ " $mods_to_load $modules_loaded " == *\ $*\ * ]]
 }
 
+dracut_module_path() {
+    echo ${dracutbasedir}/modules.d/??${1} | { read a b; echo "$a"; }
+}
+
 if ! [[ $DRACUT_INSTALL ]]; then
     DRACUT_INSTALL=$(find_binary dracut-install)
 fi
@@ -567,15 +571,16 @@ inst_opt_decompress() {
     done
 }
 
-# module_check <dracut module>
+# module_check <dracut module> [<forced>] [<module path>]
 # execute the check() function of module-setup.sh of <dracut module>
 # or the "check" script, if module-setup.sh is not found
 # "check $hostonly" is called
 module_check() {
-    local _moddir=$(echo ${dracutbasedir}/modules.d/??${1} | { read a b; echo "$a"; })
+    local _moddir=$3
     local _ret
     local _forced=0
     local _hostonly=$hostonly
+    [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
     [ $# -eq 2 ] && _forced=$2
     [[ -d $_moddir ]] || return 1
     if [[ ! -f $_moddir/module-setup.sh ]]; then
@@ -598,14 +603,15 @@ module_check() {
     return $_ret
 }
 
-# module_check_mount <dracut module>
+# module_check_mount <dracut module> [<module path>]
 # execute the check() function of module-setup.sh of <dracut module>
 # or the "check" script, if module-setup.sh is not found
 # "mount_needs=1 check 0" is called
 module_check_mount() {
-    local _moddir=$(echo ${dracutbasedir}/modules.d/??${1} | { read a b; echo "$a"; })
+    local _moddir=$2
     local _ret
     mount_needs=1
+    [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
     [[ -d $_moddir ]] || return 1
     if [[ ! -f $_moddir/module-setup.sh ]]; then
         # if we do not have a check script, we are unconditionally included
@@ -624,12 +630,13 @@ module_check_mount() {
     return $_ret
 }
 
-# module_depends <dracut module>
+# module_depends <dracut module> [<module path>]
 # execute the depends() function of module-setup.sh of <dracut module>
 # or the "depends" script, if module-setup.sh is not found
 module_depends() {
-    local _moddir=$(echo ${dracutbasedir}/modules.d/??${1} | { read a b; echo "$a"; })
+    local _moddir=$2
     local _ret
+    [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
     [[ -d $_moddir ]] || return 1
     if [[ ! -f $_moddir/module-setup.sh ]]; then
         # if we do not have a check script, we have no deps
@@ -647,12 +654,13 @@ module_depends() {
     fi
 }
 
-# module_cmdline <dracut module>
+# module_cmdline <dracut module> [<module path>]
 # execute the cmdline() function of module-setup.sh of <dracut module>
 # or the "cmdline" script, if module-setup.sh is not found
 module_cmdline() {
-    local _moddir=$(echo ${dracutbasedir}/modules.d/??${1} | { read a b; echo "$a"; })
+    local _moddir=$2
     local _ret
+    [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
     [[ -d $_moddir ]] || return 1
     if [[ ! -f $_moddir/module-setup.sh ]]; then
         [[ -x $_moddir/cmdline ]] && . "$_moddir/cmdline"
@@ -668,12 +676,13 @@ module_cmdline() {
     fi
 }
 
-# module_install <dracut module>
+# module_install <dracut module> [<module path>]
 # execute the install() function of module-setup.sh of <dracut module>
 # or the "install" script, if module-setup.sh is not found
 module_install() {
-    local _moddir=$(echo ${dracutbasedir}/modules.d/??${1} | { read a b; echo "$a"; })
+    local _moddir=$2
     local _ret
+    [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
     [[ -d $_moddir ]] || return 1
     if [[ ! -f $_moddir/module-setup.sh ]]; then
         [[ -x $_moddir/install ]] && . "$_moddir/install"
@@ -689,12 +698,13 @@ module_install() {
     fi
 }
 
-# module_installkernel <dracut module>
+# module_installkernel <dracut module> [<module path>]
 # execute the installkernel() function of module-setup.sh of <dracut module>
 # or the "installkernel" script, if module-setup.sh is not found
 module_installkernel() {
-    local _moddir=$(echo ${dracutbasedir}/modules.d/??${1} | { read a b; echo "$a"; })
+    local _moddir=$2
     local _ret
+    [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
     [[ -d $_moddir ]] || return 1
     if [[ ! -f $_moddir/module-setup.sh ]]; then
         [[ -x $_moddir/installkernel ]] && . "$_moddir/installkernel"
@@ -710,15 +720,16 @@ module_installkernel() {
     fi
 }
 
-# check_mount <dracut module>
+# check_mount <dracut module> [<use_as_dep>] [<module path>]
 # check_mount checks, if a dracut module is needed for the given
 # device and filesystem types in "${host_fs_types[@]}"
 check_mount() {
     local _mod=$1
-    local _moddir=$(echo ${dracutbasedir}/modules.d/??${1} | { read a b; echo "$a"; })
+    local _moddir=$3
     local _ret
     local _moddep
 
+    [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
     [ "${#host_fs_types[@]}" -le 0 ] && return 1
 
     # If we are already scheduled to be loaded, no need to check again.
@@ -735,7 +746,7 @@ check_mount() {
     fi
 
     if [[ " $dracutmodules $add_dracutmodules $force_add_dracutmodules" == *\ $_mod\ * ]]; then
-        module_check_mount $_mod; ret=$?
+        module_check_mount $_mod $_moddir; ret=$?
 
         # explicit module, so also accept ret=255
         [[ $ret = 0 || $ret = 255 ]] || return 1
@@ -743,14 +754,14 @@ check_mount() {
         # module not in our list
         if [[ $dracutmodules = all ]]; then
             # check, if we can and should install this module
-            module_check_mount $_mod || return 1
+            module_check_mount $_mod $_moddir || return 1
         else
             # skip this module
             return 1
         fi
     fi
 
-    for _moddep in $(module_depends $_mod); do
+    for _moddep in $(module_depends $_mod $_moddir); do
         # handle deps as if they were manually added
         [[ " $dracutmodules " == *\ $_mod\ * ]] \
             && [[ " $dracutmodules " != *\ $_moddep\ * ]] \
@@ -774,15 +785,17 @@ check_mount() {
     return 0
 }
 
-# check_module <dracut module> [<use_as_dep>]
+# check_module <dracut module> [<use_as_dep>] [<module path>]
 # check if a dracut module is to be used in the initramfs process
 # if <use_as_dep> is set, then the process also keeps track
 # that the modules were checked for the dependency tracking process
 check_module() {
     local _mod=$1
-    local _moddir=$(echo ${dracutbasedir}/modules.d/??${1} | { read a b; echo "$a"; })
+    local _moddir=$3
     local _ret
     local _moddep
+
+    [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
     # If we are already scheduled to be loaded, no need to check again.
     [[ " $mods_to_load " == *\ $_mod\ * ]] && return 0
     [[ " $mods_checked_as_dep " == *\ $_mod\ * ]] && return 1
@@ -799,9 +812,9 @@ check_module() {
 
     if [[ " $dracutmodules $add_dracutmodules $force_add_dracutmodules" == *\ $_mod\ * ]]; then
         if [[ " $dracutmodules $force_add_dracutmodules " == *\ $_mod\ * ]]; then
-            module_check $_mod 1; ret=$?
+            module_check $_mod 1 $_moddir; ret=$?
         else
-            module_check $_mod 0; ret=$?
+            module_check $_mod 0 $_moddir; ret=$?
         fi
         # explicit module, so also accept ret=255
         [[ $ret = 0 || $ret = 255 ]] || return 1
@@ -809,7 +822,7 @@ check_module() {
         # module not in our list
         if [[ $dracutmodules = all ]]; then
             # check, if we can and should install this module
-            module_check $_mod; ret=$?
+            module_check $_mod 0 $_moddir; ret=$?
             if [[ $ret != 0 ]]; then
                 [[ $2 ]] && return 1
                 [[ $ret != 255 ]] && return 1
@@ -820,7 +833,7 @@ check_module() {
         fi
     fi
 
-    for _moddep in $(module_depends $_mod); do
+    for _moddep in $(module_depends $_mod $_moddir); do
         # handle deps as if they were manually added
         [[ " $dracutmodules " == *\ $_mod\ * ]] \
             && [[ " $dracutmodules " != *\ $_moddep\ * ]] \
@@ -845,7 +858,7 @@ check_module() {
 }
 
 # for_each_module_dir <func>
-# execute "<func> <dracut module> 1"
+# execute "<func> <dracut module> 1 <module path>"
 for_each_module_dir() {
     local _modcheck
     local _mod
@@ -857,7 +870,7 @@ for_each_module_dir() {
         [[ -e $_moddir/install || -e $_moddir/installkernel || \
             -e $_moddir/module-setup.sh ]] || continue
         _mod=${_moddir##*/}; _mod=${_mod#[0-9][0-9]}
-        $_func $_mod 1
+        $_func $_mod 1 $_moddir
     done
 
     # Report any missing dracut modules, the user has specified

--- a/dracut.sh
+++ b/dracut.sh
@@ -1373,7 +1373,7 @@ do_print_cmdline()
     for moddir in "$dracutbasedir/modules.d"/[0-9][0-9]*; do
         _d_mod=${moddir##*/}; _d_mod=${_d_mod#[0-9][0-9]}
         [[ ${_mods_to_print[$_d_mod]} ]] || continue
-        module_cmdline "$_d_mod"
+        module_cmdline "$_d_mod" "$moddir"
     done
     unset moddir
 }
@@ -1454,14 +1454,14 @@ for moddir in "$dracutbasedir/modules.d"/[0-9][0-9]*; do
         dinfo "*** Including module: $_d_mod ***"
     fi
     if [[ $kernel_only == yes ]]; then
-        module_installkernel "$_d_mod" || {
+        module_installkernel "$_d_mod" "$moddir" || {
             dfatal "installkernel failed in module $_d_mod"
             exit 1
         }
     else
-        module_install "$_d_mod"
+        module_install "$_d_mod" "$moddir"
         if [[ $no_kernel != yes ]]; then
-            module_installkernel "$_d_mod" || {
+            module_installkernel "$_d_mod" "$moddir" || {
                 dfatal "installkernel failed in module $_d_mod"
                 exit 1
             }


### PR DESCRIPTION
Let the caller pass in the module path instead of try to find the module
path everytime. This helps optimize the overall runtime.

Test results (3 rounds) on Fedora 30 in KVM VM with 8 CPUs, 2G memory, HDD:

    $ time ./dracut.sh --local --quiet --hostonly --hostonly-cmdline --hostonly-i18n --hostonly-mode 'strict' -o 'plymouth dash resume ifcfg' --mount '/dev/mapper/fedora-root /sysroot xfs defaults' --no-hostonly-default-device -f initramfs.img
    Before the commit:
    real    0m11.782s  |  real    0m11.505s  |  real    0m11.958s
    user    0m9.169s   |  user    0m9.218s   |  user    0m9.327s
    sys     0m10.839s  |  sys     0m10.829s  |  sys     0m10.925s

    After this commit:
    real    0m9.866s  |  real    0m9.580s  |  real    0m9.638s
    user    0m9.048s  |  user    0m9.142s  |  user    0m9.120s
    sys     0m7.411s  |  sys     0m7.775s  |  sys     0m7.745s

Test result of building a ordinary image:

    $ time ./dracut.sh --local --quiet -f initramfs.img
    Before the commit:
    real    0m34.697s  |  real    0m34.371s  |  real    0m35.122s
    user    0m27.608s  |  user    0m27.524s  |  user    0m27.705s
    sys     0m22.341s  |  sys     0m22.032s  |  sys     0m22.246s

    After the commit:
    real    0m31.914s  |  real    0m31.006  |  real    0m31.289ss
    user    0m27.315s  |  user    0m27.324  |  user    0m27.290ss
    sys     0m19.051s  |  sys     0m18.916  |  sys     0m19.022ss

This will have an ~2s speed up.

Signed-off-by: Kairui Song <kasong@redhat.com>