### PR TITLE
systemd: skip dependency add for non-existent units

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -241,6 +241,7 @@ install() {
         systemd-ask-password-console.service \
         systemd-ask-password-plymouth.service \
         ; do
+        [[ -f $systemdsystemunitdir/$i ]] || continue
         systemctl -q --root "$initdir" add-wants "$i" systemd-vconsole-setup.service
     done
 


### PR DESCRIPTION
Fixes: https://github.com/dracutdevs/dracut/issues/795