### PR TITLE
Support for wicked network manager

### DIFF
--- a/dracut.spec
+++ b/dracut.spec
@@ -349,6 +349,7 @@ install -m 0755 51-dracut-rescue-postinst.sh $RPM_BUILD_ROOT%{_sysconfdir}/kerne
 %{dracutlibdir}/modules.d/04watchdog
 %{dracutlibdir}/modules.d/04watchdog-modules
 %{dracutlibdir}/modules.d/05busybox
+%{dracutlibdir}/modules.d/06dbus
 %{dracutlibdir}/modules.d/06rngd
 %{dracutlibdir}/modules.d/10i18n
 %{dracutlibdir}/modules.d/30convertfs

--- a/dracut.spec
+++ b/dracut.spec
@@ -434,6 +434,7 @@ install -m 0755 51-dracut-rescue-postinst.sh $RPM_BUILD_ROOT%{_sysconfdir}/kerne
 %{dracutlibdir}/modules.d/02systemd-networkd
 %{dracutlibdir}/modules.d/35network-manager
 %{dracutlibdir}/modules.d/35network-legacy
+%{dracutlibdir}/modules.d/35network-wicked
 %{dracutlibdir}/modules.d/40network
 %{dracutlibdir}/modules.d/45ifcfg
 %{dracutlibdir}/modules.d/90kernel-network-modules

--- a/modules.d/06dbus/dbus-cleanup.sh
+++ b/modules.d/06dbus/dbus-cleanup.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+systemctl stop dbus.service dbus.socket
+rm -rf /run/dbus

--- a/modules.d/06dbus/dbus-cleanup.sh
+++ b/modules.d/06dbus/dbus-cleanup.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-systemctl stop dbus.service dbus.socket
-rm -rf /run/dbus

--- a/modules.d/06dbus/module-setup.sh
+++ b/modules.d/06dbus/module-setup.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+  require_binaries dbus-daemon || return 1
+
+  return 255
+}
+
+depends() {
+  echo systemd
+  return 0
+}
+
+install() {
+  local DBUS_SERVICE=/usr/lib/systemd/system/dbus.service
+  if [[ -e $DBUS_SERVICE ]]; then
+    if [[ -L $DBUS_SERVICE ]]; then
+      DBUS_SERVICE=$(readlink $DBUS_SERVICE)
+    fi
+  else
+    DBUS_SERVICE=/etc/systemd/system/dbus.service
+    if [[ -e $DBUS_SERVICE ]]; then
+      if [[ -L $DBUS_SERVICE ]]; then
+        DBUS_SERVICE=$(readlink $DBUS_SERVICE)
+      fi
+    else
+      echo "Could not find dbus.service";
+      exit 1
+    fi
+  fi
+
+  inst_multiple \
+    $DBUS_SERVICE \
+    /usr/lib/systemd/system/dbus.socket \
+    /usr/bin/dbus-daemon \
+    /usr/bin/dbus-send
+
+  dbus_system_services="
+        org.freedesktop.systemd1
+        org.freedesktop.timedate1
+        org.freedesktop.hostname1
+  "
+  inst_dir      /etc/dbus-1/system.d
+  inst_dir      /usr/share/dbus-1/services
+  inst_dir      /usr/share/dbus-1/system-services
+  inst_multiple /etc/dbus-1/system.conf
+  inst_multiple /usr/share/dbus-1/system.conf \
+                /usr/share/dbus-1/services/org.freedesktop.systemd1.service
+  for service in $dbus_system_services ; do
+      inst_multiple        /etc/dbus-1/system.d/${service}.conf \
+              /usr/share/dbus-1/system-services/${service}.service
+  done
+  inst_multiple $(find /var/lib/dbus)
+
+  inst_hook cleanup 99 "$moddir/dbus-cleanup.sh"
+
+  grep '^messagebus:' /etc/passwd >> "$initdir/etc/passwd"
+  grep '^messagebus:' /etc/group >> "$initdir/etc/group"
+
+  # do not enable -- this is a static service
+  #systemctl --root "$initdir" enable $DBUS_SERVICE > /dev/null 2>&1
+
+  sed -i -e \
+'/^\[Unit\]/aDefaultDependencies=no\
+Conflicts=shutdown.target\
+Before=shutdown.target' \
+    "$initdir"$DBUS_SERVICE
+
+  sed -i -e \
+'/^\[Unit\]/aDefaultDependencies=no\
+Conflicts=shutdown.target\
+Before=shutdown.target
+/^\[Socket\]/aRemoveOnStop=yes' \
+    "$initdir"/usr/lib/systemd/system/dbus.socket
+
+  #We need to make sure that systemd-tmpfiles-setup.service->dbus.socket will not wait local-fs.target to start,
+  #If swap is encrypted, this would make dbus wait the timeout for the swap before loading. This could delay sysinit
+  #services that are dependent on dbus.service.
+  sed -i -Ee \
+    '/^After/s/(After[[:space:]]*=.*)(local-fs.target[[:space:]]*)(.*)/\1-\.mount \3/' \
+    "$initdir"/usr/lib/systemd/system/systemd-tmpfiles-setup.service
+}

