### PR TITLE
dracut.sh: record the actual host only module for hostonly mode

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -676,17 +676,6 @@ get_ucode_file ()
     fi
 }
 
-# Get currently loaded modules
-# sorted, and delimited by newline
-get_loaded_kernel_modules ()
-{
-    local modules=( )
-    while read _module _size _used _used_by; do
-        modules+=( "$_module" )
-    done <<< "$(lsmod | sed -n '1!p')"
-    printf '%s\n' "${modules[@]}" | sort
-}
-
 # Not every device in /dev/mapper should be examined.
 # If it is an LVM device, touch only devices which have /dev/VG/LV symlink.
 lvm_internal_dev() {

--- a/dracut.sh
+++ b/dracut.sh
@@ -1490,7 +1490,7 @@ dinfo "*** Including modules done ***"
 ## final stuff that has to happen
 if [[ $no_kernel != yes ]]; then
     if [[ $hostonly ]]; then
-        echo "$(get_loaded_kernel_modules)" > $initdir/lib/dracut/loaded-kernel-modules.txt
+        cp "$DRACUT_KERNEL_MODALIASES" $initdir/lib/dracut/hostonly-kernel-modules.txt
     fi
 
     if [[ $drivers ]]; then


### PR DESCRIPTION
Previous in commit 7047294, dracut will include the loaded kernel module
list in initramfs, so other tools could check if the loaded kernel
module is changed and rebuild the host only initramfs in case some
module required to boot the machine is missing due to host only install.

It's better to use modalias list generated by dracut-install, that
list includes the device modalias list combined with current loaded
kernel module list. In this way, if any kernel module is yet to be
loaded when the initramfs is built, or got unloaded by accident the
module list will not change. This make the list more stable over
initramfs builds.

Signed-off-by: Kairui Song <kasong@redhat.com>