### PR TITLE
01bootetc: introduce module for updating dracut etc

### DIFF
--- a/dracut.spec
+++ b/dracut.spec
@@ -343,6 +343,7 @@ install -m 0755 51-dracut-rescue-postinst.sh $RPM_BUILD_ROOT%{_sysconfdir}/kerne
 %if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version}
 %{dracutlibdir}/modules.d/01fips
 %endif
+%{dracutlibdir}/modules.d/01bootetc
 %{dracutlibdir}/modules.d/01systemd-initrd
 %{dracutlibdir}/modules.d/03modsign
 %{dracutlibdir}/modules.d/03rescue

--- a/modules.d/01bootetc/boot-etc.service
+++ b/modules.d/01bootetc/boot-etc.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Update initramfs etc
+Before=iscsi.service iscsid.service lvm2-activation-early.service
+Wants=systemd-udev-trigger.service systemd-udev-settle.service local-fs-pre.target
+After=systemd-udev-trigger.service systemd-udev-settle.service
+Before=local-fs-pre.target dracut-initqueue.service
+
+DefaultDependencies=no
+Conflicts=shutdown.target
+
+ConditionKernelCommandLine=bootetc
+ConditionPathExists=!/run/bootetc.done
+
+[Service]
+Type=oneshot
+ExecStart=/sbin/boot-etc
+ExecStart=/usr/bin/touch /run/bootetc.done
+
+[Install]
+WantedBy=sysinit.target

--- a/modules.d/01bootetc/boot-etc.sh
+++ b/modules.d/01bootetc/boot-etc.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+. /lib/dracut-lib.sh
+
+bootetc=$(getarg bootetc=)
+if [ "${bootetc}x" == "x" ]; then
+    exit 0
+fi
+
+mount_boot bootetc
+if [ -d /boot/initrd-etc ] && [ ! -f /run/bootetc.done ]; then
+    info "bootetc: Updating initramfs etc from ${bootetc}/initrd-etc"
+    copytree /boot/initrd-etc /etc
+    touch /run/bootetc.done
+
+    if [ -z "$DRACUT_SYSTEMD" ]; then
+        systemctl try-restart dracut-cmdline.service
+        systemctl try-restart systemd-udev-trigger.service
+    fi
+fi
+
+umount /boot >/dev/null 2>&1

--- a/modules.d/01bootetc/module-setup.sh
+++ b/modules.d/01bootetc/module-setup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+    return 0
+}
+
+# called by dracut
+depends() {
+    return 0
+}
+
+# called by dracut
+install() {
+    inst_simple "$moddir/boot-etc.sh" "/sbin/boot-etc"
+
+    if dracut_module_included "systemd"; then
+        inst_simple "${moddir}/boot-etc.service" "${systemdsystemunitdir}/boot-etc.service"
+        systemctl -q --root "$initdir" enable boot-etc.service
+    else
+        inst_hook pre-trigger 01 "$moddir/boot-etc.sh"
+    fi
+
+}

--- a/modules.d/01fips/fips-boot.sh
+++ b/modules.d/01fips/fips-boot.sh
@@ -6,7 +6,7 @@ elif [ -z "$fipsmode" ]; then
     die "FIPS mode have to be enabled by 'fips=1' not just 'fips'"
 elif getarg boot= >/dev/null; then
     . /sbin/fips.sh
-    if mount_boot; then
+    if mount_boot boot fips=1; then
         do_fips || die "FIPS integrity test failed"
     fi
 fi

--- a/modules.d/01fips/fips-noboot.sh
+++ b/modules.d/01fips/fips-noboot.sh
@@ -6,6 +6,6 @@ elif [ -z "$fipsmode" ]; then
     die "FIPS mode have to be enabled by 'fips=1' not just 'fips'"
 elif ! [ -f /tmp/fipsdone ]; then
     . /sbin/fips.sh
-    mount_boot
+    mount_boot boot fips=1
     do_fips || die "FIPS integrity test failed"
 fi

--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -1,58 +1,5 @@
 #!/bin/sh
 
