### PR TITLE
test/TEST-17-LVM-THIN: fail setup if we run out of space in the thin pool

### DIFF
--- a/test/TEST-17-LVM-THIN/create-root.sh
+++ b/test/TEST-17-LVM-THIN/create-root.sh
@@ -27,6 +27,7 @@ cp -a -t /sysroot /source/* && \
 umount /sysroot && \
 sleep 1 && \
 lvm lvchange -a n /dev/dracut/root && \
-sleep 1 && \
-echo "dracut-root-block-created" >/dev/sda1
+sleep 1
+dmsetup status |grep out_of_data_space || \
+    echo "dracut-root-block-created" >/dev/sda1
 poweroff -f

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -56,7 +56,7 @@ test_setup() {
     (
 	export initdir=$TESTDIR/overlay
 	. $basedir/dracut-init.sh
-	inst_multiple sfdisk mke2fs poweroff cp umount
+	inst_multiple sfdisk mke2fs poweroff cp umount grep dmsetup
 	inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
 	inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules


### PR DESCRIPTION
This condition is rather difficult to detect -- the writes will just remain
queued and get lost on shutdown, resulting in a corrupt filesystem.