### PR TITLE
Suppress spurious output when using crypt module without systemd-cryptsetup-generator

### DIFF
--- a/modules.d/90crypt/cryptroot-ask.sh
+++ b/modules.d/90crypt/cryptroot-ask.sh
@@ -8,6 +8,8 @@ NEWROOT=${NEWROOT:-"/sysroot"}
 
 . /lib/dracut-lib.sh
 
+mkdir -m 0700 /run/cryptsetup
+
 # if device name is /dev/dm-X, convert to /dev/mapper/name
 if [ "${1##/dev/dm-}" != "$1" ]; then
     device="/dev/mapper/$(dmsetup info -c --noheadings -o name "$1")"

--- a/modules.d/95rootfs-block/mount-root.sh
+++ b/modules.d/95rootfs-block/mount-root.sh
@@ -74,7 +74,7 @@ mount_root() {
 
     rootopts=
     if getargbool 1 rd.fstab -d -n rd_NO_FSTAB \
-        && ! getarg rootflags \
+        && ! getarg rootflags >/dev/null \
         && [ -f "$NEWROOT/etc/fstab" ] \
         && ! [ -L "$NEWROOT/etc/fstab" ]; then
         # if $NEWROOT/etc/fstab contains special mount options for


### PR DESCRIPTION
When using the `crypt` module without systemd-cryptsetup-generator (with `dracut -o systemd`), there is some unwanted output:

- When decrypting LUKS2 partitions, a message
    ```
    WARNING: Locking directory /run/cryptsetup is missing!
    ```
    is printed.
- If `rootflags` are specified on the kernel command line, these are erroneously printed by the `rootfs-block` module.

Creating the required directory beforehand and redirecting the output of `getarg` removes these artefacts.