### PR TITLE
95iscsi: Fix /etc/iscsi installation

### DIFF
--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -228,7 +228,8 @@ install() {
         $systemdsystemunitdir/sockets.target.wants/iscsiuio.socket
 
     if [[ $hostonly ]]; then
-        inst_dir $(/usr/bin/find /etc/iscsi)
+        inst_dir /etc/iscsi
+        inst_multiple $(find /etc/iscsi -type f)
     else
         inst_simple /etc/iscsi/iscsid.conf
     fi


### PR DESCRIPTION
Previous all files are installed with inst_dir, which will not install
the files under /etc/iscsi/, and it create folders with the same of the
files which is wrong.

Now only use inst_dir to install the config dir and ensure it
exists, and use inst_multiple to install the config files.

Signed-off-by: Kairui Song <kasong@redhat.com>