### PR TITLE
dracut: Verify multipath config_dir option

### DIFF
--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -79,6 +79,20 @@ install() {
         }
     }
 
+    # Include multipath configuration files from path specified with config_dir
+    while read _k _v; do
+        if [[ "$_k" = config_dir ]]; then
+            _v=${_v#\"}
+            config_dir=${_v%\"}
+        fi
+    done < <(/sbin/multipath -t)
+
+    if [ -d "$config_dir" ]; then
+        config_dir+="/*"
+    else
+        derror "multipath.conf: config_dir - No such directory $config_dir"
+    fi
+
     inst_multiple -o  \
         dmsetup \
         kpartx \
@@ -91,7 +105,7 @@ install() {
         /etc/xdrdevices.conf \
         /etc/multipath.conf \
         /etc/multipath/* \
-        /etc/multipath/conf.d/*
+        $config_dir
 
     [[ $hostonly ]] && [[ $hostonly_mode = "strict" ]] && {
         for_each_host_dev_and_slaves_all add_hostonly_mpath_conf


### PR DESCRIPTION
The 90multipath/module-setup.sh file currently does not check the
dm-multipath config_dir option. This option in multipath.conf file is
used to specify a custom directory/path that contains the multipath
configuration files. It's default value is /etc/multipath/conf.d

Currently install function of module-setup.sh has hardcoded the above
path, but users could change it with config_dir option. So, adding
steps to read the path specified with config_dir option and add
these configuration files to the initial ram disk image.

Signed-off-by: Milan P. Gandhi <mgandhi@redhat.com>
Reviewed-by: Martin Wilck <mwilck@suse.com>