### PR TITLE
dracut.sh: correct x86 machine hardware name

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1153,7 +1153,7 @@ if [[ ! $print_cmdline ]]; then
         case $(uname -m) in
             x86_64)
                 EFI_MACHINE_TYPE_NAME=x64;;
-            ia32)
+            i?86)
                 EFI_MACHINE_TYPE_NAME=ia32;;
             *)
                 dfatal "Architecture '$(uname -m)' not supported to create a UEFI executable"


### PR DESCRIPTION
`uname -m` reports i[34567]86 on x86 machine instead of ia32.