### PR TITLE
dracut.sh: Fix udevdir detection

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1311,8 +1311,8 @@ done
 [[ -d $udevdir ]] \
     || udevdir="$(pkg-config udev --variable=udevdir 2>/dev/null)"
 if ! [[ -d "$udevdir" ]]; then
-    [[ -e /lib/udev/collect ]] && udevdir=/lib/udev
-    [[ -e /usr/lib/udev/collect ]] && udevdir=/usr/lib/udev
+    [[ -e /lib/udev/ata_id ]] && udevdir=/lib/udev
+    [[ -e /usr/lib/udev/ata_id ]] && udevdir=/usr/lib/udev
 fi
 
 [[ -d $systemdutildir ]] \


### PR DESCRIPTION
In commit [9d1b81c dracut.sh: improve udevdir and systemdutildir
fallback logic] , it checked a common binary `collect' to location
udevdir.

But upstream systemd drop binary `collect' since systemd v240
[https://github.com/systemd/systemd/commit/a168792c2d95695fd30c0371d4b3890a9df1eafb]

So check binary `ata_id' to instead.

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>