### PR TITLE
Consollidate the qemu virtualization detection

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -1037,3 +1037,25 @@ else
         ln -sfn -- "$(convert_abs_rel "${_dest}" "${_source}")" "${initdir}/${_dest}"
     }
 fi
+
+is_qemu_virtualized() {
+    # 0 if a virt environment was detected
+    # 1 if a virt environment could not be detected
+    # 255 if any error was encountered
+    if type -P systemd-detect-virt >/dev/null 2>&1; then
+        vm=$(systemd-detect-virt --vm >/dev/null 2>&1)
+        (($? != 0)) && return 255
+        [[ $vm = "qemu" ]] && return 0
+        [[ $vm = "kvm" ]] && return 0
+        [[ $vm = "bochs" ]] && return 0
+    fi
+
+    for i in /sys/class/dmi/id/*_vendor; do
+        [[ -f $i ]] || continue
+        read vendor < $i
+        [[  "$vendor" == "QEMU" ]] && return 0
+        [[ "$vendor" == "Red Hat" ]] && return 0
+        [[  "$vendor" == "Bochs" ]] && return 0
+    done
+    return 1
+}

--- a/modules.d/90qemu-net/module-setup.sh
+++ b/modules.d/90qemu-net/module-setup.sh
@@ -3,21 +3,7 @@
 # called by dracut
 check() {
     if [[ $hostonly ]] || [[ $mount_needs ]]; then
-        if type -P systemd-detect-virt >/dev/null 2>&1; then
-            vm=$(systemd-detect-virt --vm >/dev/null 2>&1)
-            (($? != 0)) && return 255
-            [[ $vm = "qemu" ]] && return 0
-            [[ $vm = "kvm" ]] && return 0
-            [[ $vm = "bochs" ]] && return 0
-        fi
-
-        for i in /sys/class/dmi/id/*_vendor; do
-            [[ -f $i ]] || continue
-            read vendor < $i
-            [[  "$vendor" == "QEMU" ]] && return 0
-            [[  "$vendor" == "Bochs" ]] && return 0
-        done
-
+        is_qemu_virtualized && return 0
         return 255
     fi
     return 0

--- a/modules.d/90qemu/module-setup.sh
+++ b/modules.d/90qemu/module-setup.sh
@@ -3,22 +3,7 @@
 # called by dracut
 check() {
     if [[ $hostonly ]] || [[ $mount_needs ]]; then
-        if type -P systemd-detect-virt >/dev/null 2>&1; then
-            vm=$(systemd-detect-virt --vm 2>/dev/null)
-            (($? != 0)) && return 255
-            [[ $vm = "qemu" ]] && return 0
-            [[ $vm = "kvm" ]] && return 0
-            [[ $vm = "bochs" ]] && return 0
-        fi
-
-        for i in /sys/class/dmi/id/*_vendor; do
-            [[ -f $i ]] || continue
-            read vendor < $i
-            [[ "$vendor" == "QEMU" ]] && return 0
-            [[ "$vendor" == "Red Hat" ]] && return 0
-            [[ "$vendor" == "Bochs" ]] && return 0
-        done
-
+        is_qemu_virtualized && return 0
         return 255
     fi
 

--- a/modules.d/95virtfs/module-setup.sh
+++ b/modules.d/95virtfs/module-setup.sh
@@ -9,20 +9,8 @@ check() {
         return 255
     }
 
-    if type -P systemd-detect-virt >/dev/null 2>&1; then
-        vm=$(systemd-detect-virt --vm >/dev/null 2>&1)
-        (($? != 0)) && return 255
-        [[ $vm = "qemu" ]] && return 0
-        [[ $vm = "kvm" ]] && return 0
-        [[ $vm = "bochs" ]] && return 0
-    fi
+    is_qemu_virtualized && return 0
 
-    for i in /sys/class/dmi/id/*_vendor; do
-        [[ -f $i ]] || continue
-        read vendor < $i
-        [[  "$vendor" == "QEMU" ]] && return 0
-        [[  "$vendor" == "Bochs" ]] && return 0
-    done
     return 255
 }
 


### PR DESCRIPTION
Eventually, we could add a full virt detection routine.
This would be useful e.g. to determine inclusion of
ucode for hostonly setups.