### PR TITLE
dracut.sh: suppress "ignored null byte in input" warning

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1955,7 +1955,7 @@ if [[ $uefi = yes ]]; then
     echo -ne "\x00" >> "$uefi_outdir/cmdline.txt"
 
     dinfo "Using UEFI kernel cmdline:"
-    dinfo $(< "$uefi_outdir/cmdline.txt")
+    dinfo $(tr -d '\000' < "$uefi_outdir/cmdline.txt")
 
     [[ -s /usr/lib/os-release ]] && uefi_osrelease="/usr/lib/os-release"
     [[ -s /etc/os-release ]] && uefi_osrelease="/etc/os-release"


### PR DESCRIPTION
Since Bash 4.4, command substitutions containing null bytes produce a warning of the form
```
/usr/sbin/dracut: line 1958: warning: command substitution: ignored null byte in input
```
Remove the [trailing null byte](https://github.com/dracutdevs/dracut/blob/707d4e79feadb475b79fd8f15dd2fea70aa79869/dracut.sh#L1955) from the UEFI kernel command line file before printing it to suppress this warning.