### PR TITLE
network-manager: ensure that nm-run.sh is executed when needed

### DIFF
--- a/modules.d/35network-manager/nm-config.sh
+++ b/modules.d/35network-manager/nm-config.sh
@@ -5,3 +5,14 @@ if [ -n "$netroot" ] || [ -e /tmp/net.ifaces ]; then
 fi
 
 /usr/libexec/nm-initrd-generator -- $(getcmdline)
+
+if getargbool 0 rd.neednet; then
+  for i in /usr/lib/NetworkManager/system-connections/* \
+           /run/NetworkManager/system-connections/* \
+           /etc/NetworkManager/system-connections/* \
+           /etc/sysconfig/network-scripts/ifcfg-*; do
+    [ -f "$i" ] || continue
+    echo '[ -f /tmp/nm.done ]' >$hookdir/initqueue/finished/nm.sh
+    break
+  done
+fi

--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -22,3 +22,5 @@ do
     source_hook initqueue/online $ifname
     /sbin/netroot $ifname
 done
+
+> /tmp/nm.done


### PR DESCRIPTION
The network-manager command line hook must install a
initqueue/finished hook to ensure that nm-run.sh is executed when
there are network connections to activate.

Fixes: #694