### PR TITLE
90crypt/module-setup.sh: fix force on multiple lines

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -113,6 +113,7 @@ install() {
             set -- ${luksoptions}
             IFS="${OLD_IFS}"
 
+            forceentry=""
             while [ $# -gt 0 ]; do
                 case $1 in
                     force)


### PR DESCRIPTION
The first line in crypttab with a `force` option causes all subsequent lines to be included as if they also had it set because the variable used to track it is not reset between loop iterations.  So fix that by just setting it to empty before the check for the force option.