### PR TITLE
dracut-install: fetch kernel modules from kmoddir

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -915,6 +915,21 @@ esac
 
 [[ $reproducible == yes ]] && DRACUT_REPRODUCIBLE=1
 
+case "${drivers_dir}" in
+    ''|*lib/modules/${kernel}|*lib/modules/${kernel}/) ;;
+    *)
+        [[ "$DRACUT_KMODDIR_OVERRIDE" ]] || {
+	    printf "%s\n" "dracut: -k/--kmoddir path must contain \"lib/modules\" as a parent of your kernel module directory,"
+	    printf "%s\n" "dracut: or modules may not be placed in the correct location inside the initramfs."
+	    printf "%s\n" "dracut: was given: ${drivers_dir}"
+	    printf "%s\n" "dracut: expected: $(dirname ${drivers_dir})/lib/modules/${kernel}"
+	    printf "%s\n" "dracut: Please move your modules into the correct directory structure and pass the new location,"
+	    printf "%s\n" "dracut: or set DRACUT_KMODDIR_OVERRIDE=1 to ignore this check."
+	    exit 1
+	}
+	;;
+esac
+
 readonly TMPDIR="$(realpath -e "$tmpdir")"
 [ -d "$TMPDIR" ] || {
     printf "%s\n" "dracut: Invalid tmpdir '$tmpdir'." >&2

--- a/install/dracut-install.c
+++ b/install/dracut-install.c
@@ -1458,12 +1458,12 @@ static int install_dependent_modules(struct kmod_list *modlist)
                         continue;
                 }
 
-                ret = dracut_install(&path[kerneldirlen], &path[kerneldirlen], false, false, true);
+                ret = dracut_install(path, &path[kerneldirlen], false, false, true);
                 if (ret == 0) {
 			_cleanup_kmod_module_unref_list_ struct kmod_list *modlist = NULL;
 			_cleanup_kmod_module_unref_list_ struct kmod_list *modpre = NULL;
 			_cleanup_kmod_module_unref_list_ struct kmod_list *modpost = NULL;
-                        log_debug("dracut_install '%s' '%s' OK", &path[kerneldirlen], &path[kerneldirlen]);
+                        log_debug("dracut_install '%s' '%s' OK", path, &path[kerneldirlen]);
                         install_firmware(mod);
 			modlist = kmod_module_get_dependencies(mod);
 			ret = install_dependent_modules(modlist);
@@ -1473,7 +1473,7 @@ static int install_dependent_modules(struct kmod_list *modlist)
 					ret = install_dependent_modules(modpre);
 			}
                 } else {
-                        log_error("dracut_install '%s' '%s' ERROR", &path[kerneldirlen], &path[kerneldirlen]);
+                        log_error("dracut_install '%s' '%s' ERROR", path, &path[kerneldirlen]);
                 }
         }
 
@@ -1515,9 +1515,9 @@ static int install_module(struct kmod_module *mod)
                 return 1;
         }
 
-        log_debug("dracut_install '%s' '%s'", &path[kerneldirlen], &path[kerneldirlen]);
+        log_debug("dracut_install '%s' '%s'", path, &path[kerneldirlen]);
 
-        ret = dracut_install(&path[kerneldirlen], &path[kerneldirlen], false, false, true);
+        ret = dracut_install(path, &path[kerneldirlen], false, false, true);
         if (ret == 0) {
                 log_debug("dracut_install '%s' OK", kmod_module_get_name(mod));
         } else if (!arg_optional) {


### PR DESCRIPTION
dracut, when passing --kmoddir, would only install modules that exist at
the same location as it will appear in the initramfs.

For most (possibly all) outputs, the output path would be /lib/modules,
so previously all kernel modules must be copied there or the module
installation silently fails.

Now use the original path variable, and install to the shortened path
variable (as calculated by kerneldirlen).

Note: This means that the argument to --kmoddir (and the modules filetree)
should be a directory that ends in 'lib/modules/$kernelversion'.