### PR TITLE
01fips: various fixes to adapt to RHCOS and FCOS

### DIFF
--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -135,7 +135,7 @@ do_fips()
             return 1
         fi
 
-        sha512hmac -c "${BOOT_IMAGE_HMAC}" || return 1
+        (cd "${BOOT_IMAGE_HMAC%/*}" && sha512hmac -c "${BOOT_IMAGE_HMAC}") || return 1
     fi
 
     info "All initrd crypto checks done"

--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -113,6 +113,10 @@ do_fips()
         do_rhevh_check /run/initramfs/live/isolinux/vmlinuz0 || return 1
     else
         BOOT_IMAGE="$(getarg BOOT_IMAGE)"
+
+        # Trim off any leading GRUB boot device (e.g. ($root) )
+        BOOT_IMAGE="$(echo "${BOOT_IMAGE}" | sed 's/^(.*)//')"
+
         BOOT_IMAGE_NAME="${BOOT_IMAGE##*/}"
         BOOT_IMAGE_PATH="${BOOT_IMAGE%${BOOT_IMAGE_NAME}}"
 

--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -118,7 +118,7 @@ do_fips()
 
         if [ -z "$BOOT_IMAGE_NAME" ]; then
             BOOT_IMAGE_NAME="vmlinuz-${KERNEL}"
-        elif ! [ -e "/boot/${BOOT_IMAGE_PATH}/${BOOT_IMAGE}" ]; then
+        elif ! [ -e "/boot/${BOOT_IMAGE_PATH}/${BOOT_IMAGE_NAME}" ]; then
             #if /boot is not a separate partition BOOT_IMAGE might start with /boot
             BOOT_IMAGE_PATH=${BOOT_IMAGE_PATH#"/boot"}
             #on some achitectures BOOT_IMAGE does not contain path to kernel

--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -129,7 +129,7 @@ do_fips()
             fi
         fi
 
-        BOOT_IMAGE_HMAC="/boot/${BOOT_IMAGE_PATH}.${BOOT_IMAGE_NAME}.hmac"
+        BOOT_IMAGE_HMAC="/boot/${BOOT_IMAGE_PATH}/.${BOOT_IMAGE_NAME}.hmac"
         if ! [ -e "${BOOT_IMAGE_HMAC}" ]; then
             warn "${BOOT_IMAGE_HMAC} does not exist"
             return 1


### PR DESCRIPTION
See individual commit messages for details. Though note none of these patches are actually specific to RHCOS and FCOS. I've also verified that I can boot up a traditional Fedora cloud server in FIPS mode with the patches.

More background information in:
https://github.com/coreos/fedora-coreos-tracker/issues/302