### PR TITLE
Fix test in lsinitrd

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -206,7 +206,7 @@ if [ "$bin" = "MZ" ]; then
 fi
 
 if (( ${#filenames[@]} <= 0 )) && [[ -z "$unpack" ]] && [[ -z "$unpackearly" ]]; then
-    if [ -n $uefi ]; then
+    if [ -n "$uefi" ]; then
         echo -n "initrd in UEFI: $uefi: "
         du -h $image | while read a b || [ -n "$a" ]; do echo $a;done
         if [ -f "$TMPDIR/osrel.txt" ]; then


### PR DESCRIPTION
If `$uefi` is empty, this evaluated to true previously,
resulting in `initrd in UEFI: : 13M`.