### PR TITLE
test: fix preserving server.log with V=1

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -67,7 +67,7 @@ while (($# > 0)); do
                     ret=$?
                     test_cleanup
                     if ((ret!=0)) && [[ -f "$TESTDIR"/server.log ]]; then
-                        mv [[ -f "$TESTDIR"/server.log ]] ./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log
+                        mv "$TESTDIR"/server.log ./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log
                     fi
                     rm -fr -- "$TESTDIR"
                     rm -f -- .testdir${TEST_RUN_ID:+-$TEST_RUN_ID}


### PR DESCRIPTION
This is essentially equivalent to what commit 712f471ebfae
('test/test-functions: correctly move server.log') does for V=2.