### PR TITLE
move setting the "systemdutildir" variable before it's used

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -999,6 +999,16 @@ esac
 
 abs_outfile=$(readlink -f "$outfile") && outfile="$abs_outfile"
 
+
+[[ -d $systemdutildir ]] \
+    || systemdutildir=$(pkg-config systemd --variable=systemdutildir 2>/dev/null)
+
+if ! [[ -d "$systemdutildir" ]]; then
+    [[ -e /lib/systemd/systemd-udevd ]] && systemdutildir=/lib/systemd
+    [[ -e /usr/lib/systemd/systemd-udevd ]] && systemdutildir=/usr/lib/systemd
+fi
+
+
 if [[ $no_kernel != yes ]] && [[ -d $srcmods ]]; then
     if ! [[ -f $srcmods/modules.dep ]]; then
         if [[ -n "$(find "$srcmods" -name '*.ko*')" ]]; then
@@ -1313,14 +1323,6 @@ done
 if ! [[ -d "$udevdir" ]]; then
     [[ -e /lib/udev/collect ]] && udevdir=/lib/udev
     [[ -e /usr/lib/udev/collect ]] && udevdir=/usr/lib/udev
-fi
-
-[[ -d $systemdutildir ]] \
-    || systemdutildir=$(pkg-config systemd --variable=systemdutildir 2>/dev/null)
-
-if ! [[ -d "$systemdutildir" ]]; then
-    [[ -e /lib/systemd/systemd-udevd ]] && systemdutildir=/lib/systemd
-    [[ -e /usr/lib/systemd/systemd-udevd ]] && systemdutildir=/usr/lib/systemd
 fi
 
 [[ -d $systemdsystemunitdir ]] \


### PR DESCRIPTION
on line 1086 it's used to check for the uefi_stub:
"${systemdutildir}/boot/efi/linux${EFI_MACHINE_TYPE_NAME}.efi.stub"

so it needs to be defined before that