### PR TITLE
mkinitrd-dracut.sh: use vmlinux regex for ppc*, vmlinuz for i686

### DIFF
--- a/mkinitrd-dracut.sh
+++ b/mkinitrd-dracut.sh
@@ -57,10 +57,10 @@ default_kernel_images() {
         s390|s390x)
             regex='image'
             ;;
-        ppc|ppc64)
+        ppc*)
             regex='vmlinux'
             ;;
-        i386|x86_64)
+        i?86|x86_64)
             regex='vmlinuz'
             ;;
         arm*)


### PR DESCRIPTION
Previously this would not catch ppc64le, now it does; same with i686.