### PR TITLE
iscsi: fix error messages with iSCSI root

### DIFF
--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -88,6 +88,7 @@ install_iscsiroot() {
     iscsi_host=${host##*/}
 
     for flash in ${host}/flashnode_sess-* ; do
+        [ -f "$flash" ] || continue
         [ ! -e "$flash/is_boot_target" ] && continue
         is_boot=$(cat $flash/is_boot_target)
         if [ $is_boot -eq 1 ] ; then


### PR DESCRIPTION
Fixes these error messages during intird build:

cat: '/sys/devices/platform/host2/flashnode_sess-*/is_boot_target': No such file or directory
/usr/lib/dracut/modules.d/95iscsi/module-setup.sh: line 91: [: -eq: unary operator expected
cat: '/sys/devices/platform/host3/flashnode_sess-*/is_boot_target': No such file or directory
/usr/lib/dracut/modules.d/95iscsi/module-setup.sh: line 91: [: -eq: unary operator expected