### PR TITLE
Send DHCP on single device to improve boot time

### DIFF
--- a/modules.d/35network-legacy/parse-ip-opts.sh
+++ b/modules.d/35network-legacy/parse-ip-opts.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # Format:
-#       ip=[dhcp|on|any]
+#       ip=[dhcp|on|any|single-dhcp]
 #
 #       ip=<interface>:[dhcp|on|any][:[<mtu>][:<macaddr>]]
 #
@@ -77,7 +77,7 @@ for p in $(getargs ip=); do
                 ;;
             auto6);;
             either6);;
-            dhcp|dhcp6|on|any) \
+            dhcp|dhcp6|on|any|single-dhcp) \
                 [ -n "$NEEDBOOTDEV" ] && [ -z "$dev" ] && \
                     die "Sorry, 'ip=$p' does not make sense for multiple interface configurations"
                 [ -n "$ip" ] && \


### PR DESCRIPTION
devices, on which DHCP is sent. However, in most cases, only the
first one succeeds (the one for the minimum BDF device).
The second one keeps re-trying DHCP, adding almost a minute to
the bootup time, before failing. This patch sends DHCP only for
the minimum BDF device.
This is enabled only when we add ip=single-dhcp in kernel command
parameters. If the DHCP fails on minimum BDF device for some
reason, we keep note of this failed device in
/run/initramfs/dhcpfaildev. This will ensure correctness for the
case when the first device passed to ifup.sh was the minimum BDF,
but it failed; then subsequent calls to ifup.sh for other devices
will skip using the minimum BDF device for sending DHCP, and
choose another device.
Where applicable, this patch gives an improvement of about 1
minute to the system bootup time.