### PR TITLE
travis: fetch only git tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
     sudo modprobe kvm-intel nested=1 || :
     sudo modprobe kvm-amd nested=1 || :
     dmesg | tail || :
-  - git pull --depth=100
+  - git fetch --tags --unshallow
   - |
     git describe --abbrev=0 --tags || :
     git describe --tags || :

--- a/git2spec.pl
+++ b/git2spec.pl
@@ -37,7 +37,7 @@ $tag=`git describe --abbrev=0 --tags` if not defined $tag;
 chomp($tag);
 my @patches=&create_patches($tag, $pdir);
 my $num=$#patches + 2;
-$tag=~s/[^0-9]+?([0-9]+)/$1/;
+$tag=~s/[^0-9]+?([0-9]+)/$1/ if $tag !~ /\b[0-9a-f]{5,40}\b/;
 my $release="$num.git$datestr";
 $release="1" if $num == 1;
 


### PR DESCRIPTION
As Travis CI builds the merge commit[0] of given PR, doing `git pull` during
testing is somewhat useless and breaks testing of PRs against non-master
branches.

One of these *broken* PRs is, for example, https://github.com/dracutdevs/dracut/pull/612.

[0] i.e. `refs/pull/XXX/merge`, see https://docs.travis-ci.com/user/pull-requests/#how-pull-requests-are-built
>  Rather than build the commits that have been pushed to the branch the pull request is from, we build the merge between the source branch and the upstream branch.
