### PR TITLE
40network: Keep nameservers from all interfaces

### DIFF
--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -122,7 +122,12 @@ setup_net() {
     [ -e /tmp/dhclient.$netif.dhcpopts ] && . /tmp/dhclient.$netif.dhcpopts
     # set up resolv.conf
     [ -e /tmp/net.$netif.resolv.conf ] && \
-        awk '!array[$0]++' /tmp/net.$netif.resolv.conf > /etc/resolv.conf
+        # save existing entries
+        touch /etc/resolv.conf
+        cp /etc/resolv.conf /tmp/net.$netif.resolv.conf.orig
+        # prepend new DNS servers while making sure that each appear only once
+        cat /tmp/net.$netif.resolv.conf /tmp/net.$netif.resolv.conf.orig \
+            | awk '!array[$0]++' > /etc/resolv.conf
     [ -e /tmp/net.$netif.gw ]            && . /tmp/net.$netif.gw
 
     # add static route


### PR DESCRIPTION
Make sure that all nameservers configured by each interface are kept in
/etc/resolv.conf. The current code will only keep the nameservers
configured for the latest interface.

This matters especially in the case where the latest interface is
configured via DHCP and if the DHCP server does not send a nameserver.
The current code will remove all previously configured nameservers from
/etc/resolv.conf leaving the system unable to resolve hostnames.