### PR TITLE
Adding dbusdir as global var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ mandir ?= ${prefix}/share/man
 CFLAGS ?= -O2 -g -Wall -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
 bashcompletiondir ?= ${datadir}/bash-completion/completions
 pkgconfigdatadir ?= $(datadir)/pkgconfig
+dbusdir ?= $(datadir)/dbus-1
 
 man1pages = lsinitrd.1
 
@@ -186,6 +187,7 @@ endif
 	install -m 0644 lsinitrd-bash-completion.sh $(DESTDIR)${bashcompletiondir}/lsinitrd
 	mkdir -p $(DESTDIR)${pkgconfigdatadir}
 	install -m 0644 dracut.pc $(DESTDIR)${pkgconfigdatadir}/dracut.pc
+        mkdir -p $(DESTDIR)${dbusdir}
 
 dracut-version.sh:
 	@rm -f dracut-version.sh

--- a/configure
+++ b/configure
@@ -48,7 +48,8 @@ while (($# > 0)); do
         --infodir) read_arg infodir "$@" || shift;;
         --systemdsystemunitdir) read_arg systemdsystemunitdir "$@" || shift;;
         --bashcompletiondir) read_arg bashcompletiondir "$@" || shift;;
-        *) echo "Ignoring unknown option '$1'";;
+        --dbusdir) read_arg dbusdir "$@" || shift;;
+	*) echo "Ignoring unknown option '$1'";;
     esac
     shift
 done
@@ -124,6 +125,7 @@ EOF
     [[ $infodir ]] && echo "infodir ?= ${infodir}"
     [[ $systemdsystemunitdir ]] && echo "systemdsystemunitdir ?= ${systemdsystemunitdir}"
     [[ $bashcompletiondir ]] && echo "bashcompletiondir ?= ${bashcompletiondir}"
+    [[ $dbusdir ]] && echo "dbusdir ?= ${dbusdir}"
 } >> Makefile.inc.$$
 
 mv Makefile.inc.$$ Makefile.inc


### PR DESCRIPTION
Should simplify writing dbus related modules as in
inst_multiple -o \
$dbusdir/org.freedesktop.foo.conf
$systemdutildir/system/org.freedesktop.foo.service
...