### PR TITLE
Do not call cryptsetup in a systemd environment

### DIFF
--- a/modules.d/90crypt/crypt-run-generator.sh
+++ b/modules.d/90crypt/crypt-run-generator.sh
@@ -11,7 +11,7 @@ crypttab_contains "$luks" "$dev" && exit 0
 allowdiscards="-"
 
 # parse for allow-discards
-if strstr "$(cryptsetup --help)" "allow-discards"; then
+if [ -n "$DRACUT_SYSTEMD" ] || strstr "$(cryptsetup --help)" "allow-discards"; then
     if discarduuids=$(getargs "rd.luks.allow-discards"); then
         discarduuids=$(str_replace "$discarduuids" 'luks-' '')
         if strstr " $discarduuids " " ${luks##luks-}"; then

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -119,6 +119,7 @@ install() {
     fi
 
     inst_simple "$moddir/crypt-lib.sh" "/lib/dracut-crypt-lib.sh"
+    inst_script "$moddir/crypt-run-generator.sh" "/sbin/crypt-run-generator"
 
     if dracut_module_included "systemd"; then
         inst_multiple -o \
@@ -129,7 +130,6 @@ install() {
                       $systemdsystemunitdir/cryptsetup.target \
                       $systemdsystemunitdir/sysinit.target.wants/cryptsetup.target \
                       systemd-ask-password systemd-tty-ask-password-agent
-        inst_script "$moddir"/crypt-run-generator.sh /sbin/crypt-run-generator
     fi
 
     dracut_need_initqueue


### PR DESCRIPTION
systemd provides its own cryptsetup facilities, and the
cryptsetup binary might not even exist, failing
to execute the discard flag processing.

Fixes #602