### PR TITLE
99base: Remove duplicate nfsroot_to_var from dracut-lib.sh

### DIFF
--- a/modules.d/95nfs/parse-nfsroot.sh
+++ b/modules.d/95nfs/parse-nfsroot.sh
@@ -24,6 +24,7 @@
 #
 
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+ . /lib/nfs-lib.sh
 
 # This script is sourced, so root should be set. But let's be paranoid
 [ -z "$root" ] && root=$(getarg root=)

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -579,39 +579,6 @@ else
     }
 fi
 
-# root=nfs:[<server-ip>:]<root-dir>[:<nfs-options>]
-# root=nfs4:[<server-ip>:]<root-dir>[:<nfs-options>]
-nfsroot_to_var() {
-    # strip nfs[4]:
-    local arg="$@:"
-    nfs="${arg%%:*}"
-    arg="${arg##$nfs:}"
-
-    # check if we have a server
-    if strstr "$arg" ':/' ; then
-        server="${arg%%:/*}"
-        arg="/${arg##*:/}"
-    fi
-
-    path="${arg%%:*}"
-
-    # rest are options
-    options="${arg##$path}"
-    # strip leading ":"
-    options="${options##:}"
-    # strip  ":"
-    options="${options%%:}"
-
-    # Does it really start with '/'?
-    [ -n "${path%%/*}" ] && path="error";
-
-    #Fix kernel legacy style separating path and options with ','
-    if [ "$path" != "${path#*,}" ] ; then
-        options=${path#*,}
-        path=${path%%,*}
-    fi
-}
-
 # Create udev rule match for a device with its device name, or the udev property
 # ID_FS_UUID or ID_FS_LABEL
 #


### PR DESCRIPTION
It already lives in nfs-lib.sh, which is the more correct library scope.

Fixes #17