### PR TITLE
multipath: add automatic configuration for multipath

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -431,6 +431,9 @@ MULTIPATH
 **rd.multipath=0**::
    disable multipath detection
 
+**rd.multipath=default**::
+   use default multipath settings
+
 FIPS
 ~~~~
 **rd.fips**::

--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -83,11 +83,12 @@ install() {
         dmsetup \
         kpartx \
         mpath_wait \
+        mpathconf \
+        mpathpersist \
         multipath  \
         multipathd \
-        mpathpersist \
-        xdrgetuid \
         xdrgetprio \
+        xdrgetuid \
         /etc/xdrdevices.conf \
         /etc/multipath.conf \
         /etc/multipath/* \
@@ -109,7 +110,9 @@ install() {
     fi
 
     if dracut_module_included "systemd"; then
+        inst_simple "${moddir}/multipathd-configure.service" "${systemdsystemunitdir}/multipathd-configure.service"
         inst_simple "${moddir}/multipathd.service" "${systemdsystemunitdir}/multipathd.service"
+        systemctl -q --root "$initdir" enable multipathd-configure.service
         systemctl -q --root "$initdir" enable multipathd.service
     else
         inst_hook pre-trigger 02 "$moddir/multipathd.sh"

--- a/modules.d/90multipath/multipathd-configure.service
+++ b/modules.d/90multipath/multipathd-configure.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Device-Mapper Multipath Default Configuration
+Before=iscsi.service iscsid.service lvm2-activation-early.service
+Wants=systemd-udev-trigger.service systemd-udev-settle.service local-fs-pre.target
+After=systemd-udev-trigger.service systemd-udev-settle.service
+Before=local-fs-pre.target multipathd.service
+DefaultDependencies=no
+Conflicts=shutdown.target
+
+ConditionKernelCommandLine=rd.multipath=default
+ConditionPathExists=!/etc/multipath.conf
+
+[Service]
+Type=oneshot
+ExecStartPre=-/usr/bin/mkdir -p /etc/multipath/multipath.conf.d
+ExecStart=/usr/sbin/mpathconf --enable
+
+[Install]
+WantedBy=sysinit.target

--- a/modules.d/90multipath/multipathd.sh
+++ b/modules.d/90multipath/multipathd.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ "$(getarg rd.multipath)x" == "default" ] && [ ! -e /etc/multipath.conf ]; then
+    mkdir -p /etc/multipath/multipath.conf.d
+    mpathconf --enable
+fi
+
 if getargbool 1 rd.multipath -d -n rd_NO_MULTIPATH && [ -e /etc/multipath.conf ]; then
     modprobe dm-multipath
     multipathd -B || multipathd


### PR DESCRIPTION
Add support for 'rd.multipath=default' for using the default
configuration on boot. The intended purpose for this is to help support
ostree-based image boots from multipathed devices (such as Fedora and
Red Hat CoreOS).