### PR TITLE
network/net-lib.sh: Configure all iBFT interfaces

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -786,6 +786,9 @@ iscsistart -b --param node.session.timeo.replacement_timeout=30
 **rd.iscsi.ibft** **rd.iscsi.ibft=1**:
     Turn on iBFT autoconfiguration for the interfaces
 
+**rd.iscsi.mp** **rd.iscsi.mp=1**:
+    Configure all iBFT interfaces, not only used for booting (multipath)
+
 **rd.iscsi.waitnet=0**:
     Turn off waiting for all interfaces to be up before trying to login to the iSCSI targets.
 

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -251,8 +251,10 @@ ibft_to_cmdline() {
             [ -e ${iface}/flags ] && flags=$(read a < ${iface}/flags; echo $a)
             # Skip invalid interfaces
             (( $flags & 1 )) || continue
-            # Skip interfaces not used for booting
-            (( $flags & 2 )) || continue
+            # Skip interfaces not used for booting unless using multipath
+            if ! getargbool 0 rd.iscsi.mp ; then
+                (( $flags & 2 )) || continue
+            fi
             [ -e ${iface}/dhcp ] && dhcp=$(read a < ${iface}/dhcp; echo $a)
             [ -e ${iface}/origin ] && origin=$(read a < ${iface}/origin; echo $a)
             [ -e ${iface}/ip-addr ] && ip=$(read a < ${iface}/ip-addr; echo $a)


### PR DESCRIPTION
Added boolean command line option rd.iscsi.mp

I have dual port Intel 10-Gigabit X540-AT2 and wanna boot my server from iscsi.
I tried to use iBFT to automatic interface configuration (as a sysadmin i'm a bit lazy) but it configures only one interface, thus multipath is not working.

cat /sys/firmware/ibft/ethernet*/flags
3
1
In network/net-lib.sh we have
(( $flags & 2 )) || continue
which completly excludes second nic port from ibft auto configuration.
