### PR TITLE
99squash: Only start the cleaner on switch-root

### DIFF
--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -25,5 +25,6 @@ install() {
     inst $moddir/init.sh /squash/init.sh
 
     inst "$moddir/squash-mnt-clear.service" "$systemdsystemunitdir/squash-mnt-clear.service"
-    ln_r "$systemdsystemunitdir/squash-mnt-clear.service" "$systemdsystemunitdir/initrd.target.wants/squash-mnt-clear.service"
+    mkdir -p "$initdir$systemdsystemunitdir/initrd-switch-root.target.wants"
+    ln_r "$systemdsystemunitdir/squash-mnt-clear.service" "$systemdsystemunitdir/initrd-switch-root.target.wants/squash-mnt-clear.service"
 }

--- a/modules.d/99squash/squash-mnt-clear.service
+++ b/modules.d/99squash/squash-mnt-clear.service
@@ -4,17 +4,14 @@
 [Unit]
 Description=Cleanup squashfs mounts when switch root
 DefaultDependencies=no
-After=initrd.target
-After=dracut-initqueue.service dracut-pre-pivot.service
-Before=initrd-cleanup.service
+Before=initrd-switch-root.service
+After=initrd-switch-root.target
 ConditionPathExists=/squash/root
-Conflicts=initrd-switch-root.target
-IgnoreOnIsolate=true
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
+RemainAfterExit=no
 StandardInput=null
 StandardOutput=syslog+console
 StandardError=syslog+console
-ExecStop=/squash/clear-squash.sh
+ExecStart=/squash/clear-squash.sh


### PR DESCRIPTION
Currently it starts the cleaner early and do the clean up job if switch
root is called. It's better to just start the service only on switch
root to avoid any risk of service dependency failure and make is
simpler.

Signed-off-by: Kairui Song <kasong@redhat.com>