### PR TITLE
keep network device naming scheme on upgrade

### DIFF
--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -55,6 +55,8 @@ install() {
     inst_rules 91-permissions.rules
     # eudev rules
     inst_rules 80-drivers-modprobe.rules
+    # legacy persistent network device name rules
+    [[ $hostonly ]] && inst_rules 70-persistent-net.rules
 
     if dracut_module_included "systemd"; then
         inst_multiple -o ${systemdutildir}/network/*.link


### PR DESCRIPTION
Include 70-persistent-net.rules (if present) in order to keep the persistent network device naming scheme on system upgrade.