### PR TITLE
fips: add 'ofb' and 'cts' block cipher modes

### DIFF
--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -27,7 +27,7 @@ installkernel() {
         _fipsmodules+="cipher_null des3_ede aes cfb "
 
         # Modes/templates:
-        _fipsmodules+="ecb cbc ctr xts gcm ccm authenc hmac cmac "
+        _fipsmodules+="ecb cbc ctr xts gcm ccm authenc hmac cmac ofb cts "
 
         # Compression algs:
         _fipsmodules+="deflate lzo zlib "


### PR DESCRIPTION
Add cts, Linux-5.0 commit:
* 196ad6043e9f ("crypto: testmgr - mark cts(cbc(aes)) as FIPS allowed")

Linux 4.20 commits for 'ofb' (FIPS allowed too):
* dfb89ab3f0a7 ("crypto: tcrypt - add OFB functional tests")
* e497c51896b3 ("crypto: ofb - add output feedback mode")

Signed-off-by: Alexey Kodanev <alexey.kodanev@oracle.com>