### PR TITLE
Removing dracut entry not compat with new plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -294,6 +294,3 @@ uefi-lib:
 test:
   - test/*
   - test/**/*
-
-dracut:
-  - any: ['!.github/*', '!.mkosi/*', '!install/*', '!examples/*', '!modules.d/*', '.test/*']


### PR DESCRIPTION
The new plugin does not seem to be as backward compatible with the previous plugin in use as it claimed hence I remove the broken bit.