### PR TITLE
99shutdown: fix $ACTION failures if underlying systemctl command does not go through

### DIFF
--- a/modules.d/99shutdown/shutdown.sh
+++ b/modules.d/99shutdown/shutdown.sh
@@ -118,7 +118,7 @@ getarg 'rd.break=shutdown' && emergency_shell --shutdown shutdown "Break before 
 
 case "$ACTION" in
     reboot|poweroff|halt)
-        $ACTION -f -n
+        systemctl $ACTION -ff
         warn "$ACTION failed!"
         ;;
     kexec)


### PR DESCRIPTION
Problem:
In 99shutdown, it is possible for $ACTION -f -d -n to fail for reboot/poweroff,
in a situation where the $ACTION depends on systemctl D-Bus to be available.

At this point in the shutdown process, all processes/services are down, all FSs
are umount'd and all services that dictate .need_shutdown are downed by the
_check_shutdown loop. All that remains is to reboot|poweroff|halt the system
and there is no remaining sync, umount, or other shutdown work to be done.

Fix:
Change $ACTION -f -d -n to use systemctl $ACTION -ff to --force --force the
$ACTION. This will bypass any requirement on D-Bus and kick the system in gear.

Closes #869. See #869 for details.