### PR TITLE
Add a --no-switch-root option

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -416,6 +416,7 @@ rearrange_params()
         --long no-hostonly-i18n \
         --long hostonly-i18n \
         --long no-machineid \
+        --long no-switch-root \
         -- "$@")
 
     if (( $? != 0 )); then
@@ -616,6 +617,8 @@ while :; do
                        kernel_image_l="$2";            PARMS_TO_STORE+=" '$2'"; shift;;
         --no-machineid)
                        machine_id_l="no";;
+        --no-switch-root)
+                       no_switch_root_l="yes";;
         --) shift; break;;
 
         *)  # should not even reach this point
@@ -796,6 +799,7 @@ stdloglvl=$((stdloglvl + verbosity_mod_l))
 [[ $uefi_splash_image_l ]] && uefi_splash_image="$uefi_splash_image_l"
 [[ $kernel_image_l ]] && kernel_image="$kernel_image_l"
 [[ $machine_id_l ]] && machine_id="$machine_id_l"
+[[ $no_switch_root_l ]] && no_switch_root="$no_switch_root_l"
 
 if ! [[ $outfile ]]; then
     if [[ $machine_id != "no" ]]; then

--- a/modules.d/01systemd-initrd/initrd-keep.service
+++ b/modules.d/01systemd-initrd/initrd-keep.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Hang in initrd.target
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStart=

--- a/modules.d/01systemd-initrd/module-setup.sh
+++ b/modules.d/01systemd-initrd/module-setup.sh
@@ -30,11 +30,19 @@ install() {
         $systemdsystemunitdir/initrd-fs.target \
         $systemdsystemunitdir/initrd-root-device.target \
         $systemdsystemunitdir/initrd-root-fs.target \
-        $systemdsystemunitdir/initrd-switch-root.target \
-        $systemdsystemunitdir/initrd-switch-root.service \
-        $systemdsystemunitdir/initrd-cleanup.service \
-        $systemdsystemunitdir/initrd-udevadm-cleanup-db.service \
-        $systemdsystemunitdir/initrd-parse-etc.service
+
+    # Only install switch-root related service if switch root is needed
+    if [[ ! "$no_switch_root" ]]; then
+        inst_multiple -o \
+            $systemdsystemunitdir/initrd-switch-root.target \
+            $systemdsystemunitdir/initrd-switch-root.service \
+            $systemdsystemunitdir/initrd-cleanup.service \
+            $systemdsystemunitdir/initrd-udevadm-cleanup-db.service \
+            $systemdsystemunitdir/initrd-parse-etc.service
+
+        # Install a dummy service, skip parsing real root and keep initrd.target
+        inst $moddir/initrd-keep.service $systemdsystemunitdir/initrd-parse-etc.service
+    fi
 
     systemctl -q --root "$initdir" set-default initrd.target
 }

--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -25,5 +25,7 @@ install() {
     inst $moddir/init.sh /squash/init.sh
 
     inst "$moddir/squash-mnt-clear.service" "$systemdsystemunitdir/squash-mnt-clear.service"
-    systemctl -q --root "$initdir" add-wants initrd-switch-root.target squash-mnt-clear.service
+    if [[ ! $no_switch_root ]]; then
+        systemctl -q --root "$initdir" add-wants initrd-switch-root.target squash-mnt-clear.service
+    fi
 }


### PR DESCRIPTION
    Previously I added a dracut_no_switch_root helper to indicate some
    modules that the initramfs will no do swith root. To further extend the
    support for switch-root less initramfs, introduce an argument to avoid
    install some files.
    
    Some special user like kdump may run into strange race condition when
    systemd try to reload the config in the real root, this will mask the
    service for doing that, also drop other unneeded services.
    
    Signed-off-by: Kairui Song <kasong@redhat.com>