### PR TITLE
95fcoe: Fix startup when fcoe module is included

### DIFF
--- a/modules.d/95fcoe/parse-fcoe.sh
+++ b/modules.d/95fcoe/parse-fcoe.sh
@@ -15,7 +15,7 @@
 
 if ! getargbool 0 rd.nofcoe ; then
 	info "rd.nofcoe=0: skipping fcoe"
-	exit 0
+	return 0
 fi
 
 [ -z "$fcoe" ] && fcoe=$(getarg fcoe=)


### PR DESCRIPTION
The parse-fcoe.sh hook is sourced, and hence must not contain
exit 0 calls. Otherwise, the cmdline sequence will be interupted,
and no error will be reported to systemd. Use return instead.

Reference: boo#1136977