### PR TITLE
dasd: only install /etc/dasd.conf if present

### DIFF
--- a/modules.d/95dasd/module-setup.sh
+++ b/modules.d/95dasd/module-setup.sh
@@ -18,8 +18,9 @@ depends() {
 install() {
     inst_hook cmdline 30 "$moddir/parse-dasd.sh"
     inst_multiple dasdinfo dasdconf.sh normalize_dasd_arg
-    if [[ $hostonly ]]; then
-        inst -H /etc/dasd.conf
+    conf=/etc/dasd.conf
+    if [[ $hostonly && -f $conf ]] ; then
+        inst -H $conf
     fi
     inst_rules 56-dasd.rules
     inst_rules 59-dasd.rules


### PR DESCRIPTION
`dasd.conf` needn't be present on system even if modules have been loaded.

Check if file exists to avoid error message during kernel update
```bash
dracut-install: ERROR: installing '/etc/dasd.conf'
dracut: FAILED: /usr/lib/dracut/dracut-install -D /var/tmp/dracut.YvVRx5/initramfs -H /etc/dasd.conf
```