### PR TITLE
fcoe/fcoe-genrules.sh: use $name instead of $env{INTERFACE}

### DIFF
--- a/modules.d/95fcoe/fcoe-genrules.sh
+++ b/modules.d/95fcoe/fcoe-genrules.sh
@@ -7,10 +7,10 @@
 # Write udev rules
 {
     if [ -n "$fcoe_mac" ] ; then
-        printf 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="%s", RUN+="/sbin/initqueue --onetime --unique --name fcoe-up-$env{INTERFACE} /sbin/fcoe-up $env{INTERFACE} %s %s"\n' "$fcoe_mac" "$fcoe_dcb" "$fcoe_mode"
-        printf 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="%s", RUN+="/sbin/initqueue --onetime --timeout --unique --name fcoe-timeout-$env{INTERFACE} /sbin/fcoe-up $env{INTERFACE} %s %s"\n' "$fcoe_mac" "$fcoe_dcb" "$fcoe_mode"
+        printf 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="%s", RUN+="/sbin/initqueue --onetime --unique --name fcoe-up-$name /sbin/fcoe-up $name %s %s"\n' "$fcoe_mac" "$fcoe_dcb" "$fcoe_mode"
+        printf 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="%s", RUN+="/sbin/initqueue --onetime --timeout --unique --name fcoe-timeout-$name /sbin/fcoe-up $name %s %s"\n' "$fcoe_mac" "$fcoe_dcb" "$fcoe_mode"
     else
-        printf 'ACTION=="add", SUBSYSTEM=="net", NAME=="%s", RUN+="/sbin/initqueue --onetime --unique --name fcoe-up-$env{INTERFACE} /sbin/fcoe-up $env{INTERFACE} %s %s"\n' "$fcoe_interface" "$fcoe_dcb" "$fcoe_mode"
-        printf 'ACTION=="add", SUBSYSTEM=="net", NAME=="%s", RUN+="/sbin/initqueue --onetime --timeout --unique --name fcoe-timeout-$env{INTERFACE} /sbin/fcoe-up $env{INTERFACE} %s %s"\n' "$fcoe_interface" "$fcoe_dcb" "$fcoe_mode"
+        printf 'ACTION=="add", SUBSYSTEM=="net", NAME=="%s", RUN+="/sbin/initqueue --onetime --unique --name fcoe-up-$name /sbin/fcoe-up $name %s %s"\n' "$fcoe_interface" "$fcoe_dcb" "$fcoe_mode"
+        printf 'ACTION=="add", SUBSYSTEM=="net", NAME=="%s", RUN+="/sbin/initqueue --onetime --timeout --unique --name fcoe-timeout-$name /sbin/fcoe-up $name %s %s"\n' "$fcoe_interface" "$fcoe_dcb" "$fcoe_mode"
     fi
 } >> /etc/udev/rules.d/92-fcoe.rules


### PR DESCRIPTION
Followup to a8ba1c4e25051c3c482bb7a6a754c9d785463917 and 11a5501d0f844b9e52f2f1b62d980b733c73f10a

---

Hopefully the last `$env{INTERFACE}`-related change, managed to completely overlook this one...