### PR TITLE
btrfs: force preload btrfs module

### DIFF
--- a/modules.d/90btrfs/module-setup.sh
+++ b/modules.d/90btrfs/module-setup.sh
@@ -48,5 +48,7 @@ install() {
 
     inst_multiple -o btrfsck btrfs-zero-log
     inst $(command -v btrfs) /sbin/btrfs
+    # Hack for slow machines
+    # see https://github.com/dracutdevs/dracut/issues/658
+    echo "rd.driver.pre=btrfs" > ${initdir}/etc/cmdline.d/00-btrfs.conf
 }
-


### PR DESCRIPTION
fixes https://github.com/dracutdevs/dracut/issues/658

raid6_pq and xor takes time doing benchmarking

[    3.983009] request_module fs-btrfs succeeded, but still no fs?