### PR TITLE
network-legacy/ifup: dhclient should be started in oneshot mode

### DIFF
--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -52,6 +52,7 @@ do_dhcp() {
         dhclient "$@" \
                  ${_timeout:+-timeout $_timeout} \
                  -q \
+                 -1 \
                  -cf /etc/dhclient.conf \
                  -pf /tmp/dhclient.$netif.pid \
                  -lf /tmp/dhclient.$netif.lease \


### PR DESCRIPTION
since we handle the retries explicitly via rd.net.dhcp.retry

Without -1 if user sets ip=dhcp6 and there is no dhcp on the network,
dhclient seems to wait indefinitely, ignoring rd.net.timeout.dhcp