### PR TITLE
[RHEL] network: default to network-legacy even in presence of nm-initrd-generator

### DIFF
--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -8,9 +8,9 @@ check() {
 # called by dracut
 depends() {
     echo -n "kernel-network-modules "
-    if ! dracut_module_included "network-legacy" && [ -x "/usr/libexec/nm-initrd-generator" ] ; then
-        echo "network-manager"
-    else
+    # RHEL 8.1: Default to network-legacy unless the user chose
+    # network-manager manually
+    if ! dracut_module_included "network-manager" ; then
         echo "network-legacy"
     fi
     return 0


### PR DESCRIPTION
In RHEL 8.2, NetworkManager will ship with the nm-initrd-generator, but
before the install bits fall into place we want to default to network-legacy.

This unblocks the enablement of the NetworkManager bits and is intended
to be reverted later on.