### PR TITLE
TEST-{20,50,60,70): set MACAddressPolicy=keep

### DIFF
--- a/test/TEST-20-NFS/99-default.link
+++ b/test/TEST-20-NFS/99-default.link
@@ -1,0 +1,6 @@
+[Match]
+OriginalName=*
+
+[Link]
+NamePolicy=keep kernel database onboard slot path
+MACAddressPolicy=keep

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -342,6 +342,7 @@ test_setup() {
         inst_hook shutdown-emergency 000 ./hard-off.sh
         inst_hook emergency 000 ./hard-off.sh
         inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
+        inst_simple ./99-default.link /etc/systemd/network/99-default.link
     )
 
     # Make server's dracut image

--- a/test/TEST-50-MULTINIC/99-default.link
+++ b/test/TEST-50-MULTINIC/99-default.link
@@ -1,0 +1,6 @@
+[Match]
+OriginalName=*
+
+[Link]
+NamePolicy=keep kernel database onboard slot path
+MACAddressPolicy=keep

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -281,6 +281,7 @@ test_setup() {
         inst_hook shutdown-emergency 000 ./hard-off.sh
         inst_hook emergency 000 ./hard-off.sh
         inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
+        inst_simple ./99-default.link /etc/systemd/network/99-default.link
     )
 
     # Make server's dracut image

--- a/test/TEST-60-IFCFG/99-default.link
+++ b/test/TEST-60-IFCFG/99-default.link
@@ -1,0 +1,6 @@
+[Match]
+OriginalName=*
+
+[Link]
+NamePolicy=keep kernel database onboard slot path
+MACAddressPolicy=keep

--- a/test/TEST-60-IFCFG/test.sh
+++ b/test/TEST-60-IFCFG/test.sh
@@ -302,6 +302,7 @@ test_setup() {
         inst_multiple poweroff shutdown
         inst_hook emergency 000 ./hard-off.sh
         inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
+        inst_simple ./99-default.link /etc/systemd/network/99-default.link
     )
 
     # Make server's dracut image

--- a/test/TEST-70-BONDBRIDGETEAMVLAN/99-default.link
+++ b/test/TEST-70-BONDBRIDGETEAMVLAN/99-default.link
@@ -1,0 +1,6 @@
+[Match]
+OriginalName=*
+
+[Link]
+NamePolicy=keep kernel database onboard slot path
+MACAddressPolicy=keep

--- a/test/TEST-70-BONDBRIDGETEAMVLAN/test.sh
+++ b/test/TEST-70-BONDBRIDGETEAMVLAN/test.sh
@@ -302,6 +302,7 @@ test_setup() {
         inst_multiple poweroff shutdown
         inst_hook emergency 000 ./hard-off.sh
         inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
+        inst_simple ./99-default.link /etc/systemd/network/99-default.link
     )
 
     # Make server's dracut image


### PR DESCRIPTION
New systemd defaults to generating MAC addresses for software devices (whereas
previously they would inherit them from the first enslaved slave).

Sadly, among the things this breaks is our test fixture, where the dhcp servers
are configured to expect a particular MAC address. Disable this for the
affected tests, which are essentially the ones that use bridges and bonds.