### PR TITLE
network-legacy/ifup: fix ip=dhcp,dhcp6 setup_net logic

### DIFF
--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -453,17 +453,15 @@ for p in $(getargs ip=); do
             > /tmp/net.$(cat /sys/class/net/${netif}/address).up
         fi
 
-        case $autoconf in
-            dhcp|on|any|dhcp6)
-            ;;
-            *)
-                setup_net $netif
-                source_hook initqueue/online $netif
-                if [ -z "$manualup" ]; then
-                    /sbin/netroot $netif
-                fi
-                ;;
-        esac
+        # and finally, finish interface set up if there isn't already a script
+        # to do so (which is the case in the dhcp path)
+        if [ ! -e $hookdir/initqueue/setup_net_$netif.sh ]; then
+            setup_net $netif
+            source_hook initqueue/online $netif
+            if [ -z "$manualup" ]; then
+                /sbin/netroot $netif
+            fi
+        fi
 
         if command -v wicked >/dev/null && [ -z "$manualup" ]; then
             /sbin/netroot $netif

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -457,12 +457,10 @@ for p in $(getargs ip=); do
             dhcp|on|any|dhcp6)
             ;;
             *)
-                if [ $ret -eq 0 ]; then
-                    setup_net $netif
-                    source_hook initqueue/online $netif
-                    if [ -z "$manualup" ]; then
-                        /sbin/netroot $netif
-                    fi
+                setup_net $netif
+                source_hook initqueue/online $netif
+                if [ -z "$manualup" ]; then
+                    /sbin/netroot $netif
                 fi
                 ;;
         esac


### PR DESCRIPTION
Previously, we were doing `setup_net` from `ifup` for any setup that
wasn't DHCP, since those are already taken care of by `dhclient-script`.

The issue is that the case-statement we use to detect this doesn't catch
options like `ip=dhcp,dhcp6`.

Fix this by reworking the logic here to just check if a
`setup_net_$netif.sh` hook exists. If so, then we know that `setup_net`
will be called for this interface later.

This was causing issues in RHCOS which now ships with `ip=dhcp,dhcp6` to
support IPv6 environments[1]. The code here would make us do `setup_net`
pre-emptively which IIUC would then cause the initqueue to finish
earlier even if we had more udev netif events to process.

[1] coreos/coreos-assembler#1067

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1803926