### PR TITLE
98dracut-systemd: Display stdout on console as well

### DIFF
--- a/modules.d/98dracut-systemd/dracut-cmdline.service
+++ b/modules.d/98dracut-systemd/dracut-cmdline.service
@@ -23,7 +23,7 @@ Environment=NEWROOT=/sysroot
 Type=oneshot
 ExecStart=-/bin/dracut-cmdline
 StandardInput=null
-StandardOutput=syslog
+StandardOutput=syslog+console
 StandardError=syslog+console
 KillMode=process
 RemainAfterExit=yes

--- a/modules.d/98dracut-systemd/dracut-initqueue.service
+++ b/modules.d/98dracut-systemd/dracut-initqueue.service
@@ -21,7 +21,7 @@ Environment=NEWROOT=/sysroot
 Type=oneshot
 ExecStart=-/bin/dracut-initqueue
 StandardInput=null
-StandardOutput=syslog
+StandardOutput=syslog+console
 StandardError=syslog+console
 KillMode=process
 RemainAfterExit=yes

--- a/modules.d/98dracut-systemd/dracut-mount.service
+++ b/modules.d/98dracut-systemd/dracut-mount.service
@@ -19,7 +19,7 @@ Environment=NEWROOT=/sysroot
 Type=oneshot
 ExecStart=-/bin/dracut-mount
 StandardInput=null
-StandardOutput=syslog
+StandardOutput=syslog+console
 StandardError=syslog+console
 KillMode=process
 RemainAfterExit=yes

--- a/modules.d/98dracut-systemd/dracut-pre-mount.service
+++ b/modules.d/98dracut-systemd/dracut-pre-mount.service
@@ -19,7 +19,7 @@ Environment=NEWROOT=/sysroot
 Type=oneshot
 ExecStart=-/bin/dracut-pre-mount
 StandardInput=null
-StandardOutput=syslog
+StandardOutput=syslog+console
 StandardError=syslog+console
 KillMode=process
 RemainAfterExit=yes

--- a/modules.d/98dracut-systemd/dracut-pre-pivot.service
+++ b/modules.d/98dracut-systemd/dracut-pre-pivot.service
@@ -27,7 +27,7 @@ Environment=NEWROOT=/sysroot
 Type=oneshot
 ExecStart=-/bin/dracut-pre-pivot
 StandardInput=null
-StandardOutput=syslog
+StandardOutput=syslog+console
 StandardError=syslog+console
 KillMode=process
 RemainAfterExit=yes

--- a/modules.d/98dracut-systemd/dracut-pre-trigger.service
+++ b/modules.d/98dracut-systemd/dracut-pre-trigger.service
@@ -20,7 +20,7 @@ Environment=NEWROOT=/sysroot
 Type=oneshot
 ExecStart=-/bin/dracut-pre-trigger
 StandardInput=null
-StandardOutput=syslog
+StandardOutput=syslog+console
 StandardError=syslog+console
 KillMode=process
 RemainAfterExit=yes

--- a/modules.d/98dracut-systemd/dracut-pre-udev.service
+++ b/modules.d/98dracut-systemd/dracut-pre-udev.service
@@ -24,7 +24,7 @@ Environment=NEWROOT=/sysroot
 Type=oneshot
 ExecStart=-/bin/dracut-pre-udev
 StandardInput=null
-StandardOutput=syslog
+StandardOutput=syslog+console
 StandardError=syslog+console
 KillMode=process
 RemainAfterExit=yes


### PR DESCRIPTION
This fixes the behavior of info() on systems with systemd,
and matches it to the SysVinit behavior.

Previously, stdout would go exclusively to journal/syslog,
rendering info messages useless for situations where the system
would fail to boot up (e.g. fips).