### PR TITLE
95nvmf: add NVMe over TCP support

### DIFF
--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -19,18 +19,40 @@ check() {
             [ -L "$d" ] || continue
             if readlink "$d" | grep -q nvme-fabrics ; then
                 traddr=$(cat "$d"/address)
-		break
-	    fi
-	done
+                break
+            fi
+        done
         [[ "${traddr#traddr=nn-}" != "$traddr" ]]
+    }
+
+    # XXX: maybe create a "get_nvmf_transport" function?
+    is_nvme_tcp() {
+        local _dev=$1
+        local trtype
+
+        [[ -L "/sys/dev/block/$_dev" ]] || return 0
+        cd -P "/sys/dev/block/$_dev" || return 0
+        if [ -f partition ] ; then
+            cd ..
+        fi
+        for d in device/nvme* ; do
+            [ -L "$d" ] || continue
+            if readlink "$d" | grep -q nvme-fabrics ; then
+                trtype=$(cat "$d"/transport)
+                break
+            fi
+        done
+        [[ "$trtype" == "tcp" ]]
     }
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         pushd . >/dev/null
         for_each_host_dev_and_slaves is_nvme_fc
         local _is_nvme_fc=$?
+        for_each_host_dev_and_slaves is_nvme_tcp
+        local _is_nvme_tcp=$?
         popd >/dev/null
-        [[ $_is_nvme_fc == 0 ]] || return 255
+        [[ $_is_nvme_fc == 0 ]] || [[ $_is_nvme_tcp == 0 ]] || return 255
         if [ ! -f /sys/class/fc/fc_udev_device/nvme_discovery ] ; then
             if [ ! -f /etc/nvme/discovery.conf ] ; then
                 echo "No discovery arguments present"
@@ -43,13 +65,14 @@ check() {
 
 # called by dracut
 depends() {
-    echo bash rootfs-block
+    echo bash rootfs-block network
     return 0
 }
 
 # called by dracut
 installkernel() {
     instmods nvme_fc lpfc qla2xxx
+    hostonly="" instmods nvme_tcp nvme_fabrics
 }
 
 # called by dracut

--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -77,6 +77,8 @@ install() {
     inst_simple "/etc/nvme/hostnqn"
     inst_simple "/etc/nvme/hostid"
 
+    inst_multiple ip sed
+
     inst_multiple nvme
     inst_multiple -o \
         "$systemdsystemunitdir/nvm*-connect@.service" \

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -66,7 +66,7 @@ parse_nvmf_discover() {
     echo "--transport=$trtype --traddr=$traddr --host-traddr=$hosttraddr --trsvcid=$trsvcid" >> /etc/nvme/discovery.conf
 }
 
-if ! getargbool 0 rd.nonvmf ; then
+if getargbool 0 rd.nonvmf ; then
 	info "rd.nonvmf=0: skipping nvmf"
 	return 0
 fi

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -36,33 +36,31 @@ parse_nvmf_discover() {
 
     case $# in
         2)
-            trtype=$1
-            traddr=$2
+            [ ! -z "$1" ] && trtype=$1
+            [ ! -z "$2" ] && traddr=$2
             ;;
         3)
-            trtype=$1
-            traddr=$2
-            hosttraddr=$3
+            [ ! -z "$1" ] && trtype=$1
+            [ ! -z "$2" ] && traddr=$2
+            [ ! -z "$3" ] && hosttraddr=$3
             ;;
         4)
-            trtype=$1
-            traddr=$2
-            hosttraddr=$3
-            trsvcid=$4
+            [ ! -z "$1" ] && trtype=$1
+            [ ! -z "$2" ] && traddr=$2
+            [ ! -z "$3" ] && hosttraddr=$3
+            [ ! -z "$4" ] && trsvcid=$4
             ;;
         *)
             warn "Invalid arguments for nvmf.discover=$1"
             return 1
             ;;
     esac
