### PR TITLE
iscsi: always popd, even if there is no iscsi device

### DIFF
--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -22,8 +22,10 @@ check() {
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         pushd . >/dev/null
-        for_each_host_dev_and_slaves is_iscsi || return 255
+        for_each_host_dev_and_slaves is_iscsi
+        local _is_iscsi=$?
         popd >/dev/null
+        [[ $_is_iscsi == 0 ]] || return 255
     }
     return 0
 }


### PR DESCRIPTION
When `iscsi-initiator-utils` package is installed but there is no iscsi device, trying to create a initramfs with manually including some file into the initramfs fails to include the file, but includes an empty directory instead:

~~~
# echo "myfile" > ./myfile
# dracut /tmp/initramfs.img --force -i ./myfile /mydir/myfile

# lsinitrd /tmp/initramfs.img | grep myfile
Arguments: --force --include './myfile' '/mydir/myfile'
drwxr-xr-x   2 root     root            0 Mar  1 11:53 mydir/myfile
~~~

We can see that **myfile** is now an empty directory.

If we uninstall the `iscsi-initiator-utils` package, then it works because the **95iscsi** module is skipped:

~~~
# echo "myfile" > ./myfile
# dracut /tmp/initramfs.img --force -i ./myfile /mydir/myfile

# lsinitrd /tmp/initramfs.img | grep myfile
Arguments: --force --include './myfile' '/mydir/myfile'
-rw-r--r--   1 root     root            7 Mar  1 11:55 mydir/myfile
~~~

This is due to a missing `popd` instruction.