### PR TITLE
95cifs rootflags and kmods

### DIFF
--- a/modules.d/95cifs/cifs-lib.sh
+++ b/modules.d/95cifs/cifs-lib.sh
@@ -30,5 +30,5 @@ cifs_to_var() {
     if [ ! "$cifsuser" -o ! "$cifspass" ]; then
 	die "For CIFS support you need to specify a cifsuser and cifspass either in the cifsuser and cifspass commandline parameters or in the root= CIFS URL."
     fi
-    options="user=$cifsuser,pass=$cifspass"
+    options="user=$cifsuser,pass=$cifspass,$(getarg rootflags=)"
 }

--- a/modules.d/95cifs/cifsroot.sh
+++ b/modules.d/95cifs/cifsroot.sh
@@ -16,7 +16,7 @@ echo server: $server
 echo path: $path
 echo options: $options
 
-mount.cifs //$server/$path $NEWROOT -o $options && { [ -e /dev/root ] || ln -s null /dev/root ; }
+mount.cifs "//$server/$path" "$NEWROOT" -o "$options" && { [ -e /dev/root ] || ln -s null /dev/root ; }
 
 # inject new exit_if_exists
 echo 'settle_exit_if_exists="--exit-if-exists=/dev/root"; rm -f -- "$job"' > $hookdir/initqueue/cifs.sh

--- a/modules.d/95cifs/module-setup.sh
+++ b/modules.d/95cifs/module-setup.sh
@@ -25,11 +25,11 @@ depends() {
 installkernel() {
     instmods cifs ipv6
     # hash algos
-    instmods md4 md5 sha256
+    instmods md4 md5 sha256 sha512
     # ciphers
-    instmods aes arc4 des ecb
+    instmods aes arc4 des ecb gcm aead2
     # macs
-    instmods hmac cmac
+    instmods hmac cmac ccm
 }
 
 # called by dracut


### PR DESCRIPTION
These helped me (a) boot and (b) stop smuggling options in `cifspass=`