-    if [ -z "$traddr" ] ; then
+    if [ "$traddr" = "none" ] ; then
         warn "traddr is mandatory for $trtype"
         return 1;
     fi
-    [ -z "$hosttraddr" ] && hosttraddr="none"
-    [ -z "$trsvcid" ] && trsvcid=4420
     if [ "$trtype" = "fc" ] ; then
-        if [ -z "$hosttraddr" ] ; then
+        if [ "$hosttraddr" = "none" ] ; then
             warn "host traddr is mandatory for fc"
             return 1
         fi

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -51,7 +51,7 @@ parse_nvmf_discover() {
         return 1;
     fi
     [ -z "$hosttraddr" ] && hosttraddr="none"
-    [ -z "$trsvcid" ] && trsvcid="none"
+    [ -z "$trsvcid" ] && trsvcid=4420
     if [ "$trtype" = "fc" ] ; then
         if [ -z "$hosttraddr" ] ; then
             warn "host traddr is mandatory for fc"
@@ -60,8 +60,6 @@ parse_nvmf_discover() {
     elif [ "$trtype" != "rdma" ] && [ "$trtype" != "tcp" ] ; then
         warn "unsupported transport $trtype"
         return 1
-    elif [ -z "$trsvcid" ] ; then
-        trsvcid=4420
     fi
     echo "--transport=$trtype --traddr=$traddr --host-traddr=$hosttraddr --trsvcid=$trsvcid" >> /etc/nvme/discovery.conf
 }

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -44,9 +44,12 @@ validate_ip_conn() {
         return 1
     fi
 
-    ifname=$(ip -o route get to $iscsi_address | sed -n 's/.*dev \([^ ]*\).*/\1/p')
-
-    # XXX: any way to validate ifname?
+    ifname=$(ip -o route get to $local_address | sed -n 's/.*dev \([^ ]*\).*/\1/p')
+    
+    if ip l show "$ifname" >/dev/null 2>&1 ; then
+       warn "invalid network interface $ifname"
+       return 1
+    fi
 
     # confirm there's a route to destination
     if ip route get "$traddr" >/dev/null 2>&1 ; then
@@ -63,19 +66,19 @@ parse_nvmf_discover() {
 
     case $# in
         2)
-            [ ! -z "$1" ] && trtype=$1
-            [ ! -z "$2" ] && traddr=$2
+            [ -n "$1" ] && trtype=$1
+            [ -n "$2" ] && traddr=$2
             ;;
         3)
-            [ ! -z "$1" ] && trtype=$1
-            [ ! -z "$2" ] && traddr=$2
-            [ ! -z "$3" ] && hosttraddr=$3
+            [ -n "$1" ] && trtype=$1
+            [ -n "$2" ] && traddr=$2
+            [ -n "$3" ] && hosttraddr=$3
             ;;
         4)
-            [ ! -z "$1" ] && trtype=$1
-            [ ! -z "$2" ] && traddr=$2
-            [ ! -z "$3" ] && hosttraddr=$3
-            [ ! -z "$4" ] && trsvcid=$4
+            [ -n "$1" ] && trtype=$1
+            [ -n "$2" ] && traddr=$2
+            [ -n "$3" ] && hosttraddr=$3
+            [ -n "$4" ] && trsvcid=$4
             ;;
         *)
             warn "Invalid arguments for nvmf.discover=$1"


### PR DESCRIPTION
Add support to boot from an NVMe over TCP device.

Example of supported command line formats:

nvme.discover=tcp:192.168.1.3::4420
nvme.discover=tcp:192.168.1.3 # will use 4420 as default svcid

Requires rd.neednet=1

Known issues:
System hangs at shutdown/reboot (SLES 15 SP2). I haven't investigated why yet.

TODO: pull network module only if 'tcp' transport.

Signed-off-by: Enzo Matsumiya <ematsumiya@suse.de>