### PR TITLE
40network: bump rd.net.timeout.carrier to 10 seconds

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -674,7 +674,7 @@ NFS
     Wait <seconds> until IPv6 automatic addresses are assigned. Default is 40 seconds.
 
 **rd.net.timeout.carrier=**__<seconds>__::
-    Wait <seconds> until carrier is recognized. Default is 5 seconds.
+    Wait <seconds> until carrier is recognized. Default is 10 seconds.
 
 CIFS
 ~~~

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -718,7 +718,7 @@ iface_has_carrier() {
     interface="/sys/class/net/$interface"
     [ -d "$interface" ] || return 2
     local timeout="$(getargs rd.net.timeout.carrier=)"
-    timeout=${timeout:-5}
+    timeout=${timeout:-10}
     timeout=$(($timeout*10))
 
     linkup "$1"


### PR DESCRIPTION
On some devices kernel currently takes 5.2 seconds to detect carrier,
so let's make the default in dracut bit more sensible.

See also https://bugzilla.redhat.com/show_bug.cgi?id=1772010