### PR TITLE
dracut.cmdline.7.asc: clarify usage of `rd.lvm.vg` and `rd.lvm.lv`

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -281,12 +281,12 @@ LVM
     disable LVM detection
 
 **rd.lvm.vg=**__<volume group name>__::
-    only activate the volume groups with the given name. rd.lvm.vg can be
-    specified multiple times on the kernel command line.
+    only activate all logical volumes in the the volume groups with the given name.
+    rd.lvm.vg can be specified multiple times on the kernel command line.
 
-**rd.lvm.lv=**__<logical volume name>__::
-    only activate the logical volumes with the given name. rd.lvm.lv can be
-    specified multiple times on the kernel command line.
+**rd.lvm.lv=**__<volume group name>/<logical volume name>__::
+    only activate the logical volumes with the given name.
+    rd.lvm.lv can be specified multiple times on the kernel command line.
 
 **rd.lvm.conf=0**::
     remove any _/etc/lvm/lvm.conf_, which may exist in the initramfs


### PR DESCRIPTION
Fixes: https://github.com/dracutdevs/dracut/issues/816