### PR TITLE
95fcoe: load 'libfcoe' module as a fallback

### DIFF
--- a/modules.d/95fcoe/parse-fcoe.sh
+++ b/modules.d/95fcoe/parse-fcoe.sh
@@ -23,7 +23,7 @@ fi
 # If it's not set we don't continue
 [ -z "$fcoe" ] && return
 
-[ -e /sys/bus/fcoe/ctlr_create ] || modprobe -b -a fcoe || die "FCoE requested but kernel/initrd does not support FCoE"
+[ -e /sys/bus/fcoe/ctlr_create ] || modprobe -b -a fcoe || modprobe -b -a libfcoe || die "FCoE requested but kernel/initrd does not support FCoE"
 
 initqueue --onetime modprobe -b -q bnx2fc
 


### PR DESCRIPTION
The kernel may only enable 'libfcoe' module. Some modules like bnx2fc
provides FCoE but only depend on 'libfcoe'. Loading 'fcoe' module may
fail but the kernel do support FCoE.

'libfcoe' will be installed as a dependency when installing block device
drivers if it's required. So no need to install it in installkernel.

Signed-off-by: Kairui Song <kasong@redhat.com>