### PR TITLE
99base: Don't let vinfo return 1

### DIFF
--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -70,7 +70,7 @@ if [ -z "$DRACUT_SYSTEMD" ]; then
         check_quiet
         echo "<30>dracut: $*" > /dev/kmsg
         [ "$DRACUT_QUIET" != "yes" ] && \
-            echo "dracut: $*" >&2
+            echo "dracut: $*" >&2 || :
     }
 
 else


### PR DESCRIPTION
When DRACUT_SYSTEMD is set and DRACUT_QUIET=yes, vinfo returns 1. This is a problem for hooks which end with vinfo, as then the hook returns 1. Especially problematic if this is a shutdown hook, as it will be restarted again and again.

This commit fixes that.