### PR TITLE
35network-legacy: using 'replace' instead of 'add' to add route

### DIFF
--- a/modules.d/35network-legacy/dhclient-script.sh
+++ b/modules.d/35network-legacy/dhclient-script.sh
@@ -146,7 +146,7 @@ parse_option_121() {
             temp_result="$destination via $gateway dev $interface"
         fi
 
-        echo "/sbin/ip route add $temp_result"
+        echo "/sbin/ip route replace $temp_result"
     done
 }
 


### PR DESCRIPTION
This is a simple trick to honor RFC 3442:
If the DHCP server returns both a Classless Static Routes option and
a Router option, the DHCP client MUST ignore the Router option.

Fixes #683 

Signed-off-by: Jacob Wen <jian.w.wen@oracle.com>