### PR TITLE
Revert "wait for IPv6 RA if using none/static IPv6 assignment"

### DIFF
--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -655,7 +655,6 @@ wait_for_ipv6_dad_link() {
     while [ $cnt -lt $timeout ]; do
         [ -n "$(ip -6 addr show dev "$1" scope link)" ] \
             && [ -z "$(ip -6 addr show dev "$1" scope link tentative)" ] \
-            && [ -n "$(ip -6 route list proto ra dev "$1" | grep ^default)" ] \
             && return 0
         [ -n "$(ip -6 addr show dev "$1" scope link dadfailed)" ] \
             && return 1


### PR DESCRIPTION
This reverts commit c603419030136570b5944dc4620f62d07b9e82bb.

wait_for_ipv6_dad_link is only called from dhclient script,
so the original intent "wait for IPv6 RA if using none/static IPv6 assignment"
does not seem to be correct.

Anyway, this brings an issue on isolated networks, where you don't
have any routes outside. dhclient-script hangs on this check
and after it times out, dhclient is able to set the address normally.