### PR TITLE
10i18n: enable rd.vconsole.* and rd.locale.* handling when systemd module is included

### DIFF
--- a/modules.d/10i18n/module-setup.sh
+++ b/modules.d/10i18n/module-setup.sh
@@ -102,8 +102,8 @@ install() {
         if ! dracut_module_included "systemd"; then
             inst ${moddir}/console_init.sh /lib/udev/console_init
             inst_rules ${moddir}/10-console.rules
-            inst_hook cmdline 20 "${moddir}/parse-i18n.sh"
         fi
+        inst_hook cmdline 20 "${moddir}/parse-i18n.sh"
 
         if [[ ${kbddir} != "/usr/share" ]]; then
             inst_dir /usr/share


### PR DESCRIPTION
`parse-i18n.sh`  correctly handles `rd.vconsole.*` and `rd.locale.*` command line parameters and adds respective systemd's keys into /etc/vconsole.conf and /etc/locale.conf files, so this fix makes them being available according to dracut.cmdline(7) when `systemd` dracut  module is included