### PR TITLE
TEST-{20,30,31,40,50,60,70): wait for server interfaces to come up

### DIFF
--- a/test/TEST-20-NFS/server-init.sh
+++ b/test/TEST-20-NFS/server-init.sh
@@ -8,6 +8,21 @@ echo > /dev/watchdog
 stty sane
 echo "made it to the rootfs!"
 echo server > /proc/sys/kernel/hostname
+
+wait_for_if_link() {
+    local cnt=0
+    local li
+    while [ $cnt -lt 600 ]; do
+        li=$(ip -o link show dev $1 2>/dev/null)
+        [ -n "$li" ] && return 0
+        sleep 0.1
+        cnt=$(($cnt+1))
+    done
+    return 1
+}
+
+wait_for_if_link eth0
+
 ip addr add 127.0.0.1/8 dev lo
 ip link set lo up
 ip link set dev eth0 name ens3

--- a/test/TEST-30-ISCSI/server-init.sh
+++ b/test/TEST-30-ISCSI/server-init.sh
@@ -7,6 +7,22 @@ export PS1='nfstest-server:\w\$ '
 stty sane
 echo "made it to the rootfs!"
 echo server > /proc/sys/kernel/hostname
+
+wait_for_if_link() {
+    local cnt=0
+    local li
+    while [ $cnt -lt 600 ]; do
+        li=$(ip -o link show dev $1 2>/dev/null)
+        [ -n "$li" ] && return 0
+        sleep 0.1
+        cnt=$(($cnt+1))
+    done
+    return 1
+}
+
+wait_for_if_link eth0
+wait_for_if_link eth1
+
 ip addr add 127.0.0.1/8 dev lo
 ip link set lo up
 ip link set dev eth0 name ens3

--- a/test/TEST-31-ISCSI-MULTI/server-init.sh
+++ b/test/TEST-31-ISCSI-MULTI/server-init.sh
@@ -7,6 +7,22 @@ export PS1='nfstest-server:\w\$ '
 stty sane
 echo "made it to the rootfs!"
 echo server > /proc/sys/kernel/hostname
+
+wait_for_if_link() {
+    local cnt=0
+    local li
+    while [ $cnt -lt 600 ]; do
+        li=$(ip -o link show dev $1 2>/dev/null)
+        [ -n "$li" ] && return 0
+        sleep 0.1
+        cnt=$(($cnt+1))
+    done
+    return 1
+}
+
+wait_for_if_link eth0
+wait_for_if_link eth1
+
 ip addr add 127.0.0.1/8 dev lo
 ip link set lo up
 ip link set dev eth0 name ens3

--- a/test/TEST-40-NBD/server-init.sh
+++ b/test/TEST-40-NBD/server-init.sh
@@ -7,6 +7,21 @@ export PS1='nbdtest-server:\w\$ '
 stty sane
 echo "made it to the rootfs!"
 echo server > /proc/sys/kernel/hostname
+
+wait_for_if_link() {
+    local cnt=0
+    local li
+    while [ $cnt -lt 600 ]; do
+        li=$(ip -o link show dev $1 2>/dev/null)
+        [ -n "$li" ] && return 0
+        sleep 0.1
+        cnt=$(($cnt+1))
+    done
+    return 1
+}
+
+wait_for_if_link eth0
+
 ip addr add 127.0.0.1/8 dev lo
 ip link set lo up
 ip link set dev eth0 name ens3

--- a/test/TEST-50-MULTINIC/server-init.sh
+++ b/test/TEST-50-MULTINIC/server-init.sh
@@ -49,6 +49,8 @@ linkup() {
      && wait_for_if_up $1 2>/dev/null
 }
 
+wait_for_if_link eth0
+
 >/dev/watchdog
 ip addr add 127.0.0.1/8 dev lo
 linkup lo

--- a/test/TEST-60-IFCFG/server-init.sh
+++ b/test/TEST-60-IFCFG/server-init.sh
@@ -49,6 +49,11 @@ linkup() {
      && wait_for_if_up $1 2>/dev/null
 }
 
+wait_for_if_link eth0
+wait_for_if_link eth1
+wait_for_if_link eth2
+wait_for_if_link eth3
+
 modprobe --all -b -q 8021q ipvlan macvlan
 >/dev/watchdog
 ip addr add 127.0.0.1/8 dev lo

--- a/test/TEST-70-BONDBRIDGETEAMVLAN/server-init.sh
+++ b/test/TEST-70-BONDBRIDGETEAMVLAN/server-init.sh
@@ -49,6 +49,11 @@ linkup() {
      && wait_for_if_up $1 2>/dev/null
 }
 
+wait_for_if_link eth0
+wait_for_if_link eth1
+wait_for_if_link eth2
+wait_for_if_link eth3
+
 modprobe --all -b -q 8021q ipvlan macvlan
 >/dev/watchdog
 ip addr add 127.0.0.1/8 dev lo


### PR DESCRIPTION
The network interfaces appear asynchronously and sometimes just too late,
after we're already halfway throught server-init.sh:

  + ip link set dev eth0 name ens3
  Cannot find device "eth0"
  + ip addr add 192.168.50.1/24 dev ens3
  Cannot find device "ens3"
  + dhcpd -cf /etc/dhcpd.conf -lf /var/lib/dhcpd/dhcpd.leases ens3 ens5
  ...
  [    8.040825] e1000 0000:00:03.0 eth0: (PCI:33MHz:32-bit) 52:54:01:12:34:56
  [    8.047105] e1000 0000:00:03.0 eth0: Intel(R) PRO/1000 Network Connection
  ...
  No subnet declaration for ens3 (no IPv4 addresses).
  ** Ignoring requests on ens3.  If this is not what
     you want, please write a subnet declaration
     in your dhcpd.conf file for the network segment
     to which interface ens3 is attached. **

Whoopsie. Let's ensure all the interfaces are there before we proceed
fiddling around with them.