### PR TITLE
rngd: new module running early during boot to help generating entropy when system's default entropy sources are poor (e.g. use of SSD disks or UEFI RNG not available)

### DIFF
--- a/modules.d/06rngd/module-setup.sh
+++ b/modules.d/06rngd/module-setup.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# Author: Renaud Métrich <rmetrich@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+depends() {
+    echo systemd
+    return 0
+}
+
+check() {
+    # if there's no rngd binary, no go.
+    require_binaries rngd || return 1
+
+    return 0
+}
+
+install() {
+    inst rngd
+    inst_simple "${moddir}/rngd.service" "${systemdsystemunitdir}/rngd.service"
+    mkdir -p "${initdir}${systemdsystemunitdir}/sysinit.target.wants"
+    ln -rfs "${initdir}${systemdsystemunitdir}/rngd.service" \
+        "${initdir}${systemdsystemunitdir}/sysinit.target.wants/rngd.service"
+}

--- a/modules.d/06rngd/rngd.service
+++ b/modules.d/06rngd/rngd.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Hardware RNG Entropy Gatherer Daemon
+DefaultDependencies=no
+Before=systemd-udevd.service
+
+[Service]
+ExecStart=/usr/sbin/rngd -f


### PR DESCRIPTION
On systems with low entropy at boot, the boot can take up to several
hours, specially when NBDE is used (e.g. clevis) which makes use of
the random number generator.

Enabling rngd service at boot early, because dracut-initqueue runs,
enables to initialize the random number generator in a couple of seconds
instead of minutes or hours.

See also Red Hat BZs:
- https://bugzilla.redhat.com/show_bug.cgi?id=1728583 (Backport random.trust_cpu)
- https://bugzilla.redhat.com/show_bug.cgi?id=1726617 (clevis takes up to 20 minutes or more to unlock the root devices at boot)