### PR TITLE
00systemd: Support systemd.volatile option by including service

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -48,6 +48,7 @@ install() {
         $systemdutildir/systemd-sysctl \
         $systemdutildir/systemd-modules-load \
         $systemdutildir/systemd-vconsole-setup \
+        $systemdutildir/systemd-volatile-root \
         $systemdutildir/system-generators/systemd-fstab-generator \
         $systemdutildir/system-generators/systemd-gpt-auto-generator \
         \
@@ -104,6 +105,7 @@ install() {
         $systemdsystemunitdir/systemd-ask-password-plymouth.service \
         $systemdsystemunitdir/systemd-journald.service \
         $systemdsystemunitdir/systemd-vconsole-setup.service \
+        $systemdsystemunitdir/systemd-volatile-root.service \
         $systemdsystemunitdir/systemd-random-seed-load.service \
         $systemdsystemunitdir/systemd-random-seed.service \
         $systemdsystemunitdir/systemd-sysctl.service \


### PR DESCRIPTION
The varying rd.live options are not sufficient to cover all bases, such as a normal block device root. systemd has introduced the ability to remount these as tmpfs or overlayfs in the initrd. Dracut however does not include the required binary.


Including the binary and service is sufficient to mount normal block devices and loop mounted block devices as overlays in my tests, but I expect there to be conflicts with rd.live options that I was not able to test. All docker test environments pass locally with these inclusions.

Alternately this could be made available as an additional module, volatile options are quite limited currently so it likely wouldn't replace all rd.live cases either. Happy to work with anyone to achieve this.