### PR TITLE
i18n: Always install /etc/vconsole.conf

### DIFF
--- a/modules.d/10i18n/module-setup.sh
+++ b/modules.d/10i18n/module-setup.sh
@@ -230,9 +230,7 @@ install() {
             print_vars LC_ALL LANG >> ${initdir}${I18N_CONF}
         fi
 
-        if dracut_module_included "systemd" && [[ -f $dracutsysrootdir${VCONFIG_CONF} ]]; then
-            inst_simple ${VCONFIG_CONF}
-        else
+        if ! dracut_module_included "systemd"; then
             mksubdirs ${initdir}${VCONFIG_CONF}
             print_vars KEYMAP EXT_KEYMAPS UNICODE FONT FONT_MAP FONT_UNIMAP >> ${initdir}${VCONFIG_CONF}
         fi
@@ -262,6 +260,11 @@ install() {
 
     if checks; then
         install_base
+
+        # https://github.com/dracutdevs/dracut/issues/796
+        if dracut_module_included "systemd" && [[ -f $dracutsysrootdir${VCONFIG_CONF} ]]; then
+            inst_simple ${VCONFIG_CONF}
+        fi
 
         if [[ ${hostonly} ]] && ! [[ ${i18n_install_all} == "yes" ]]; then
             install_local_i18n || install_all_kbd


### PR DESCRIPTION
/etc/vconsole.conf must be installed always, even in generic initrds, not only host-only ones.
systemd-vconsole-setup is run at initrd stage and expects either /etc/vconsole.conf or kernel cmdline options to exist.

I have also proposed a change in systemd-vconsole-setup that makes it behave better if /etc/vconsole.conf does not exist:
https://github.com/systemd/systemd/pull/15479
But it is just a fallback. If /etc/vconsole.conf does not exist in initrd and if that patch is applied on systemd,
then the default consoel font is set despite the one being set in /etc/vconsole.conf and this setting is inherited
when new TTYs are opened. This leads to full ignorance of settings in /etc/vconsole.conf.
It is incorrect, and that is why this file must be copied to initrds always, but not only on host-only initrds.

Fixes: https://github.com/dracutdevs/dracut/issues/796