### PR TITLE
dracut.sh: fix ia32 detection for uefi executables

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1153,7 +1153,7 @@ if [[ ! $print_cmdline ]]; then
         case $(uname -m) in
             x86_64)
                 EFI_MACHINE_TYPE_NAME=x64;;
-            ia32)
+            i?86)
                 EFI_MACHINE_TYPE_NAME=ia32;;
             *)
                 dfatal "Architecture '$(uname -m)' not supported to create a UEFI executable"


### PR DESCRIPTION
As far as I can tell, uname -m will never output ia32, only i386 or i686.