### PR TITLE
Replace ln with systemctl

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -240,9 +240,7 @@ install() {
         systemd-ask-password-console.service \
         systemd-ask-password-plymouth.service \
         ; do
-        mkdir -p "${initdir}${systemdsystemunitdir}/${i}.wants"
-        ln_r "${systemdsystemunitdir}/systemd-vconsole-setup.service" \
-            "${systemdsystemunitdir}/${i}.wants/systemd-vconsole-setup.service"
+        systemctl -q --root "$initdir" add-wants "$i" systemd-vconsole-setup.service
     done
 
     mkdir -p "$initdir/etc/systemd"
@@ -254,6 +252,6 @@ install() {
         echo "RateLimitBurst=0"
     } >> "$initdir/etc/systemd/journald.conf"
 
-    ln_r "${systemdsystemunitdir}/multi-user.target" "${systemdsystemunitdir}/default.target"
+    systemctl -q --root "$initdir" set-default multi-user.target
 }
 

--- a/modules.d/01systemd-initrd/module-setup.sh
+++ b/modules.d/01systemd-initrd/module-setup.sh
@@ -36,6 +36,5 @@ install() {
         $systemdsystemunitdir/initrd-udevadm-cleanup-db.service \
         $systemdsystemunitdir/initrd-parse-etc.service
 
-    ln_r "${systemdsystemunitdir}/initrd.target" "${systemdsystemunitdir}/default.target"
+    systemctl -q --root "$initdir" set-default initrd.target
 }
-

--- a/modules.d/02systemd-networkd/module-setup.sh
+++ b/modules.d/02systemd-networkd/module-setup.sh
@@ -61,11 +61,11 @@ install() {
 
     for i in \
         systemd-networkd-wait-online.service \
-            systemd-networkd.service \
-            systemd-networkd.socket
-#            systemd-timesyncd.service
+        systemd-networkd.service \
+        systemd-networkd.socket
+#       systemd-timesyncd.service
     do
-        systemctl --root "$initdir" enable "$i"
+        systemctl -q --root "$initdir" enable "$i"
     done
 }
 

--- a/modules.d/06rngd/module-setup.sh
+++ b/modules.d/06rngd/module-setup.sh
@@ -33,7 +33,6 @@ check() {
 install() {
     inst rngd
     inst_simple "${moddir}/rngd.service" "${systemdsystemunitdir}/rngd.service"
-    mkdir -p "${initdir}${systemdsystemunitdir}/sysinit.target.wants"
-    ln -rfs "${initdir}${systemdsystemunitdir}/rngd.service" \
-        "${initdir}${systemdsystemunitdir}/sysinit.target.wants/rngd.service"
+
+    systemctl -q --root "$initdir" add-wants sysinit.target rngd.service
 }

--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -110,8 +110,7 @@ install() {
 
     if dracut_module_included "systemd"; then
         inst_simple "${moddir}/multipathd.service" "${systemdsystemunitdir}/multipathd.service"
-        mkdir -p "${initdir}${systemdsystemunitdir}/sysinit.target.wants"
-        ln -rfs "${initdir}${systemdsystemunitdir}/multipathd.service" "${initdir}${systemdsystemunitdir}/sysinit.target.wants/multipathd.service"
+        systemctl -q --root "$initdir" enable multipathd.service
     else
         inst_hook pre-trigger 02 "$moddir/multipathd.sh"
         inst_hook cleanup   02 "$moddir/multipathd-stop.sh"

--- a/modules.d/90stratis/module-setup.sh
+++ b/modules.d/90stratis/module-setup.sh
@@ -24,8 +24,7 @@ install() {
 
     if dracut_module_included "systemd"; then
         inst_simple "${moddir}/stratisd-init.service" "${systemdsystemunitdir}/stratisd-init.service"
-        mkdir -p "${initdir}${systemdsystemunitdir}/sysinit.target.wants"
-        ln -rfs "${initdir}${systemdsystemunitdir}/stratisd-init.service" "${initdir}${systemdsystemunitdir}/sysinit.target.wants/stratisd-init.service"
+        systemctl -q --root "$initdir" enable stratisd-init.service
     else
         inst_hook cmdline 25 "$moddir/stratisd-start.sh"
         inst_hook cleanup 25 "$moddir/stratisd-stop.sh"

--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -253,20 +253,18 @@ install() {
                       $systemdsystemunitdir/iscsiuio.socket \
                       iscsiadm iscsid
 
-        mkdir -p "${initdir}/$systemdsystemunitdir/sockets.target.wants"
         for i in \
                 iscsid.socket \
                 iscsiuio.socket \
             ; do
-            ln_r "$systemdsystemunitdir/${i}" "$systemdsystemunitdir/sockets.target.wants/${i}"
+            systemctl -q --root "$initdir" enable "$i"
         done
-
-        mkdir -p "${initdir}/$systemdsystemunitdir/basic.target.wants"
+        
         for i in \
                 iscsid.service \
                 iscsiuio.service \
             ; do
-            ln_r "$systemdsystemunitdir/${i}" "$systemdsystemunitdir/basic.target.wants/${i}"
+            systemctl -q --root "$initdir" add-wants basic.target "$i"
         done
 
         # Make sure iscsid is started after dracut-cmdline and ready for the initqueue

--- a/modules.d/98dracut-systemd/module-setup.sh
+++ b/modules.d/98dracut-systemd/module-setup.sh
@@ -43,7 +43,6 @@ install() {
 
     inst_script "$moddir/rootfs-generator.sh" $systemdutildir/system-generators/dracut-rootfs-generator
 
-    mkdir -p "${initdir}/$systemdsystemunitdir/initrd.target.wants"
     for i in \
         dracut-cmdline.service \
         dracut-cmdline-ask.service \
@@ -55,7 +54,7 @@ install() {
         dracut-pre-udev.service \
         ; do
         inst_simple "$moddir/${i}" "$systemdsystemunitdir/${i}"
-        ln_r "$systemdsystemunitdir/${i}" "$systemdsystemunitdir/initrd.target.wants/${i}"
+        systemctl -q --root "$initdir" add-wants initrd.target "$i"
     done
 
     inst_simple "$moddir/dracut-tmpfiles.conf" "$tmpfilesdir/dracut-tmpfiles.conf"

--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -25,6 +25,5 @@ install() {
     inst $moddir/init.sh /squash/init.sh
 
     inst "$moddir/squash-mnt-clear.service" "$systemdsystemunitdir/squash-mnt-clear.service"
-    mkdir -p "$initdir$systemdsystemunitdir/initrd-switch-root.target.wants"
-    ln_r "$systemdsystemunitdir/squash-mnt-clear.service" "$systemdsystemunitdir/initrd-switch-root.target.wants/squash-mnt-clear.service"
+    systemctl -q --root "$initdir" add-wants initrd-switch-root.target squash-mnt-clear.service
 }


### PR DESCRIPTION
Replace manual creating of symbolic links via ``mkdir`` and ``ln`` with ``systemctl`` calls.

This patch also unify how symbolic links are created in ``module-setup.sh`` files. It might help new contributors with creating new dracut modules.