### PR TITLE
95znet: Add a rd.znet_ifname= option

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -863,6 +863,11 @@ ZNET
     RHEL/Fedora with ccw_init, which is called from udev for certain
     devices on z-series.
     rd.znet can be specified multiple times on the kernel command line.
+
+**rd.znet_ifname=**__<ifname>__:__<subchannels>__::
+    Assign network device name <interface> (i.e. "bootnet") to the NIC
+    corresponds to the subchannels. This is useful when dracut's default
+    "ifname=" doesn't work due to device having a changing MAC address.
 +
 [listing]
 .Example

--- a/modules.d/95znet/parse-ccw.sh
+++ b/modules.d/95znet/parse-ccw.sh
@@ -4,4 +4,22 @@ for ccw_arg in $(getargs rd.ccw -d 'rd_CCW=') $(getargs rd.znet -d 'rd_ZNET='); 
     echo $ccw_arg >> /etc/ccw.conf
 done
 
+for ifname in $(getargs rd.znet_ifname); do
+    IFS=: read ifname_if ifname_subchannels _rest <<< "$ifname"
+    if [ -z "$ifname_if" ] || [ -z "$ifname_subchannels" ] || [ -n "$_rest" ]; then
+        warn "Invalid arguments for rd.znet_ifname="
+    else
+        {
+            ifname_subchannels=${ifname_subchannels//,/|}
+
+            echo 'ACTION!="add|change", GOTO="ccw_ifname_end"'
+            echo 'ATTR{type}!="1", GOTO="ccw_ifname_end"'
+            echo 'SUBSYSTEM!="net", GOTO="ccw_ifname_end"'
+            echo "SUBSYSTEMS==\"ccwgroup\", KERNELS==\"$ifname_subchannels\", DRIVERS==\"?*\" NAME=\"$ifname_if\""
+            echo 'LABEL="ccw_ifname_end"'
+
+        } > /etc/udev/rules.d/81-ccw-ifname.rules
+    fi
+done
+
 znet_cio_free


### PR DESCRIPTION
qeth device may have a different IP for each boot, so the rd.ifname=
option will no longer work. So for znet device, introduce a
rd.znet_ifname= options, to subchannel id instead of MAC address as the
identifier and rename the interface.

Signed-off-by: Kairui Song <kasong@redhat.com>