### PR TITLE
Make TEST-16-DMSQUASH Python 3 compatible

### DIFF
--- a/test/TEST-16-DMSQUASH/create.py
+++ b/test/TEST-16-DMSQUASH/create.py
@@ -137,7 +137,8 @@ def parse_options(args):
 def main():
     try:
         options = parse_options(sys.argv[1:])
-    except Usage, (msg, no_error):
+    except Usage as e:
+        msg, no_error = e.args
         if no_error:
             out = sys.stdout
             ret = 0
@@ -179,12 +180,12 @@ def main():
         creator.install()
         creator.configure()
         if options.give_shell:
-            print "Launching shell. Exit to continue."
-            print "----------------------------------"
+            print("Launching shell. Exit to continue.")
+            print("----------------------------------")
             creator.launch_shell()
         creator.unmount()
         creator.package(os.environ.get("TESTDIR", "."))
-    except imgcreate.CreatorError, e:
+    except imgcreate.CreatorError as e:
         logging.error(u"Error creating Live CD : %s" % e)
         return 1
     finally:

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -7,11 +7,14 @@ KVERSION="${KVERSION-$(uname -r)}"
 #DEBUGFAIL="rd.shell rd.break rd.debug systemd.log_level=debug systemd.log_target=console"
 
 test_check() {
-    if ! [ -d "/usr/lib/python2.7/site-packages/imgcreate" ]; then
-        echo "python-imgcreate not installed"
+    for pdir in $(python -c "import site; print(site.getsitepackages())" | sed -e 's/\[\(.*\)\]/\1/' -e "s/', /' /g") ; do
+        pdir1=$(echo $pdir | sed "s/^'\(.*\)'$/\1/")
+        if [[ -d $pdir1/imgcreate ]]; then
+            return 0
+        fi
+    done
+    echo "python-imgcreate not installed"
 	return 1
-    fi
-    return 0
 }
 
 test_run() {


### PR DESCRIPTION
This change still supports Python 2.6 and 2.7 but loses support
for Python 2.5.

The reason for this change was that Fedora 30 does not ship
python-imgcreate but ships python3-imgcreate.

Signed-off-by: Böszörményi Zoltán <zboszor@pr.hu>