### PR TITLE
github: fetch git tags before testing

### DIFF
--- a/fedora-test-github.sh
+++ b/fedora-test-github.sh
@@ -7,6 +7,16 @@ set -ex
 RUN_ID="$1"
 TESTS=$2
 
+# GitHub workflows fetch a clone of the dracut repository which doesn't
+# contain git tags, thus "breaking" the RPM build in certain situations
+# i.e.:
+# DRACUT_MAIN_VERSION in Makefile is defined as an output of `git describe`,
+# which in full git clone returns a tag with a numeric version. However,
+# without tags it returns SHA of the last commit, which later propagates into
+# `Provides:` attribute of the built RPM and can break dependency tree when
+# installed
+[[ -d .git ]] && git fetch --tags && git describe --tags
+
 ./configure
 
 NCPU=$(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
GitHub workflows fetch a clone of the dracut repository which doesn't
contain git tags, thus "breaking" the RPM build in certain situations
i.e.:
DRACUT_MAIN_VERSION in Makefile is defined as an output of `git describe`,
which in full git clone returns a tag with a numeric version. However,
without tags it returns SHA of the last commit, which later propagates into
`Provides: `attribute of the built RPM and can break dependency tree when
installed

---

This caused two issues:

```
/var/tmp/dracut-test.cfXQz4/dracut-a902d6a947e02b1dcbbb24e5f02f9e29e9b57955-1.fc30.src.rpm
...
++ cp --reflink=auto -a '/var/tmp/dracut-test.cfXQz4/dracut-[0-9]*.x86_64.rpm' '/var/tmp/dracut-test.cfXQz4/dracut-network-[0-9]*.x86_64.rpm' /var/tmp/dracut-test.cfXQz4/root//var/tmp/dracut-test.cfXQz4/
cp: cannot stat '/var/tmp/dracut-test.cfXQz4/dracut-[0-9]*.x86_64.rpm': No such file or directory
cp: cannot stat '/var/tmp/dracut-test.cfXQz4/dracut-network-[0-9]*.x86_64.rpm': No such file or directory
```

which I managed to fix by

```diff
diff --git a/test/TEST-99-RPM/test.sh b/test/TEST-99-RPM/test.sh
index af64c24a..edbe8af4 100755
--- a/test/TEST-99-RPM/test.sh
+++ b/test/TEST-99-RPM/test.sh
@@ -26,9 +26,12 @@ test_run() {
     mount -t devtmpfs devtmpfs "$rootdir/dev"
 
     mkdir -p "$rootdir/$TESTDIR"
+    # Determine RPM's version-release string, so we can properly match specific
+    # dracut packages
+    release="$(rpm -qp --qf "%{version}-%{release}" "$TESTDIR"/dracut-*.src.rpm)"
     cp --reflink=auto -a \
-       "$TESTDIR"/dracut-[0-9]*.$(uname -m).rpm \
-       "$TESTDIR"/dracut-network-[0-9]*.$(uname -m).rpm \
+       "$TESTDIR/dracut-$release.$(uname -m).rpm" \
+       "$TESTDIR/dracut-network-$release.$(uname -m).rpm" \
        "$rootdir/$TESTDIR/"
     . /etc/os-release
     dnf_or_yum=yum
@@ -51,7 +54,7 @@ test_run() {
                         mdadm \
                         bash \
                         iscsi-initiator-utils \
-                        "$TESTDIR"/dracut-[0-9]*.$(uname -m).rpm \
+                        "$TESTDIR/dracut-$release.$(uname -m).rpm" \
                         ${NULL} && break
         #"$TESTDIR"/dracut-config-rescue-[0-9]*.$(uname -m).rpm \
             #"$TESTDIR"/dracut-network-[0-9]*.$(uname -m).rpm \
```

but this just uncovered another issue:

```
 Error: 
 Problem: package device-mapper-multipath-0.7.9-6.git2df6110.fc30.x86_64 requires device-mapper >= 1.02.96, but none of the providers can be installed
  - package device-mapper-1.02.154-3.fc30.x86_64 conflicts with dracut < 002-18 provided by dracut-f634abe25257e60a87bfef1540dac1d2df5b315e-1.fc30.x86_64
  - conflicting requests
```

I guess if we wanted to fix this and support RPM builds where `DRACUT_MAIN_VERSION=` is a full SHA then `git2spec.pl` would need to be fixed accordingly (and possibly some other fixes), because right now the resulting specfile leads to issues:

```specfile
...
%define dist_free_release 1

Name: dracut
Version: 11a5501d0f844b9e52f2f1b62d980b733c73f10a
Release: %{dist_free_release}%{?dist}
...
Provides:  dracut-generic = %{version}-%{release}
...
...