### PR TITLE
90kernel-modules: add pci_hyperv

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -57,7 +57,7 @@ installkernel() {
         instmods \
             yenta_socket \
             atkbd i8042 usbhid firewire-ohci pcmcia hv-vmbus \
-            virtio virtio_ring virtio_pci virtio_scsi \
+            virtio virtio_ring virtio_pci virtio_scsi pci_hyperv \
             "=drivers/pcmcia"
 
         if [[ "${DRACUT_ARCH:-$(uname -m)}" == arm* || "${DRACUT_ARCH:-$(uname -m)}" == aarch64 ]]; then


### PR DESCRIPTION
Install pci_hyperv for SR-IOV devices on hyperv machines.