### PR TITLE
Fine tune mksquashfs options for squash module

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1871,7 +1871,7 @@ fi
 
 if dracut_module_included "squash"; then
     dinfo "*** Squashing the files inside the initramfs ***"
-    mksquashfs $squash_dir $squash_img -comp xz -b 64K -Xdict-size 100% &> /dev/null
+    mksquashfs $squash_dir $squash_img -no-xattrs -no-exports -noappend -always-use-fragments -comp xz -Xdict-size 100% -no-progress 1> /dev/null
 
     if [[ $? != 0 ]]; then
         dfatal "dracut: Failed making squash image"


### PR DESCRIPTION
Drop some unneeded metadata in the squash image, and print the error
message if something went wrong.

Signed-off-by: Kairui Song <kasong@redhat.com>