-mount_boot()
-{
-    boot=$(getarg boot=)
-
-    if [ -n "$boot" ]; then
-        case "$boot" in
-        LABEL=*)
-            boot="$(echo $boot | sed 's,/,\\x2f,g')"
-            boot="/dev/disk/by-label/${boot#LABEL=}"
-            ;;
-        UUID=*)
-            boot="/dev/disk/by-uuid/${boot#UUID=}"
-            ;;
-        PARTUUID=*)
-            boot="/dev/disk/by-partuuid/${boot#PARTUUID=}"
-            ;;
-        PARTLABEL=*)
-            boot="/dev/disk/by-partlabel/${boot#PARTLABEL=}"
-            ;;
-        /dev/*)
-            ;;
-        *)
-            die "You have to specify boot=<boot device> as a boot option for fips=1" ;;
-        esac
-
-        if ! [ -e "$boot" ]; then
-            udevadm trigger --action=add >/dev/null 2>&1
-            [ -z "$UDEVVERSION" ] && UDEVVERSION=$(udevadm --version)
-            i=0
-            while ! [ -e $boot ]; do
-                if [ $UDEVVERSION -ge 143 ]; then
-                    udevadm settle --exit-if-exists=$boot
-                else
-                    udevadm settle --timeout=30
-                fi
-                [ -e $boot ] && break
-                sleep 0.5
-                i=$(($i+1))
-                [ $i -gt 40 ] && break
-            done
-        fi
-
-        [ -e "$boot" ] || return 1
-
-        mkdir /boot
-        info "Mounting $boot as /boot"
-        mount -oro "$boot" /boot || return 1
-    elif [ -d "$NEWROOT/boot" ]; then
-        rm -fr -- /boot
-        ln -sf "$NEWROOT/boot" /boot
-    fi
-}
-
 do_rhevh_check()
 {
     KERNEL=$(uname -r)

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -1300,3 +1300,59 @@ remove_hostonly_files() {
         done < /lib/dracut/hostonly-files
     fi
 }
+
+mount_boot() {
+    boot_flag="$1"; shift;
+    calling_args="${@}"
+
+    boot=$(getarg $boot_flag=)
+    if [ -n "$boot" ]; then
+        case "$boot" in
+        LABEL=*)
+            boot="$(echo $boot | sed 's,/,\\x2f,g')"
+            boot="/dev/disk/by-label/${boot#LABEL=}"
+            ;;
+        UUID=*)
+            boot="/dev/disk/by-uuid/${boot#UUID=}"
+            ;;
+        PARTUUID=*)
+            boot="/dev/disk/by-partuuid/${boot#PARTUUID=}"
+            ;;
+        PARTLABEL=*)
+            boot="/dev/disk/by-partlabel/${boot#PARTLABEL=}"
+            ;;
+        /dev/*)
+            die "You have to specify $boot_flag=<boot device> as a boot option${calling_args:+ for $calling_args}"
+            ;;
+        *)
+            die "${die_msg}"
+            ;;
+        esac
+
+        if ! [ -e "$boot" ]; then
+            udevadm trigger --action=add >/dev/null 2>&1
+            [ -z "$UDEVVERSION" ] && UDEVVERSION=$(udevadm --version)
+            i=0
+            while ! [ -e $boot ]; do
+                if [ $UDEVVERSION -ge 143 ]; then
+                    udevadm settle --exit-if-exists=$boot
+                else
+                    udevadm settle --timeout=30
+                fi
+                [ -e $boot ] && break
+                sleep 0.5
+                i=$(($i+1))
+                [ $i -gt 40 ] && break
+            done
+        fi
+
+        [ -e "$boot" ] || return 1
+
+        mkdir -p /boot
+        info "Mounting $boot as /boot"
+        mount -oro "$boot" /boot || return 1
+    elif [ -d "$NEWROOT/boot" ]; then
+        rm -fr -- /boot
+        ln -sf "$NEWROOT/boot" /boot
+    fi
+}


### PR DESCRIPTION
This provides support for updating '/etc/' in the initramfs using
'bootetc=<DEVICE>'. If the device has the path '/initrd-etc', then the
tree is copied into the initramfs.

The purpose of bootetc is to aide immutable operating systems like
Fedora and Red Hat CoreOS that ship static initrds with a path for
user-provided configuration. Example use cases include udev rules, iSCSI
and multipath configuration, fips and Network Manager configurations.