### PR TITLE
Add support for creating signed UEFI images

### DIFF
--- a/dracut.conf.5.asc
+++ b/dracut.conf.5.asc
@@ -204,6 +204,10 @@ provide a valid _/etc/fstab_.
     _/lib/systemd/boot/efi/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
     or _/usr/lib/gummiboot/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
 
+*uefi_secureboot_cert=*"_<FILE>_", *uefi_secureboot_key=*"_<FILE>_"::
+    Specifies a certificate and corresponding key, which are used to sign the created UEFI executable.
+    Requires both certificate and key need to be specified and _sbsign_ to be installed.
+
 *kernel_image=*"_<FILE>_"::
     Specifies the kernel image, which to include in the UEFI executable. The default is
     _/lib/modules/<KERNEL-VERSION>/vmlinuz_ or _/boot/vmlinuz-<KERNEL-VERSION>_

--- a/dracut.sh
+++ b/dracut.sh
@@ -772,6 +772,16 @@ if ! [[ $outfile ]]; then
     fi
 
     if [[ $uefi == "yes" ]]; then
+        if [[ -n "$uefi_secureboot_key" && -z "$uefi_secureboot_cert" ]] || [[ -z $uefi_secureboot_key && -n $uefi_secureboot_cert ]]; then
+            dfatal "Need 'uefi_secureboot_key' and 'uefi_secureboot_cert' both to be set."
+            exit 1
+        fi
+
+        if [[ -n "$uefi_secureboot_key" && -n "$uefi_secureboot_cert" ]] && !command -v sbsign &>/dev/null; then
+            dfatal "Need 'sbsign' to create a signed UEFI executable"
+            exit 1
+        fi
+
         BUILD_ID=$(cat /etc/os-release /usr/lib/os-release \
                        | while read -r line || [[ $line ]]; do \
                        [[ $line =~ BUILD_ID\=* ]] && eval "$line" && echo "$BUILD_ID" && break; \
@@ -1940,9 +1950,22 @@ if [[ $uefi = yes ]]; then
            --add-section .cmdline="${uefi_outdir}/cmdline.txt" --change-section-vma .cmdline=0x30000 \
            --add-section .linux="$kernel_image" --change-section-vma .linux=0x40000 \
            --add-section .initrd="${DRACUT_TMPDIR}/initramfs.img" --change-section-vma .initrd=0x3000000 \
-           "$uefi_stub" "${uefi_outdir}/linux.efi" \
-            && cp --reflink=auto "${uefi_outdir}/linux.efi" "$outfile"; then
-        dinfo "*** Creating UEFI image file '$outfile' done ***"
+           "$uefi_stub" "${uefi_outdir}/linux.efi"; then
+        if [[ -n "${uefi_secureboot_key}" && -n "${uefi_secureboot_cert}" ]]; then \
+            if sbsign \
+                    --key "${uefi_secureboot_key}" \
+                    --cert "${uefi_secureboot_cert}" \
+                    --output "$outfile" "${uefi_outdir}/linux.efi"; then
+                dinfo "*** Creating signed UEFI image file '$outfile' done ***"
+            else
+                dfatal "*** Creating signed UEFI image file '$outfile' failed ***"
+                exit 1
+            fi
+        else
+            if cp --reflink=auto "${uefi_outdir}/linux.efi" "$outfile"; then
+                dinfo "*** Creating UEFI image file '$outfile' done ***"
+            fi
+        fi
     else
         rm -f -- "$outfile"
         dfatal "*** Creating UEFI image file '$outfile' failed ***"


### PR DESCRIPTION
This adds configuration parameters `uefi_secureboot_cert` and `uefi_secureboot_key`.
In dracut's `--uefi` mode, provided `sbsign` is installed, the resulting UEFI executable is signed with the key.