### PR TITLE
fix graphics startup failure with the rhgb paramter in CentOS8.2

### DIFF
--- a/modules.d/50drm/module-setup.sh
+++ b/modules.d/50drm/module-setup.sh
@@ -33,7 +33,7 @@ installkernel() {
     if [[ $hostonly ]]; then
         for i in /sys/bus/{pci/devices,virtio/devices,soc/devices/soc?}/*/modalias; do
             [[ -e $i ]] || continue
-            if hostonly="" dracut_instmods --silent -s "drm_crtc_init" -S "iw_handler_get_spy" $(<$i); then
+            if hostonly="" dracut_instmods --silent -s "drm_crtc_init|drm_dev_register" -S "iw_handler_get_spy" $(<$i); then
                 if strstr "$(modinfo -F filename $(<$i) 2>/dev/null)" radeon.ko; then
                     hostonly='' instmods amdkfd
                 fi

--- a/modules.d/98dracut-systemd/dracut-pre-pivot.sh
+++ b/modules.d/98dracut-systemd/dracut-pre-pivot.sh
@@ -18,7 +18,7 @@ source_hook pre-pivot
 getarg 'rd.break=cleanup' 'rdbreak=cleanup' && emergency_shell -n cleanup "Break cleanup"
 source_hook cleanup
 
-_bv=$(getarg rd.break -d rdbreak) && [ -n "$_bv" ] &&
+_bv=$(getarg rd.break -d rdbreak) && [ -z "$_bv" ] &&
     emergency_shell -n switch_root "Break before switch_root"
 unset _bv
 

--- a/modules.d/98dracut-systemd/dracut-pre-pivot.sh
+++ b/modules.d/98dracut-systemd/dracut-pre-pivot.sh
@@ -18,7 +18,7 @@ source_hook pre-pivot
 getarg 'rd.break=cleanup' 'rdbreak=cleanup' && emergency_shell -n cleanup "Break cleanup"
 source_hook cleanup
 
-_bv=$(getarg rd.break -d rdbreak) && [ -z "$_bv" ] &&
+_bv=$(getarg rd.break -d rdbreak) && [ -n "$_bv" ] &&
     emergency_shell -n switch_root "Break before switch_root"
 unset _bv
 


### PR DESCRIPTION
the bug occurs because the DRM (cirrus) driver for graphics card is not in the initrd.