### PR TITLE
TEST-50-MULTINIC: fix how a basename is determined

### DIFF
--- a/test/TEST-50-MULTINIC/client-init.sh
+++ b/test/TEST-50-MULTINIC/client-init.sh
@@ -105,7 +105,7 @@ export TERM=linux
 export PS1='initramfs-test:\w\$ '
 stty sane
 echo "made it to the rootfs! Powering down."
-for i in /sys/class/net/*/
+for i in /sys/class/net/*
 do
     # booting with network-manager module
     state=/run/NetworkManager/devices/$(cat $i/ifindex)


### PR DESCRIPTION
Analogous to what commit 687e17aa7f2f ("network-manager: fix getting of
ifname from the sysfs path") fixes.