### PR TITLE
ask for a password on readkey failure

### DIFF
--- a/modules.d/90crypt/cryptroot-ask.sh
+++ b/modules.d/90crypt/cryptroot-ask.sh
@@ -156,9 +156,9 @@ else
 
         info "Using '$keypath' on '$keydev'"
         readkey "$keypath" "$keydev" "$device" \
-            | cryptsetup -d - $cryptsetupopts luksOpen "$device" "$luksname"
+            | cryptsetup -d - $cryptsetupopts luksOpen "$device" "$luksname" \
+            && ask_passphrase=0
         unset keypath keydev
-        ask_passphrase=0
         break
     done
 fi


### PR DESCRIPTION
This fixes a problem I had on my systems where the password stored in a keyfile was not correct. `cryptsetup` produced an error message and could not open the root device. In such a case shouldn't the user be asked for a password instead in order to recover the system?