### PR TITLE
90crypt: make `rd.luks.key` usable with encrypted keydev.

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -302,6 +302,8 @@ crypto LUKS
     The comparisons also matches, if _<luks uuid>_ is only the beginning of the
     LUKS UUID, so you don't have to specify the full UUID.
     This parameter can be specified multiple times.
+    _<luks uuid>_ may be prefixed by the keyword `keysource:`, see
+    _rd.luks.key_ below.
 
 **rd.luks.allow-discards=**__<luks uuid>__::
     Allow  using  of discards (TRIM) requests for LUKS partitions with the given
@@ -397,6 +399,49 @@ head -32c /dev/urandom > rootkey.key
 cryptsetup --batch-mode --key-file rootkey.key \
            luksFormat /dev/sda47
 --
+
+You can also use regular key files on an encrypted _keydev_.
+
+Compared to using GPG encrypted keyfiles on an unencrypted
+device this provides the following advantages:
+
+- you can unlock your disk(s) using multiple passphrases
+- better security by not loosing the key stretching mechanism
+
+To use an encrypted _keydev_ you *must* ensure that it becomes
+available by using the keyword `keysource`, e.g.
+`rd.luks.uuid=keysource:aaaa`
+_aaaa_ being the uuid of the encrypted _keydev_.
+
+Example:
+
+Lets assume you have three disks _A_, _B_ and _C_ with the uuids
+_aaaa_, _bbbb_ and _cccc_. +
+You want to unlock _A_ and _B_ using keyfile _keyfile_. +
+The unlocked volumes be _A'_, _B'_ and _C'_ with the uuids
+_AAAA_, _BBBB_ and _CCCC_. +
+_keyfile_ is saved on _C'_ as _/keyfile_.
+
+One luks keyslot of each _A_, _B_ and _C_ is setup with a
+passphrase. +
+Another luks keyslot of each _A_ and _B_ is setup with _keyfile_.
+
+To boot this configuration you could use:
+[listing]
+--
+rd.luks.uuid=aaaa
+rd.luks.uuid=bbbb
+rd.luks.uuid=keysource:cccc
+rd.luks.key=/keyfile:UUID=CCCC
+--
+Dracut asks for the passphrase for _C_ and uses the
+keyfile to unlock _A_ and _B_. +
+If getting the passphrase for _C_ fails it falls back to
+asking for the passphrases for _A_ and _B_.
+
+If you want _C'_ to stay unlocked, specify a luks name for
+it, e.g. `rd.luks.name=cccc=mykeys`, otherwise it gets closed
+when not needed anymore.
 ===============================
 
 MD RAID


### PR DESCRIPTION
Add optional prefix `keysource:` for the values of `rd.luks.partuuid`,
`rd.luks.serial` and `rd.luks.uuid`.
If specified, ask for passphrase instead of waiting for keydevs to come
online.

This makes it possible to use an encrypted *keydev* with `rd.luks.key`.

The `keysource:` keyword essentially marks an `rd.luks.partuuid` / `rd.luks.serial` / `rd.luks.uuid` argument as always-ask-for-passphrase. Without it, and with `rd.luks.key` specified, dracut would wait for an appropriate key entry to appear in `/tmp/luks.keys` (which won't happen) until timeout, resulting in the asking-for-passphrase fallback for all devices.

What I'm not yet sure about is if the priority of 31 for a generated `cleanup`-hook is appropriate (another cleanup hook of the module uses 30-*). It seems to work fine for me but, well, feedback welcome :).

## Changes

`90crypt`-module and related documentation.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

