### PR TITLE
network-manager: don't run NetworkManager when there are no connections

### DIFF
--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -1,10 +1,17 @@
 #!/bin/sh
 
-if getargbool 0 rd.debug -d -y rdinitdebug -d -y rdnetdebug; then
-    /usr/sbin/NetworkManager --configure-and-quit=initrd --debug --log-level=trace
-else
-    /usr/sbin/NetworkManager --configure-and-quit=initrd --no-daemon
-fi
+for i in /usr/lib/NetworkManager/system-connections/* \
+         /run/NetworkManager/system-connections/* \
+         /etc/NetworkManager/system-connections/* \
+         /etc/sysconfig/network-scripts/ifcfg-*; do
+  [ -f "$i" ] || continue
+  if getargbool 0 rd.debug -d -y rdinitdebug -d -y rdnetdebug; then
+      /usr/sbin/NetworkManager --configure-and-quit=initrd --debug --log-level=trace
+  else
+      /usr/sbin/NetworkManager --configure-and-quit=initrd --no-daemon
+  fi
+  break
+done
 
 for _i in /sys/class/net/*
 do


### PR DESCRIPTION
NetworkManager would unnecessarily bring up the devices, colliding with
further attempts to rename the devices.

This is arguably a NetworkManager bug and should eventually be fixed there.
Running NetworkManager without the connection is unnecessary regardless.