### PR TITLE
net-lib: check if addr exists before checking for dad state

### DIFF
--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -653,7 +653,8 @@ wait_for_ipv6_dad_link() {
     timeout=$(($timeout*10))
 
     while [ $cnt -lt $timeout ]; do
-        [ -z "$(ip -6 addr show dev "$1" scope link tentative)" ] \
+        [ -n "$(ip -6 addr show dev "$1" scope link)" ] \
+            && [ -z "$(ip -6 addr show dev "$1" scope link tentative)" ] \
             && [ -n "$(ip -6 route list proto ra dev "$1" | grep ^default)" ] \
             && return 0
         [ -n "$(ip -6 addr show dev "$1" scope link dadfailed)" ] \
@@ -671,7 +672,8 @@ wait_for_ipv6_dad() {
     timeout=$(($timeout*10))
 
     while [ $cnt -lt $timeout ]; do
-        [ -z "$(ip -6 addr show dev "$1" tentative)" ] \
+        [ -n "$(ip -6 addr show dev "$1")" ] \
+            && [ -z "$(ip -6 addr show dev "$1" tentative)" ] \
             && [ -n "$(ip -6 route list proto ra dev "$1" | grep ^default)" ] \
             && return 0
         [ -n "$(ip -6 addr show dev "$1" dadfailed)" ] \


### PR DESCRIPTION
Before we check if dad is done we should first make sure,
that there is a link local address where we do the check.

Due to this issue, on ipv6 only setups sometimes dhclient started
asking for ip address, before the link local address was present
and failed immediately.