--- a/modules.d/06dbus/module-setup.sh
+++ b/modules.d/06dbus/module-setup.sh
@@ -36,21 +36,12 @@ install() {
     /usr/bin/dbus-daemon \
     /usr/bin/dbus-send
 
-  dbus_system_services="
-        org.freedesktop.systemd1
-        org.freedesktop.timedate1
-        org.freedesktop.hostname1
-  "
   inst_dir      /etc/dbus-1/system.d
   inst_dir      /usr/share/dbus-1/services
   inst_dir      /usr/share/dbus-1/system-services
   inst_multiple /etc/dbus-1/system.conf
   inst_multiple /usr/share/dbus-1/system.conf \
                 /usr/share/dbus-1/services/org.freedesktop.systemd1.service
-  for service in $dbus_system_services ; do
-      inst_multiple        /etc/dbus-1/system.d/${service}.conf \
-              /usr/share/dbus-1/system-services/${service}.service
-  done
   inst_multiple $(find /var/lib/dbus)
 
   inst_hook cleanup 99 "$moddir/dbus-cleanup.sh"

--- a/modules.d/06dbus/module-setup.sh
+++ b/modules.d/06dbus/module-setup.sh
@@ -46,8 +46,8 @@ install() {
 
   inst_hook cleanup 99 "$moddir/dbus-cleanup.sh"
 
-  grep '^messagebus:' /etc/passwd >> "$initdir/etc/passwd"
-  grep '^messagebus:' /etc/group >> "$initdir/etc/group"
+  grep '^\(d\|message\)bus:' /etc/passwd >> "$initdir/etc/passwd"
+  grep '^\(d\|message\)bus:' /etc/group >> "$initdir/etc/group"
 
   # do not enable -- this is a static service
   #systemctl --root "$initdir" enable $DBUS_SERVICE > /dev/null 2>&1

--- a/modules.d/06dbus/module-setup.sh
+++ b/modules.d/06dbus/module-setup.sh
@@ -34,7 +34,8 @@ install() {
     $DBUS_SERVICE \
     /usr/lib/systemd/system/dbus.socket \
     /usr/bin/dbus-daemon \
-    /usr/bin/dbus-send
+    /usr/bin/dbus-send \
+    /usr/bin/busctl
 
   inst_dir      /etc/dbus-1/system.d
   inst_dir      /usr/share/dbus-1/services

--- a/modules.d/35network-wicked/module-setup.sh
+++ b/modules.d/35network-wicked/module-setup.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+    local _program
+
+    require_binaries wicked || return 1
+
+    # do not add this module by default
+    return 255
+}
+
+# called by dracut
+depends() {
+    echo systemd dbus
+    return 0
+}
+
+# called by dracut
+installkernel() {
+    return 0
+}
+
+# called by dracut
+install() {
+    inst_hook cmdline 99 "$moddir/wicked-config.sh"
+
+    # Seems to not execute if in initqueue/settled
+    inst_hook pre-mount 99 "$moddir/wicked-run.sh"
+
+    inst_dir /etc/wicked/extensions
+    inst_dir /usr/share/wicked/schema
+    inst_dir /usr/lib/wicked/bin
+    inst_dir /var/lib/wicked
+
+    inst_multiple /etc/wicked/*.xml
+    inst_multiple /etc/wicked/extensions/*
+    inst_multiple /etc/dbus-1/system.d/org.opensuse.Network*
+    inst_multiple /usr/share/wicked/schema/*
+    inst_multiple /usr/lib/wicked/bin/*
+    inst_multiple /usr/sbin/wicked*
+
+    wicked_units="
+        $systemdsystemunitdir/wickedd.service \
+        $systemdsystemunitdir/wickedd-auto4.service \
+        $systemdsystemunitdir/wickedd-dhcp4.service \
+        $systemdsystemunitdir/wickedd-dhcp6.service \
+        $systemdsystemunitdir/wickedd-nanny.service"
+
+    inst_multiple $wicked_units
+
+    for unit in $wicked_units; do
+        sed -i 's/^After=.*/After=dbus.service/g' $initdir/$unit
+        sed -i 's/^Wants=\(.*\)/Wants=\1 dbus.service/g' $initdir/$unit
+        sed -i -e \
+            '/^\[Unit\]/aDefaultDependencies=no\
+            Conflicts=shutdown.target\
+            Before=shutdown.target' \
+                "$initdir"$unit
+    done
+}

--- a/modules.d/35network-wicked/module-setup.sh
+++ b/modules.d/35network-wicked/module-setup.sh
@@ -26,7 +26,7 @@ install() {
     inst_hook cmdline 99 "$moddir/wicked-config.sh"
 
     # Seems to not execute if in initqueue/settled
-    inst_hook pre-mount 99 "$moddir/wicked-run.sh"
+    inst_hook pre-udev 99 "$moddir/wicked-run.sh"
 
     inst_dir /etc/wicked/extensions
     inst_dir /usr/share/wicked/schema
@@ -51,6 +51,7 @@ install() {
 
     for unit in $wicked_units; do
         sed -i 's/^After=.*/After=dbus.service/g' $initdir/$unit
+        sed -i 's/^Before=\(.*\)/Before=\1 dracut-pre-udev.service/g' $initdir/$unit
         sed -i 's/^Wants=\(.*\)/Wants=\1 dbus.service/g' $initdir/$unit
         sed -i -e \
             '/^\[Unit\]/aDefaultDependencies=no\

--- a/modules.d/35network-wicked/module-setup.sh
+++ b/modules.d/35network-wicked/module-setup.sh
@@ -28,6 +28,9 @@ install() {
     # Seems to not execute if in initqueue/settled
     inst_hook pre-udev 99 "$moddir/wicked-run.sh"
 
+    # even with wicked configuring the interface, ip is useful
+    inst_multiple ip
+
     inst_dir /etc/wicked/extensions
     inst_dir /usr/share/wicked/schema
     inst_dir /usr/lib/wicked/bin

--- a/modules.d/35network-wicked/module-setup.sh
+++ b/modules.d/35network-wicked/module-setup.sh
@@ -41,6 +41,7 @@ install() {
     inst_multiple /etc/dbus-1/system.d/org.opensuse.Network*
     inst_multiple /usr/share/wicked/schema/*
     inst_multiple /usr/lib/wicked/bin/*
+    inst_multiple /usr/libexec/wicked/bin/*
     inst_multiple /usr/sbin/wicked*
 
     wicked_units="

--- a/modules.d/35network-wicked/wicked-config.sh
+++ b/modules.d/35network-wicked/wicked-config.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+getcmdline > /tmp/cmdline.$$.conf
+wicked show-config --ifconfig dracut:cmdline:/tmp/cmdline.$$.conf > /tmp/dracut.xml
+rm -f /tmp/cmdline.$$.conf

--- a/modules.d/35network-wicked/wicked-run.sh
+++ b/modules.d/35network-wicked/wicked-run.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+systemctl start wickedd
+# detection wrapper around ifup --ifconfig "final xml" all
+wicked bootstrap --ifconfig /tmp/dracut.xml all
+systemctl stop wickedd

--- a/modules.d/35network-wicked/wicked-run.sh
+++ b/modules.d/35network-wicked/wicked-run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
+# ensure wickedd is running
 systemctl start wickedd
 # detection wrapper around ifup --ifconfig "final xml" all
 wicked bootstrap --ifconfig /tmp/dracut.xml all
-systemctl stop wickedd

--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -7,15 +7,25 @@ check() {
 
 # called by dracut
 depends() {
-    echo -n "kernel-network-modules "
-
     is_qemu_virtualized && echo -n "qemu-net "
 
-    if ! dracut_module_included "network-legacy" && [ -x "$dracutsysrootdir/usr/libexec/nm-initrd-generator" ] ; then
-        echo "network-manager"
-    else
-        echo "network-legacy"
-    fi
+    for module in network-wicked network-manager network-legacy ; do
+        if dracut_module_included "$module" ; then
+                network_handler="$module"
+                break
+            fi
+        done;
+
+        if [ -z "$network_handler" ]; then
+            if require_binaries wicked; then
+                network_handler="network-wicked"
+            elif [ -x "$dracutsysrootdir/usr/libexec/nm-initrd-generator" ]; then
+                network_handler="network-manager"
+            else
+                network_handler="network-legacy"
+            fi
+        fi
+    echo "kernel-network-modules $network_handler"
     return 0
 }
 


### PR DESCRIPTION
This introduces support for [wicked](https://github.com/openSUSE/wicked) as network management module.

Todo:

* [x] compare dbus module with the one in the [bluetooth HiD PR](https://github.com/dracutdevs/dracut/pull/544).
* [ ] add tests if possible (wicked is probably not available on fedora)
* [ ] check if all parameters are properly accepted
* [ ] add documentation
