### PR TITLE
Retrieve service, rpc and protcol entries via getent

### DIFF
--- a/modules.d/95cifs/module-setup.sh
+++ b/modules.d/95cifs/module-setup.sh
@@ -37,7 +37,13 @@ install() {
     local _i
     local _nsslibs
     inst_multiple -o mount.cifs
-    inst_multiple /etc/services /etc/nsswitch.conf /etc/protocols
+    inst_multiple /etc/nsswitch.conf
+    if [ $hostonly ]; then
+        getent services > ${initdir}/etc/services
+        getent protocols > ${initdir}/etc/protocols
+    else
+        inst_multiple /etc/services /etc/protocols
+    fi
 
     inst_libdir_file 'libcap-ng.so*'
 

--- a/modules.d/95nfs/module-setup.sh
+++ b/modules.d/95nfs/module-setup.sh
@@ -77,8 +77,16 @@ cmdline() {
 install() {
     local _i
     local _nsslibs
-    inst_multiple -o rpc.idmapd mount.nfs mount.nfs4 umount sed /etc/netconfig chmod "$tmpfilesdir/rpcbind.conf"
-    inst_multiple /etc/services /etc/nsswitch.conf /etc/rpc /etc/protocols /etc/idmapd.conf
+    inst_multiple -o portmap rpcbind rpc.statd mount.nfs \
+        mount.nfs4 umount rpc.idmapd sed /etc/netconfig chmod "$tmpfilesdir/rpcbind.conf"
+    inst_multiple /etc/nsswitch.conf /etc/idmapd.conf
+    if [ $hostonly ]; then
+        getent services > ${initdir}/etc/services
+        getent protocols > ${initdir}/etc/protocols
+        getent rpc > ${initdir}/etc/rpc
+    else
+        inst_multiple /etc/services /etc/protocols /etc/rpc
+    fi
 
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _netconf="$(cmdline)"

--- a/modules.d/95nfs/module-setup.sh
+++ b/modules.d/95nfs/module-setup.sh
@@ -122,7 +122,8 @@ install() {
     inst "$moddir/nfs-lib.sh" "/lib/nfs-lib.sh"
     mkdir -m 0755 -p "$initdir/var/lib/nfs/rpc_pipefs"
     mkdir -m 0770 -p "$initdir/var/lib/rpcbind"
-    mkdir -m 0755 -p "$initdir/var/lib/nfs/statd/sm"
+    [ -d "$initdir/var/lib/nfs/statd/sm" ] && mkdir -m 0755 -p "$initdir/var/lib/nfs/statd/sm"
+    [ -d "$initdir/var/lib/nfs/sm" ] && mkdir -m 0755 -p "$initdir/var/lib/nfs/sm"
 
     # Rather than copy the passwd file in, just set a user for rpcbind
     # We'll save the state and restart the daemon from the root anyway


### PR DESCRIPTION
Sometimes, systems have more elaborate backends in nsswitch.conf,
the complexity of which we do not want in the initrd. SUSE systems
with atomic for instance, where those files may also reside in /usr/etc.

With this change, the unavaiable nsswitch.conf backends will be silently
ignored, and we still end up with all the information we need.

Reference: boo#1165366