### PR TITLE
Install crypto modules in 90kernel-modules

### DIFF
--- a/modules.d/90btrfs/module-setup.sh
+++ b/modules.d/90btrfs/module-setup.sh
@@ -26,8 +26,6 @@ depends() {
 # called by dracut
 installkernel() {
     instmods btrfs
-    # Make sure btfs can use fast crc32c implementations where available (bsc#1011554)
-    instmods crc32c-intel
 }
 
 # called by dracut

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -25,11 +25,7 @@ depends() {
 # called by dracut
 installkernel() {
     hostonly="" instmods drbg
-    arch=$(uname -m)
-    [[ $arch == x86_64 ]] && arch=x86
-    [[ $arch == s390x ]] && arch=s390
-    [[ $arch == aarch64 ]] && arch=arm64
-    instmods dm_crypt =crypto =drivers/crypto =arch/$arch/crypto
+    instmods dm_crypt
 }
 
 # called by dracut

--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -104,6 +104,15 @@ installkernel() {
         elif [[ "${host_fs_types[*]}" ]]; then
             hostonly='' instmods "${host_fs_types[@]}"
         fi
+
+        arch=${DRACUT_ARCH:-$(uname -m)}
+
+        # We don't want to play catch up with hash and encryption algorithms.
+        # To be safe, just use the hammer and include all crypto.
+        [[ $arch == x86_64 ]] && arch=x86
+        [[ $arch == s390x ]] && arch=s390
+        [[ $arch == aarch64 ]] && arch=arm64
+        instmods "=crypto" "=arch/$arch/crypto" "=drivers/crypto"
     fi
     :
 }


### PR DESCRIPTION
We don't want to play catch up with hash and encryption algorithms.
To be safe, just use the hammer and include all crypto.

Fixes https://github.com/dracutdevs/dracut/issues/802