### PR TITLE
rngd: install dependant libs too

### DIFF
--- a/modules.d/06rngd/module-setup.sh
+++ b/modules.d/06rngd/module-setup.sh
@@ -33,6 +33,8 @@ check() {
 install() {
     inst rngd
     inst_simple "${moddir}/rngd.service" "${systemdsystemunitdir}/rngd.service"
+    # make sure dependant libs are installed too
+    inst_libdir_file opensc-pkcs11.so
 
     systemctl -q --root "$initdir" add-wants sysinit.target rngd.service
 }


### PR DESCRIPTION
By default rng-tools are compiled with pkcs11 support.
Make sure opensc-pkcs11.so library is installed inside initramfs to prevent error on boot