### PR TITLE
dhclient-script: ipv6 uses different variables for nameservers

### DIFF
--- a/modules.d/35network-legacy/dhclient-script.sh
+++ b/modules.d/35network-legacy/dhclient-script.sh
@@ -75,8 +75,8 @@ setup_interface() {
 
 setup_interface6() {
     domain=$new_domain_name
-    search=$(printf -- "$new_domain_search")
-    namesrv=$new_domain_name_servers
+    search=$(printf -- "$new_dhcp6_domain_search")
+    namesrv=$new_dhcp6_name_servers
     hostname=$new_host_name
     [ -n "$new_dhcp_lease_time" ] && lease_time=$new_dhcp_lease_time
     [ -n "$new_max_life" ] && lease_time=$new_max_life


### PR DESCRIPTION
new_domain_name_servers and new_domain_search is only provided vit IPv4

see: https://src.fedoraproject.org/rpms/dhcp/blob/HEAD/f/dhclient-script#_148