### PR TITLE
Fix boot with `fips` without a value

### DIFF
--- a/modules.d/01fips/fips-boot.sh
+++ b/modules.d/01fips/fips-boot.sh
@@ -2,6 +2,8 @@
 
 if ! fipsmode=$(getarg fips) || [ "$fipsmode" = "0" ]; then
     rm -f -- /etc/modprobe.d/fips.conf >/dev/null 2>&1
+elif [ -z "$fipsmode" ]; then
+    die "FIPS mode have to be enabled by 'fips=1' not just 'fips'"
 elif getarg boot= >/dev/null; then
     . /sbin/fips.sh
     if mount_boot; then

--- a/modules.d/01fips/fips-boot.sh
+++ b/modules.d/01fips/fips-boot.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if ! fipsmode=$(getarg fips) || [ $fipsmode = "0" ]; then
+if ! fipsmode=$(getarg fips) || [ "$fipsmode" = "0" ]; then
     rm -f -- /etc/modprobe.d/fips.conf >/dev/null 2>&1
 elif getarg boot= >/dev/null; then
     . /sbin/fips.sh

--- a/modules.d/01fips/fips-noboot.sh
+++ b/modules.d/01fips/fips-noboot.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if ! fipsmode=$(getarg fips) || [ $fipsmode = "0" ]; then
+if ! fipsmode=$(getarg fips) || [ "$fipsmode" = "0" ]; then
     rm -f -- /etc/modprobe.d/fips.conf >/dev/null 2>&1
 elif ! [ -f /tmp/fipsdone ]; then
     . /sbin/fips.sh

--- a/modules.d/01fips/fips-noboot.sh
+++ b/modules.d/01fips/fips-noboot.sh
@@ -2,6 +2,8 @@
 
 if ! fipsmode=$(getarg fips) || [ "$fipsmode" = "0" ]; then
     rm -f -- /etc/modprobe.d/fips.conf >/dev/null 2>&1
+elif [ -z "$fipsmode" ]; then
+    die "FIPS mode have to be enabled by 'fips=1' not just 'fips'"
 elif ! [ -f /tmp/fipsdone ]; then
     . /sbin/fips.sh
     mount_boot


### PR DESCRIPTION
If you boot system with `fips` and not `fips=1` then you will get unary operator expected error. This will fix the problem.

Although it won't boot even after the patch but that is the same behavior as with `fips=1`, the error is fixed by this. It looks like fips on Fedora 30 and Rawhide is broken because of loop devices?

Tested also on Fedora 29 and it works correctly there.

Thanks @lnykryn for your help with this.