### PR TITLE
Shutdown umount loop early-terminates on failure, not on success

### DIFF
--- a/modules.d/99shutdown/shutdown.sh
+++ b/modules.d/99shutdown/shutdown.sh
@@ -44,7 +44,7 @@ source_hook pre-shutdown
 
 warn "Killing all remaining processes"
 
-killall_proc_mountpoint /oldroot || sleep 0.2
+killall_proc_mountpoint /oldroot && sleep 0.2
 
 umount_a() {
     local _did_umount="n"


### PR DESCRIPTION
umount_a returns 0 on success, fix the logic accordingly.

Fixes #483

Patch-by: Martin Whitaker <foss@martin-whitaker.me.uk>