### PR TITLE
Replace $(arch) by $(uname -m)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ rpm: dracut-$(VERSION).tar.xz syncheck
 	rpmbuild --define "_topdir $$PWD" --define "_sourcedir $$PWD" \
 	        --define "_specdir $$PWD" --define "_srcrpmdir $$PWD" \
 		--define "_rpmdir $$PWD" -ba dracut.spec; ) && \
-	( mv "$$rpmbuild"/{,$$(arch)/}*.rpm $(DESTDIR).; rm -fr -- "$$rpmbuild"; ls $(DESTDIR)*.rpm )
+	( mv "$$rpmbuild"/{,$$(uname -m)/}*.rpm $(DESTDIR).; rm -fr -- "$$rpmbuild"; ls $(DESTDIR)*.rpm )
 
 srpm: dracut-$(VERSION).tar.xz syncheck
 	rpmbuild=$$(mktemp -d -t rpmbuild-dracut.XXXXXX); src=$$(pwd); \

--- a/dracut.sh
+++ b/dracut.sh
@@ -1060,13 +1060,13 @@ if [[ ! $print_cmdline ]]; then
             exit 1
         fi
         unset EFI_MACHINE_TYPE_NAME
-        case $(arch) in
+        case $(uname -m) in
             x86_64)
                 EFI_MACHINE_TYPE_NAME=x64;;
             ia32)
                 EFI_MACHINE_TYPE_NAME=ia32;;
             *)
-                dfatal "Architecture '$(arch)' not supported to create a UEFI executable"
+                dfatal "Architecture '$(uname -m)' not supported to create a UEFI executable"
                 exit 1
                 ;;
         esac

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -25,7 +25,7 @@ depends() {
 # called by dracut
 installkernel() {
     hostonly="" instmods drbg
-    arch=$(arch)
+    arch=$(uname -m)
     [[ $arch == x86_64 ]] && arch=x86
     [[ $arch == s390x ]] && arch=s390
     instmods dm_crypt =crypto =drivers/crypto =arch/$arch/crypto

--- a/test/TEST-99-RPM/test.sh
+++ b/test/TEST-99-RPM/test.sh
@@ -27,8 +27,8 @@ test_run() {
 
     mkdir -p "$rootdir/$TESTDIR"
     cp --reflink=auto -a \
-       "$TESTDIR"/dracut-[0-9]*.$(arch).rpm \
-       "$TESTDIR"/dracut-network-[0-9]*.$(arch).rpm \
+       "$TESTDIR"/dracut-[0-9]*.$(uname -m).rpm \
+       "$TESTDIR"/dracut-network-[0-9]*.$(uname -m).rpm \
        "$rootdir/$TESTDIR/"
     . /etc/os-release
     dnf_or_yum=yum
@@ -51,10 +51,10 @@ test_run() {
                         mdadm \
                         bash \
                         iscsi-initiator-utils \
-                        "$TESTDIR"/dracut-[0-9]*.$(arch).rpm \
+                        "$TESTDIR"/dracut-[0-9]*.$(uname -m).rpm \
                         ${NULL} && break
-        #"$TESTDIR"/dracut-config-rescue-[0-9]*.$(arch).rpm \
-            #"$TESTDIR"/dracut-network-[0-9]*.$(arch).rpm \
+        #"$TESTDIR"/dracut-config-rescue-[0-9]*.$(uname -m).rpm \
+            #"$TESTDIR"/dracut-network-[0-9]*.$(uname -m).rpm \
             #    ${NULL}
     done
     (( i < 5 ))


### PR DESCRIPTION
`arch` is an alias for `uname -m` that is not provided by all distributions, so replacing it improves portability. This has already been done in some places, see e.g. ffe53c91c5e56f8fb1f3fbfa84275822074f52d6, this pull requests fixes the remaining occurrences.