### PR TITLE
dracut.sh: fix EFI directory if ESP is mounted to /efi

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -777,7 +777,7 @@ if ! [[ $outfile ]]; then
                        [[ $line =~ BUILD_ID\=* ]] && eval "$line" && echo "$BUILD_ID" && break; \
                    done)
         if [[ -d /efi ]] && mountpoint -q /efi; then
-            efidir=/efi
+            efidir=/efi/EFI
         else
             efidir=/boot/EFI
             if [[ -d /boot/efi/EFI ]] && mountpoint -q /boot/efi; then


### PR DESCRIPTION
The EFI executables produced by `dracut --uefi` must be placed in the subdirectory `/EFI/Linux` of the EFI system partition (ESP) according to the [Boot Loader Specification](https://systemd.io/BOOT_LOADER_SPECIFICATION#logic).

This is done correctly for the mount points `/boot` and `/boot/efi`, but for the mount point `/efi`, the files are placed in `/efi/Linux` instead of the correct `/efi/EFI/Linux`. This commit fixes the directory so that the EFI executables are picked up correctly by conforming boot loaders.

Apart from complying to the specification, the change is also in line with the commit message of 5c57209ba5ef36f8856b4ea1694de8e1da508b71 ("dracut.sh: add default path for --uefi") which introduced this feature as well as the documentation in [dracut.8.asc](https://github.com/dracutdevs/dracut/blob/master/dracut.8.asc):

> **--uefi**
> Instead of creating an initramfs image, dracut will create an UEFI executable, which can be executed by an UEFI BIOS. The default output filename is _<EFI>/EFI/Linux/linux-$kernel$-<MACHINE_ID>-<BUILD_ID>.efi_. <EFI> might be _/efi_, _/boot_ or _/boot/efi_ depending on where the ESP partition is mounted. The <BUILD_ID> is taken from BUILD_ID in _/usr/lib/os-release_ or if it exists _/etc/os-release_ and is left out, if BUILD_ID is non-existant or empty.