### PR TITLE
Fips workaround for Fedora/RHEL

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1941,6 +1941,17 @@ if [[ $kernel_only != yes ]]; then
             break 2
         done
     done
+
+    # FIPS workaround for Fedora/RHEL: libcrypto needs libssl when FIPS is enabled
+    if [[ $DRACUT_FIPS_MODE ]]; then
+      for _dir in $libdirs; do
+          for _f in "$dracutsysrootdir$_dir/libcrypto.so"*; do
+              [[ -e "$_f" ]] || continue
+              inst_libdir_file -o "libssl.so*"
+              break 2
+          done
+      done
+    fi
 fi
 
 if [[ $do_strip = yes ]] && ! [[ $DRACUT_FIPS_MODE ]]; then

--- a/dracut.sh
+++ b/dracut.sh
@@ -1661,15 +1661,6 @@ if [[ $kernel_only != yes ]]; then
     # Now we are done with lazy resolving, always install dependencies
     unset DRACUT_RESOLVE_LAZY
     export DRACUT_RESOLVE_DEPS=1
-
-    # libpthread workaround: pthread_cancel wants to dlopen libgcc_s.so
-    for _dir in $libdirs; do
-        for _f in "$dracutsysrootdir$_dir/libpthread.so"*; do
-            [[ -e "$_f" ]] || continue
-            inst_libdir_file "libgcc_s.so*"
-            break 2
-        done
-    done
 fi
 
 for ((i=0; i < ${#include_src[@]}; i++)); do
@@ -1937,6 +1928,17 @@ if dracut_module_included "squash"; then
             if [[ -e $squash_dir${file#$initdir} ]]; then
                 mv $squash_dir${file#$initdir} $file
             fi
+        done
+    done
+fi
+
+if [[ $kernel_only != yes ]]; then
+    # libpthread workaround: pthread_cancel wants to dlopen libgcc_s.so
+    for _dir in $libdirs; do
+        for _f in "$dracutsysrootdir$_dir/libpthread.so"*; do
+            [[ -e "$_f" ]] || continue
+            inst_libdir_file "libgcc_s.so*"
+            break 2
         done
     done
 fi


### PR DESCRIPTION
On Fedora/RHEL, libcryto will verify both itself and libssl on start, if
libssl is missing, FIPS self test will fail. However libssl is not a
dependency of libcryto so dracut will not install it, unless some other
binary or library pulls it in. Systemd requires libssl, so in most cases
it just worked, but could fail in some corner cases where systemd is not
used.