### PR TITLE
95iscsi: fix missing space when compiling cmdline args

### DIFF
--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -65,7 +65,7 @@ install_ibft() {
             if [ ${d##*/} = "ibft" ] && [ "$ibft_mod" != "bnx2i" ] ; then
                 echo -n "rd.iscsi.ibft=1 "
             fi
-            echo -n "rd.iscsi.firmware=1"
+            echo -n "rd.iscsi.firmware=1 "
         fi
     done
 }


### PR DESCRIPTION
Reference: bsc#1172816