### PR TITLE
network-manager: install libnss DNS and mDNS plugins

### DIFF
--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -51,4 +51,9 @@ install() {
     if ! [[ -d "$initdir/etc/sysconfig/network-scripts" ]]; then
         inst_libdir_file "NetworkManager/$_nm_version/libnm-settings-plugin-ifcfg-rh.so"
     fi
+
+    _arch=${DRACUT_ARCH:-$(uname -m)}
+
+    inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"libnss_dns.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libnss_mdns4_minimal.so.*"
 }


### PR DESCRIPTION
Install libnss_dns.so and libnss_mdns4_minimal.so plugins for the Name
Service Switch (NSS) functionality of glibc so that name resolution
through /etc/resolv.conf and mDNS works in the initrd.

Fixes: #772