### PR TITLE
fix graphics startup failure with the rhgb paramter in CentOS8.2

### DIFF
--- a/modules.d/50drm/module-setup.sh
+++ b/modules.d/50drm/module-setup.sh
@@ -33,7 +33,7 @@ installkernel() {
     if [[ $hostonly ]]; then
         for i in /sys/bus/{pci/devices,virtio/devices,soc/devices/soc?}/*/modalias; do
             [[ -e $i ]] || continue
-            if hostonly="" dracut_instmods --silent -s "drm_crtc_init" -S "iw_handler_get_spy" $(<$i); then
+            if hostonly="" dracut_instmods --silent -s "drm_crtc_init|drm_dev_register" -S "iw_handler_get_spy" $(<$i); then
                 if strstr "$(modinfo -F filename $(<$i) 2>/dev/null)" radeon.ko; then
                     hostonly='' instmods amdkfd
                 fi


### PR DESCRIPTION
This pull request changes...
1、refer to  PR in RHEL-8 branch (https://github.com/dracutdevs/dracut/pull/904).
2、fix graphics startup failure with the rhgb paramter in CentOS8.2


