### PR TITLE
cms/cmssetup.sh: use $name instead of $env{INTERFACE}

### DIFF
--- a/modules.d/80cms/cmssetup.sh
+++ b/modules.d/80cms/cmssetup.sh
@@ -164,11 +164,11 @@ processcmsfile()
             driver=$NETTYPE
         fi
 
-        printf 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", KERNELS=="%s", ENV{INTERFACE}=="?*", RUN+="/sbin/initqueue --onetime --unique --name cmsifup-$env{INTERFACE} /sbin/cmsifup $env{INTERFACE}"\n' "$driver" "$devbusid" > /etc/udev/rules.d/99-cms.rules
+        printf 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", KERNELS=="%s", ENV{INTERFACE}=="?*", RUN+="/sbin/initqueue --onetime --unique --name cmsifup-$name /sbin/cmsifup $name"\n' "$driver" "$devbusid" > /etc/udev/rules.d/99-cms.rules
         # remove the default net rules
         rm -f -- /etc/udev/rules.d/91-default-net.rules
         [[ -f /etc/udev/rules.d/90-net.rules ]] \
-            || printf 'SUBSYSTEM=="net", ACTION=="online", RUN+="/sbin/initqueue --onetime --env netif=$env{INTERFACE} source_hook initqueue/online"\n' >> /etc/udev/rules.d/99-cms.rules
+            || printf 'SUBSYSTEM=="net", ACTION=="online", RUN+="/sbin/initqueue --onetime --env netif=$name source_hook initqueue/online"\n' >> /etc/udev/rules.d/99-cms.rules
         udevadm control --reload
         znet_cio_free
     fi


### PR DESCRIPTION
Followup to a8ba1c4e25051c3c482bb7a6a754c9d785463917