### PR TITLE
Revert "travis: run TEST-14-IMSM on Fedora 29"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   - IMAGE=latest TESTS=10
   - IMAGE=latest TESTS=11
   - IMAGE=latest TESTS=13
-  - IMAGE=29 TESTS=14
+  - IMAGE=latest TESTS=14
   - IMAGE=latest TESTS=15
   - IMAGE=latest TESTS=17
 


### PR DESCRIPTION
We're on Fedora 31 that should be good enough for this test.

This reverts commit 7a2503ab8cec9473ad6dacf4f48b17344219f3c0.