### PR TITLE
ucode: properly include early only ucode

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1694,6 +1694,7 @@ if [[ $early_microcode = yes ]]; then
                 if [[ $hostonly ]]; then
                     _src=$(get_ucode_file)
                     [[ $_src ]] || break
+                    [[ -r $_fwdir/$_fw/$_src ]] || _src="${_src}.early"
                     [[ -r $_fwdir/$_fw/$_src ]] || break
                 fi
 


### PR DESCRIPTION
Intel has notified us that some microcode updates are not safe
to be applied during runtime. To accomodate for that, microcode
files shipped by SUSE and openSUSE have an '.early' postfix such
that triggering

/sys/devices/system/cpu/microcode/reload

from a booted system cannot pick up the ucode by accident, while
still allowing the code to be picked up during initrd time.

This change is needed to make this scheme work also in a hostonly
situation.

Currently, this affects only 06-4f-01, which is now 06-4f-01.early.

If a distro does not change the filename, the behavior does not
change.

Reference: osc#1098915