### PR TITLE
TEST-99: exclude /etc/dnf/* from check

### DIFF
--- a/test/TEST-99-RPM/test.sh
+++ b/test/TEST-99-RPM/test.sh
@@ -84,6 +84,7 @@ find / -xdev -type f -not -path '/var/*' \
   -not -path "/boot/loader/entries/\$(cat /etc/machine-id)-*" \
   -not -path "/boot/\$(cat /etc/machine-id)/*" \
   -not -path '/etc/openldap/certs/*' \
+  -not -path '/etc/dnf/*' \
   -print0 | xargs -0 rpm -qf | \
   grep -F 'not owned' &>> /test.output || :
 exit 0


### PR DESCRIPTION
file /etc/dnf/modules.d/eclipse.module.rpmmoved is not owned by any package