### PR TITLE
95ssh-client: improve nsswitch.conf parser

### DIFF
--- a/modules.d/95ssh-client/module-setup.sh
+++ b/modules.d/95ssh-client/module-setup.sh
@@ -68,7 +68,9 @@ install() {
     inst_multiple ssh scp
     inst_sshenv
 
-    _nsslibs=$(sed -e '/^#/d' -e 's/^.*://' -e 's/\[NOTFOUND=return\]//' $dracutsysrootdir/etc/nsswitch.conf \
+    _nsslibs=$(
+        sed -e 's/#.*//; s/^[^:]*://; s/\[[^]]*\]//' \
+            $dracutsysrootdir/etc/nsswitch.conf \
         |  tr -s '[:space:]' '\n' | sort -u | tr -s '[:space:]' '|')
     _nsslibs=${_nsslibs#|}
     _nsslibs=${_nsslibs%|}


### PR DESCRIPTION
The actual syntax of nsswitch.conf is slightly different from the
current regular expression:

- A comment can appear anywhere, not just at the beginning of a
  line.
- Action items take the general form [STATUS=ACTION] or
  [!STATUS=ACTION] (with some optional whitespace).
- A service name cannot include a colon. This is a nitpick,
  because there should never be more than a single colon per
  line.

Signed-off-by: Petr Tesarik <ptesarik@suse.com>