### PR TITLE
95fcoe: default rd.nofcoe to false

### DIFF
--- a/modules.d/95fcoe/lldpad.sh
+++ b/modules.d/95fcoe/lldpad.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if ! getargbool 0 rd.nofcoe ; then
+if getargbool 0 rd.nofcoe ; then
 	info "rd.nofcoe=0: skipping lldpad activation"
 	return 0
 fi

--- a/modules.d/95fcoe/parse-fcoe.sh
+++ b/modules.d/95fcoe/parse-fcoe.sh
@@ -13,7 +13,7 @@
 # fcoe=eth0:nodcb:vn2vn
 # fcoe=4a:3f:4c:04:f8:d7:nodcb:fabric
 
-if ! getargbool 0 rd.nofcoe ; then
+if getargbool 0 rd.nofcoe ; then
 	info "rd.nofcoe=0: skipping fcoe"
 	return 0
 fi


### PR DESCRIPTION
rd.nofcoe should default to false, e.g. fcoe should be enabled unless
overwritten from the command line.
The same applies for lldapd.sh.