### PR TITLE
network-manager: set kernel hostname from the command line

### DIFF
--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -10,6 +10,10 @@ for i in /usr/lib/NetworkManager/system-connections/* \
   else
       /usr/sbin/NetworkManager --configure-and-quit=initrd --no-daemon
   fi
+
+  if [ -s /run/NetworkManager/initrd/hostname ]; then
+      cat /run/NetworkManager/initrd/hostname > /proc/sys/kernel/hostname
+  fi
   break
 done
 


### PR DESCRIPTION
Since commit ff70adf873ef ("initrd: save hostname to a file in /run"),
the initrd generator of NetworkManager parses the hostname from 'ip='
options of the kernel command line and writes it to
/run/NetworkManager/initrd/hostname.

When that file exists, set the kernel hostname.

In presence of multiple hostnames in the command line, the last one
wins. Hostnames from command line always have precedence over ones
received through DHCP. This is a bit different from the legacy network
module that gives higher precedence to the hostname (from DHCP or
command line) of the last interface that is brought up, which depends
on the udev order.