### PR TITLE
90kernel-modules/module-setup.sh: add sg kernel module

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -25,7 +25,7 @@ installkernel() {
     }
 
     install_block_modules () {
-        hostonly='' instmods sr_mod sd_mod scsi_dh ata_piix
+        hostonly='' instmods sg sr_mod sd_mod scsi_dh ata_piix
         instmods \
             scsi_dh_rdac scsi_dh_emc scsi_dh_alua \
             =ide nvme vmd \


### PR DESCRIPTION
Fixes udevd messages about failure of `modprobe -bv sg`.