### PR TITLE
35network-legacy: use $name instead of $env{INTERFACE}

### DIFF
--- a/modules.d/35network-legacy/net-genrules.sh
+++ b/modules.d/35network-legacy/net-genrules.sh
@@ -65,9 +65,9 @@ command -v fix_bootif >/dev/null || . /lib/net-lib.sh
         bootdev=$(cat /tmp/net.bootdev)
     fi
 
-    ifup='/sbin/ifup $env{INTERFACE}'
+    ifup='/sbin/ifup $name'
 
-    runcmd="RUN+=\"/sbin/initqueue --name ifup-\$env{INTERFACE} --unique --onetime $ifup\""
+    runcmd="RUN+=\"/sbin/initqueue --name ifup-\$name --unique --onetime $ifup\""
 
     # We have some specific interfaces to handle
     if [ -n "${RAW_IFACES}${IFACES}" ]; then


### PR DESCRIPTION
The original behavior of $env{INTERFACE} was undocumented and changed in
the recent udev versions, breaking the ability to bring up networking
reliably. Switching to $name directive should fix this issue.

Related links:
 - https://github.com/systemd/systemd/pull/12700 (udev PR)
 - https://github.com/systemd/systemd/issues/12291 (related udev issue)
 - https://github.com/systemd/systemd/issues/14935 (this issue, udev side)
 - https://github.com/dracutdevs/dracut/issues/732 (this issue, dracut side)

Fixes: #732

---

WIP for now, as I'd like to check the compatibility with older udev, and if it doesn't break something else with the current one.