### PR TITLE
Don't start rngd if there is no hardware entropy generator

### DIFF
--- a/modules.d/06rngd/rngd.service
+++ b/modules.d/06rngd/rngd.service
@@ -2,6 +2,7 @@
 Description=Hardware RNG Entropy Gatherer Daemon
 DefaultDependencies=no
 Before=systemd-udevd.service
+ConditionPathExists=/dev/hw_random
 
 [Service]
 ExecStart=/usr/sbin/rngd -f


### PR DESCRIPTION
rngd requires a hardware random generator device:
```
-r, --rng-device=file      Kernel device used for random number input
                             (default: /dev/hw_random)
```
But it is not present in virtual machines and multiple hardware paltforms.
It leads to rngd.service being failed in initrd.
Let's stop trying to run rngd if default device /dev/hw_random does not exist.