### PR TITLE
Always pull in machinery to read ifcfg files

### DIFF
--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -47,10 +47,8 @@ install() {
     fi
 
     # We don't install the ifcfg files from the host automatically.
-    # But if the user chooses to include them, we pull in the machinery to read them.
-    if ! [[ -d "$initdir/etc/sysconfig/network-scripts" ]]; then
-        inst_libdir_file "NetworkManager/$_nm_version/libnm-settings-plugin-ifcfg-rh.so"
-    fi
+    # But the user might choose to include them, so we pull in the machinery to read them.
+    inst_libdir_file "NetworkManager/$_nm_version/libnm-settings-plugin-ifcfg-rh.so"
 
     _arch=${DRACUT_ARCH:-$(uname -m)}
 


### PR DESCRIPTION
So far machinery is only pulled in if the user has not yet included any ifcfg files.

Noticed when boot failed after changing my custom module's prefix to be loaded before other modules.
The current code contradicts the code and depends on when user decides  to add ifcfg files.
I therefore believe that it would be better to simply always pull in the required library.