### PR TITLE
51-dracut-rescue-postinst.sh: Create hmac file for rescue kernel

### DIFF
--- a/51-dracut-rescue-postinst.sh
+++ b/51-dracut-rescue-postinst.sh
@@ -16,10 +16,18 @@ fi
 [[ $MACHINE_ID ]] || exit 1
 [[ -f $KERNEL_IMAGE ]] || exit 1
 
+KERNEL_HMAC="${KERNEL_IMAGE%/*}/.vmlinuz-${KERNEL_VERSION}.hmac"
 INITRDFILE="/boot/initramfs-0-rescue-${MACHINE_ID}.img"
 NEW_KERNEL_IMAGE="${KERNEL_IMAGE%/*}/vmlinuz-0-rescue-${MACHINE_ID}"
+NEW_KERNEL_HMAC="${KERNEL_IMAGE%/*}/.vmlinuz-0-rescue-${MACHINE_ID}.hmac"
 
-[[ -f $INITRDFILE ]] && [[ -f $NEW_KERNEL_IMAGE ]] && exit 0
+if [[ -f $INITRDFILE ]] && [[ -f $NEW_KERNEL_IMAGE ]]; then
+   if [[ -f $NEW_KERNEL_HMAC ]]; then
+      exit 0
+   elif [[ ! -f '/usr/bin/sha512hmac' ]]; then
+      exit 0
+   fi
+fi
 
 dropindirs_sort()
 {
@@ -58,11 +66,20 @@ fi
 
 if [[ ! -f $NEW_KERNEL_IMAGE ]]; then
     cp --reflink=auto "$KERNEL_IMAGE" "$NEW_KERNEL_IMAGE"
+    if [[ ! -f $NEW_KERNEL_HMAC  ]] && [[ -f $KERNEL_HMAC ]]; then
+        cp --reflink=auto "$KERNEL_HMAC" "$NEW_KERNEL_HMAC"
+    fi
     ((ret+=$?))
 fi
 
-new-kernel-pkg --install "$KERNEL_VERSION" --kernel-image "$NEW_KERNEL_IMAGE" --initrdfile "$INITRDFILE" --banner "$NAME $VERSION_ID Rescue $MACHINE_ID"
+if [[ ! -f $NEW_KERNEL_HMAC ]] && [[ -f '/usr/bin/sha512hmac' ]]; then
+    sha512hmac "$NEW_KERNEL_IMAGE" > "$NEW_KERNEL_HMAC"
+    ((ret+=$?))
+fi
 
-((ret+=$?))
+if [[ ! $(grep -r Rescue /boot/) ]]; then
+   new-kernel-pkg --install "$KERNEL_VERSION" --kernel-image "$NEW_KERNEL_IMAGE" --initrdfile "$INITRDFILE" --banner "$NAME $VERSION_ID Rescue $MACHINE_ID"
+   ((ret+=$?))
+fi
 
 exit $ret


### PR DESCRIPTION
When fips=1 is enabled on a server, and the server is booted into the generated rescue kernel grub menu entry. It will fail to boot since there isn't an hmac file for the rescue vmlinuz file. This patch checks if the sha512hmac binary exist, if it does it generates the hmac file for the rescue kernel. Also it checks if a rescue kernel entry exist in the grub.cfg, if it does it doesn't add a new entry. This is so when ran on existing rescue kernels, it doesn't create duplicate entries when generating the hmac. 

https://bugzilla.redhat.com/show_bug.cgi?id=923439