### PR TITLE
travis: switch to Bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: generic
+dist: bionic
 sudo: required
 services:
 - docker


### PR DESCRIPTION
Thanks to @filbranden, who pointed me to [this tweet](https://twitter.com/_AkihiroSuda_/status/1167336407779557376), I discovered that Travis CI now supports KVM (`vmx` flag in `/proc/cpuinfo`) on Bionic nodes. This should speed up our CI significantly, as currently everything is being tested under QEMU.

Just a quick proof it indeed runs under KVM without any other tweaks (from my debugging session):
```
[    5.986821] Run /init as init process
systemd v241-12.git1e19bcd.fc30 running in system mode. (+PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=hybrid)
Virtualization QEMU found in DMI (/sys/class/dmi/id/sys_vendor)
Virtualization found, CPUID=KVMKVMKVM
Found VM virtualization kvm
Detected virtualization kvm.
Detected architecture x86-64.
Running in initial RAM disk.
```

Let's see some numbers:
#### Old run (plain QEMU)
![image](https://user-images.githubusercontent.com/679338/65417247-e92ac400-ddf9-11e9-9c1f-8c520fb7e348.png)

#### New run (QEMU + KVM)
![image](https://user-images.githubusercontent.com/679338/65417312-0fe8fa80-ddfa-11e9-9102-87f02ed009a3.png)


cc @evverx - just a quick heads up as you may find this, relatively new feature, useful (if you don't already know about it) :-)

