### PR TITLE
Support the EFI Stub loader's splash image feature.

### DIFF
--- a/dracut.8.asc
+++ b/dracut.8.asc
@@ -517,6 +517,10 @@ will not be able to boot.
     _$prefix/lib/systemd/boot/efi/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
     or _$prefix/lib/gummiboot/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
 
+**--uefi-splash-image _<FILE>_**::
+    Specifies the UEFI stub loader's splash image. Requires bitmap (**.bmp**) image
+    format.
+
 **--kernel-image _<FILE>_**::
     Specifies the kernel image, which to include in the UEFI executable. The default is
     _/lib/modules/<KERNEL-VERSION>/vmlinuz_ or _/boot/vmlinuz-<KERNEL-VERSION>_

--- a/dracut.conf.5.asc
+++ b/dracut.conf.5.asc
@@ -205,6 +205,9 @@ provide a valid _/etc/fstab_.
     _/lib/systemd/boot/efi/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
     or _/usr/lib/gummiboot/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
 
+*uefi_splash_image=*"_<FILE>_"::
+    Specifies the UEFI stub loader's splash image. Requires bitmap (**.bmp**) image format.
+
 *uefi_secureboot_cert=*"_<FILE>_", *uefi_secureboot_key=*"_<FILE>_"::
     Specifies a certificate and corresponding key, which are used to sign the created UEFI executable.
     Requires both certificate and key need to be specified and _sbsign_ to be installed.


### PR DESCRIPTION
Support the EFI Stub loader's splash image feature.

Checks if `uefi_splash_image` exists in `dracutsysroot` if not unset
`uefi_splash_image`. Alternate Value parameter expansion adds section-vma
for splash image to EFI stub loader when the path to image is valid and
not an empty file.

I did not test on other distributions, but on Arch Linux the `systemd`
package includes a splash image at the path
 `/usr/share/systemd/bootctl/splash-arch.bmp`. Perhaps, if this is a
common practice, a default image could be gathered from that directory.

It is required that the image be in bitmap (`.bmp`) format according to 
`splash.c`.

The code for `stub.c` and `splash.c` can be found at:
https://github.com/systemd/systemd/blob/master/src/boot/efi/stub.c
https://github.com/systemd/systemd/blob/master/src/boot/efi/splash.c