### PR TITLE
Write dns values passed by ip argument to ifcfg-* files

### DIFF
--- a/modules.d/45ifcfg/write-ifcfg.sh
+++ b/modules.d/45ifcfg/write-ifcfg.sh
@@ -270,7 +270,7 @@ for netup in /tmp/net.*.did-setup ; do
         done
     fi
     i=1
-    for ns in $(getargs nameserver); do
+    for ns in $(getargs nameserver) $dns1 $dns2; do
         echo "DNS${i}=\"${ns}\"" >> /tmp/ifcfg/ifcfg-$netif
         i=$((i+1))
     done


### PR DESCRIPTION
This patch should fix issue, where dns server were passed by parameter via cmd, but wasn't written to ifcfg file.

Resolve: rhbz#1767100