### PR TITLE
Check .hmac of boot.iso in fips mode

### DIFF
--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -111,6 +111,9 @@ do_fips()
         do_rhevh_check /run/initramfs/live/vmlinuz0 || return 1
     elif [ -e "/run/initramfs/live/isolinux/vmlinuz0" ]; then
         do_rhevh_check /run/initramfs/live/isolinux/vmlinuz0 || return 1
+    elif [ -e "/run/install/repo/images/pxeboot/vmlinuz" ]; then
+        # This is a boot.iso with the .hmac inside the install.img
+        do_rhevh_check /run/install/repo/images/pxeboot/vmlinuz || return 1
     else
         BOOT_IMAGE="$(getarg BOOT_IMAGE)"
         BOOT_IMAGE_NAME="${BOOT_IMAGE##*/}"


### PR DESCRIPTION
Instead of carrying the kernel and hmac in the install.img (which takes
up more space) use the vmlinuz installed under /images/pxeboot/ and the
.hmac in the install.img /boot.

This check is triggered by the presence of /run/install/repo/images/pxeboot/vmlinuz

Related: rhbz#1782737