### PR TITLE
90kernel-modules: Add PCI host controller modules

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -51,6 +51,7 @@ installkernel() {
             "=drivers/input/keyboard" \
             "=drivers/usb/storage" \
             "=drivers/pci/host" \
+            "=drivers/pci/controller" \
             ${NULL}
 
         instmods \


### PR DESCRIPTION
Currently there is no usb support on RPi4 in the
initrd phase as the pcie-brcmstb module is missing.
If part of the boot is handled from a USB stick
(e.g. with Ignition), the stick cannot be accessed.

Reference: boo#1162669