### PR TITLE
51-dracut-rescue.install: Don't use BLS fragment shipped by kernel pa…

### DIFF
--- a/51-dracut-rescue.install
+++ b/51-dracut-rescue.install
@@ -106,7 +106,11 @@ case "$COMMAND" in
                 echo "initrd     $BOOT_DIR/initrd"
             } > $LOADER_ENTRY
         else
-            cp -aT "${KERNEL_IMAGE%/*}/bls.conf" $LOADER_ENTRY
+            if [[ -e "${BLS_DIR}/${MACHINE_ID}-${KERNEL_VERSION}.conf" ]]; then
+                cp -aT "${BLS_DIR}/${MACHINE_ID}-${KERNEL_VERSION}.conf" $LOADER_ENTRY
+            else
+                cp -aT "${KERNEL_IMAGE%/*}/bls.conf" $LOADER_ENTRY
+            fi
             sed -i 's/'$KERNEL_VERSION'/0-rescue-'${MACHINE_ID}'/' $LOADER_ENTRY
         fi
 


### PR DESCRIPTION
…ckage

For the GRUB and zipl bootloaders the BLS fragment that is shipped by the
kernel package is used, so the same fragment is used for the rescue entry.

But there are cases where this BLS fragment is not suitable. For example,
if the boot directory is on a btrfs subvolume the path in the linux and
initrd fiels need to be adjusted with the real path. Otherwise GRUB won't
be able to read them.

The GRUB and zipl kernel-install plugins already take care of this before
installing the BLS fragments, so just copy the installed fragment that has
the updated paths instead of using the BLS shipped by the kernel package.

Resolves: rhbz#1827882

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>