### PR TITLE
call netroot on wicked dhcp setup

### DIFF
--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -462,6 +462,11 @@ for p in $(getargs ip=); do
                 fi
                 ;;
         esac
+
+        if command -v wicked >/dev/null && [ -z "$manualup" ]; then
+            /sbin/netroot $netif
+        fi
+
         exit $ret
     fi
 done


### PR DESCRIPTION
modules.d/35network-legacy/dhclient-script.sh takes over the task of calling netroot when using dhclient for network setup.
This is not the case when wicked is used.
Hence we need an explicit call to the netroot script for the wicked case.