### PR TITLE
FIPS fixes

### DIFF
--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -69,6 +69,14 @@ do_rhevh_check()
     return 0
 }
 
+nonfatal_modprobe()
+{
+    modprobe $1 2>&1 > /dev/stdout |
+        while read -r line || [ -n "$line" ]; do
+            echo "${line#modprobe: FATAL: }" >&2
+        done
+}
+
 fips_load_crypto()
 {
     FIPSMODULES=$(cat /etc/fipsmodules)
@@ -77,7 +85,7 @@ fips_load_crypto()
     mv /etc/modprobe.d/fips.conf /etc/modprobe.d/fips.conf.bak
     for _module in $FIPSMODULES; do
         if [ "$_module" != "tcrypt" ]; then
-            if ! modprobe "${_module}" 2>/tmp/fips.modprobe_err; then
+            if ! nonfatal_modprobe "${_module}" 2>/tmp/fips.modprobe_err; then
                 # check if kernel provides generic algo
                 _found=0
                 while read _k _s _v || [ -n "$_k" ]; do

--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -1,5 +1,17 @@
 #!/bin/sh
 
+# systemd lets stdout go to journal only, but the system
+# has to halt when the integrity check fails to satisfy FIPS.
+if [ -z "$DRACUT_SYSTEMD" ]; then
+    fips_info() {
+        info "$*"
+    }
+else
+    fips_info() {
+        echo "$*" >&2
+    }
+fi
+
 mount_boot()
 {
     boot=$(getarg boot=)
@@ -45,7 +57,7 @@ mount_boot()
         [ -e "$boot" ] || return 1
 
         mkdir /boot
-        info "Mounting $boot as /boot"
+        fips_info "Mounting $boot as /boot"
         mount -oro "$boot" /boot || return 1
     elif [ -d "$NEWROOT/boot" ]; then
         rm -fr -- /boot
@@ -65,7 +77,7 @@ do_rhevh_check()
         warn "HMAC sum mismatch"
         return 1
     fi
-    info "rhevh_check OK"
+    fips_info "rhevh_check OK"
     return 0
 }
 
@@ -81,7 +93,7 @@ fips_load_crypto()
 {
     FIPSMODULES=$(cat /etc/fipsmodules)
 
-    info "Loading and integrity checking all crypto modules"
+    fips_info "Loading and integrity checking all crypto modules"
     mv /etc/modprobe.d/fips.conf /etc/modprobe.d/fips.conf.bak
     for _module in $FIPSMODULES; do
         if [ "$_module" != "tcrypt" ]; then
@@ -100,7 +112,7 @@ fips_load_crypto()
     done
     mv /etc/modprobe.d/fips.conf.bak /etc/modprobe.d/fips.conf
 
-    info "Self testing crypto algorithms"
+    fips_info "Self testing crypto algorithms"
     modprobe tcrypt || return 1
     rmmod tcrypt
 }
@@ -114,7 +126,7 @@ do_fips()
 
     KERNEL=$(uname -r)
 
-    info "Checking integrity of kernel"
+    fips_info "Checking integrity of kernel"
     if [ -e "/run/initramfs/live/vmlinuz0" ]; then
         do_rhevh_check /run/initramfs/live/vmlinuz0 || return 1
     elif [ -e "/run/initramfs/live/isolinux/vmlinuz0" ]; then
@@ -153,7 +165,7 @@ do_fips()
         (cd "${BOOT_IMAGE_HMAC%/*}" && sha512hmac -c "${BOOT_IMAGE_HMAC}") || return 1
     fi
 
-    info "All initrd crypto checks done"
+    fips_info "All initrd crypto checks done"
 
     > /tmp/fipsdone
 


### PR DESCRIPTION
Two semi-related fixes for FIPS:

The first tries removes the FATAL modprobe output. It turned out to be confusing to users, as it's not fatal in the FIPS context.

The second one supersedes #826. I found it hard to get rid of the informative output, so here is fips_info(), which is info, but to stderr.