### PR TITLE
Consider also drm_dev_register when looking for gpu driver

### DIFF
--- a/modules.d/50drm/module-setup.sh
+++ b/modules.d/50drm/module-setup.sh
@@ -40,6 +40,6 @@ installkernel() {
             fi
         done
     else
-        dracut_instmods -o -s "drm_crtc_init" "=drivers/gpu/drm" "=drivers/staging"
+        dracut_instmods -o -s "drm_crtc_init|drm_dev_register" "=drivers/gpu/drm" "=drivers/staging"
     fi
 }


### PR DESCRIPTION
DRM drivers are filtered for drm_crtc_init symbol,
but not all drivers use it. Especially, cirrus driver
doesn't use it since Linux 5.2.

The practical result is text plymouth theme instead of graphical when in qemu.

Fix it by looking also for drm_dev_register symbol.
Suggested by @haraldh
Fixes #712