### PR TITLE
Fix Unicode and dracut install labeler

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0002728 Feature Request"
+name: "\U00002728 Feature Request"
 about: A request for enhancement in Dracut
 labels: 'enhancement'
 ---

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,7 +8,7 @@ github:
   - .github/*
   - .github/**/*
 
-dracut install:
+dracut-install:
   - install/*
   - install/**/*
 


### PR DESCRIPTION
This pull request fixes the UC in feature request template and a missing '-' in dracut install which caused incorrect label on PR

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
