### PR TITLE
35network-legacy: simplify fallback dhcp setup

### DIFF
--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -376,23 +376,6 @@ else
 fi
 
 
-# No ip lines default to dhcp
-ip=$(getarg ip)
-
-if [ -z "$NO_AUTO_DHCP" ] && [ -z "$ip" ]; then
-    if [ "$netroot" = "dhcp6" ]; then
-        do_dhcp -6
-    else
-        do_dhcp -4
-    fi
-
-    for s in $(getargs nameserver); do
-        [ -n "$s" ] || continue
-        echo nameserver $s >> /tmp/net.$netif.resolv.conf
-    done
-fi
-
-
 # Specific configuration, spin through the kernel command line
 # looking for ip= lines
 for p in $(getargs ip=); do
@@ -473,20 +456,38 @@ done
 
 # no ip option directed at our interface?
 if [ -z "$NO_AUTO_DHCP" ] && [ ! -e /tmp/net.${netif}.up ]; then
+    ret=1
     if [ -e /tmp/net.bootdev ]; then
         BOOTDEV=$(cat /tmp/net.bootdev)
         if [ "$netif" = "$BOOTDEV" ] || [ "$BOOTDEV" = "$(cat /sys/class/net/${netif}/address)" ]; then
-            load_ipv6
             do_dhcp
+            ret=$?
         fi
     else
-        if getargs 'ip=dhcp6'; then
+        # No ip lines, no bootdev -> default to dhcp
+        ip=$(getarg ip)
+
+        if getargs 'ip=dhcp6' || [ -z "$ip" -a "$netroot" = "dhcp6" ]; then
             load_ipv6
             do_dhcp -6
+            ret=$?
         fi
-        if getargs 'ip=dhcp'; then
+        if getargs 'ip=dhcp' || [ -z "$ip" -a "$netroot" != "dhcp6" ]; then
             do_dhcp -4
+            ret=$?
         fi
+    fi
+
+    for s in $(getargs nameserver); do
+        [ -n "$s" ] || continue
+        echo nameserver $s >> /tmp/net.$netif.resolv.conf
+    done
+
+    if [ "$ret" -eq 0 ] && [ -n "$(ls /tmp/leaseinfo.${netif}*)" ]; then
+         > /tmp/net.${netif}.did-setup
+         if [ -e /sys/class/net/${netif}/address ]; then
+             > /tmp/net.$(cat /sys/class/net/${netif}/address).did-setup
+         fi
     fi
 fi
 


### PR DESCRIPTION
combine code for "no ip option directed at our interface" and
"No ip lines default to dhcp"
correct evaluation of return code
fix application of "load_ipv6" call to ipv6 setup only