### PR TITLE
network-legacy/ifup: nuke pid and lease files if dhclient failed

### DIFF
--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -62,6 +62,9 @@ do_dhcp() {
         [ $_COUNT -lt $_DHCPRETRY ] && sleep 1
     done
     warn "dhcp for interface $netif failed"
+    # nuke those files since we failed; we might retry dhcp again if it's e.g.
+    # `ip=dhcp,dhcp6` and we check for the PID file at the top
+    rm -f /tmp/dhclient.$netif.{pid,lease}
     return 1
 }
 


### PR DESCRIPTION
Otherwise we won't retry dhclient again on that interface. In
FCOS/RHCOS, we want to bake in `ip=dhcp,dhcp6` so we automatically try
getting a DHCPv6 lease if DHCPv4 failed.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1793591