### PR TITLE
Change the order of NFS servers during the boot

### DIFF
--- a/modules.d/95nfs/nfs-lib.sh
+++ b/modules.d/95nfs/nfs-lib.sh
@@ -112,8 +112,8 @@ nfsroot_from_dhcp() {
     [ -n "$new_root_path" ] && nfsroot_to_var "$nfs:$new_root_path"
     [ -z "$path" ] && [ "$(getarg root=)" = "/dev/nfs" ] && path=/tftpboot/%s
     [ -z "$server" ] && server=$srv
-    [ -z "$server" ] && server=$new_dhcp_server_identifier
     [ -z "$server" ] && server=$new_next_server
+    [ -z "$server" ] && server=$new_dhcp_server_identifier
     [ -z "$server" ] && server=${new_root_path%%:*}
 }
 


### PR DESCRIPTION
NFS server provided by DHCP in next-server option has higher priority than DHCP-server itself.

RH Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1859513