### PR TITLE
network-manager: fix getting of ifname from the sysfs path

### DIFF
--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -6,7 +6,7 @@ else
     /usr/sbin/NetworkManager --configure-and-quit=initrd --no-daemon
 fi
 
-for _i in /sys/class/net/*/
+for _i in /sys/class/net/*
 do
     state=/run/NetworkManager/devices/$(cat $_i/ifindex)
     grep -q connection-uuid= $state 2>/dev/null || continue


### PR DESCRIPTION
commit 5e0f8c8a4ced ('network-manager: remove useless use of basename')
somewhat carelessly didn't take into account that $_i has a slash at
the end which made the result of the ## substitution be just an empty
string.

The slash was put to the end of /sys/class/net/*/ to make sure we're only
iterating directories, but it's not strictly necessary. In an unlikely case
something else than a directory appears in /sys/class/net/, we'll already deal
with it gracefully. Remove it.

This fixes the TEST-30-ISCSI test.