### PR TITLE
51-dracut-rescue: do not require non-empty kernel cmdline

### DIFF
--- a/50-dracut.install
+++ b/50-dracut.install
@@ -35,9 +35,7 @@ case "$COMMAND" in
             read -r -d '' -a BOOT_OPTIONS < /etc/kernel/cmdline
         elif [[ -f /usr/lib/kernel/cmdline ]]; then
             read -r -d '' -a BOOT_OPTIONS < /usr/lib/kernel/cmdline
-        fi
-
-        if ! [[ ${BOOT_OPTIONS[*]} ]]; then
+        else
             read -r -d '' -a BOOT_OPTIONS < /proc/cmdline
         fi
 

--- a/50-dracut.install
+++ b/50-dracut.install
@@ -36,7 +36,13 @@ case "$COMMAND" in
         elif [[ -f /usr/lib/kernel/cmdline ]]; then
             read -r -d '' -a BOOT_OPTIONS < /usr/lib/kernel/cmdline
         else
-            read -r -d '' -a BOOT_OPTIONS < /proc/cmdline
+            declare -a BOOT_OPTIONS
+
+            read -r -d '' -a line < /proc/cmdline
+            for i in "${line[@]}"; do
+                [[ "${i#initrd=*}" != "$i" ]] && continue
+                BOOT_OPTIONS+=("$i")
+            done
         fi
 
         unset noimageifnotneeded

--- a/51-dracut-rescue.install
+++ b/51-dracut-rescue.install
@@ -48,6 +48,8 @@ if [[ -f /etc/kernel/cmdline ]]; then
 elif [[ -f /usr/lib/kernel/cmdline ]]; then
     read -r -d '' -a BOOT_OPTIONS < /usr/lib/kernel/cmdline
 else
+    declare -a BOOT_OPTIONS
+
     read -r -d '' -a line < /proc/cmdline
     for i in "${line[@]}"; do
         [[ "${i#initrd=*}" != "$i" ]] && continue

--- a/51-dracut-rescue.install
+++ b/51-dracut-rescue.install
@@ -47,20 +47,12 @@ if [[ -f /etc/kernel/cmdline ]]; then
     read -r -d '' -a BOOT_OPTIONS < /etc/kernel/cmdline
 elif [[ -f /usr/lib/kernel/cmdline ]]; then
     read -r -d '' -a BOOT_OPTIONS < /usr/lib/kernel/cmdline
-fi
-
-if ! [[ "${BOOT_OPTIONS[@]}" ]]; then
+else
     read -r -d '' -a line < /proc/cmdline
     for i in "${line[@]}"; do
         [[ "${i#initrd=*}" != "$i" ]] && continue
         BOOT_OPTIONS+=("$i")
     done
-fi
-
-if ! [[ ${BOOT_OPTIONS[*]} ]]; then
-    echo "Could not determine the kernel command line parameters." >&2
-    echo "Please specify the kernel command line in /etc/kernel/cmdline!" >&2
-    exit 1
 fi
 
 if [[ -d "${BOOT_DIR_ABS%/*}" ]]; then


### PR DESCRIPTION
When booting with Fedora-Server-dvd-x86_64-30-20190411.n.0.iso,
/proc/cmdline is empty (libvirt, qemu host with bios, not sure if that
matters), after installation to disk, anaconda would "crash" in kernel-core
%posttrans, after calling kernel-install, because dracut would fail
with
> Could not determine the kernel command line parameters.
> Please specify the kernel command line in /etc/kernel/cmdline!

I guess it's legitimate, even if unusual, to have no cmdline parameters.
Two changes are done in this patch:
1. do not fail if the cmdline is empty.
2. if /usr/lib/kernel/cmdline or /etc/kernel/cmdline are present, but
   empty, ignore /proc/cmdline. If there's explicit configuration to
   have empty cmdline, don't ignore it.