### PR TITLE
Make lsinitrd usable for images made with Debian mkinitramfs

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -236,6 +236,8 @@ case $bin in
     $'\x71\xc7'*|070701)
         CAT="cat --"
         is_early=$(cpio --extract --verbose --quiet --to-stdout -- 'early_cpio' < "$image" 2>/dev/null)
+        # Debian mkinitramfs does not create the file 'early_cpio', so let's check if firmware files exist
+        [[ "$is_early" ]] || is_early=$(cpio --list --verbose --quiet --to-stdout -- 'kernel/*/microcode/*.bin' < "$image" 2>/dev/null)
         if [[ "$is_early" ]]; then
             if [[ -n "$unpack" ]]; then
                 # should use --unpackearly for early CPIO


### PR DESCRIPTION
Debian mkinitramfs does not create the file 'early_cpio', so detection
of additional cpio images fails and only the first cpio is listed.

I checked some Arch and Gentoo initramfs files and these didn't have
'early_cpio' either, but they also have only one cpio part.

Fix this so that if check for 'early_cpio' fails, check if directory
'kernel' (as part of '/kernel/x86/microcode') exists.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>