### PR TITLE
dracut.cmdline.7.asc: fix typo

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -607,7 +607,7 @@ interface name. Better name it "bootnet" or "bluesocket".
     boolean, bring up network even without netroot set
 
 **vlan=**__<vlanname>__:__<phydevice>__::
-    Setup vlan device named <vlanname> on <phydeivce>.
+    Setup vlan device named <vlanname> on <phydevice>.
     We support the four styles of vlan names: VLAN_PLUS_VID (vlan0005),
     VLAN_PLUS_VID_NO_PAD (vlan5), DEV_PLUS_VID (eth0.0005),
     DEV_PLUS_VID_NO_PAD (eth0.5)


### PR DESCRIPTION
Fix a typo in the man page.