### PR TITLE
Fix pre-trigger stage by replacing exit with return in lldpad.sh

### DIFF
--- a/modules.d/95fcoe/lldpad.sh
+++ b/modules.d/95fcoe/lldpad.sh
@@ -2,7 +2,7 @@
 
 if ! getargbool 0 rd.nofcoe ; then
 	info "rd.nofcoe=0: skipping lldpad activation"
-	exit 0
+	return 0
 fi
 
 # Note lldpad will stay running after switchroot, the system initscripts


### PR DESCRIPTION
Using exit makes the pre-trigger stage finish after running 03-lldpad.sh
pre-trigger hook.