### PR TITLE
dracut-emergency: run emergency hooks before rdsosreport

### DIFF
--- a/modules.d/98dracut-systemd/dracut-emergency.sh
+++ b/modules.d/98dracut-systemd/dracut-emergency.sh
@@ -14,9 +14,9 @@ export _rdshell_name="dracut" action="Boot" hook="emergency"
 _emergency_action=$(getarg rd.emergency)
 
 if getargbool 1 rd.shell -d -y rdshell || getarg rd.break -d rdbreak; then
+    source_hook "$hook"
     FSTXT="/run/dracut/fsck/fsck_help_$fstype.txt"
     RDSOSREPORT="$(rdsosreport)"
-    source_hook "$hook"
     while read _tty rest; do
         (
             echo


### PR DESCRIPTION
Match non-systemd _emergency_shell() behaviour in running emergency
hooks prior to rdsosreport.
On my system this trims ~30ms from boot to emergency hook invocation,
which can be important when critical steps are performed by the hook.

Signed-off-by: David Disseldorp <ddiss@suse.de>