### PR TITLE
nfsroot follow ifcfg settings for boot protocol

### DIFF
--- a/modules.d/95nfs/module-setup.sh
+++ b/modules.d/95nfs/module-setup.sh
@@ -65,7 +65,12 @@ cmdline() {
         printf 'ifname=%s:%s ' ${ifname} ${ifmac}
     fi
 
-    printf 'ip=%s:static\n' ${ifname}
+    bootproto=$(sed -n "/BOOTPROTO/s/BOOTPROTO='\([[:alpha:]]*6\?\)4\?'/\1/p" /etc/sysconfig/network/ifcfg-$ifname)
+    if [ $bootproto ]; then
+        printf 'ip=%s:%s ' ${ifname} ${bootproto}
+    else
+        printf 'ip=%s:static ' ${ifname}
+    fi
 }
 
 # called by dracut


### PR DESCRIPTION
There is no reason why the network setup of an nfs client needs to be static.
We should rather use the BOOTPROTO setting from the ifcfg file and only fall back to a static setup, if this information is not available.