### PR TITLE
Add --uefi-output for custom output filename

### DIFF
--- a/dracut-bash-completion.sh
+++ b/dracut-bash-completion.sh
@@ -38,7 +38,7 @@ _dracut() {
                               --fwdir --libdirs --fscks --add-fstab --mount --device --nofscks
                               --kmoddir --conf --confdir --tmpdir --stdlog --compress --prefix
                               --kernel-cmdline --sshkey --persistent-policy --install-optional
-                              --loginstall --uefi-stub --kernel-image
+                              --loginstall --uefi-stub --kernel-image --uefi-output
                               '
         )
 

--- a/dracut.8.asc
+++ b/dracut.8.asc
@@ -524,6 +524,9 @@ will not be able to boot.
     Specifies the UEFI stub loader's splash image. Requires bitmap (**.bmp**) image
     format.
 
+**--uefi-output _<FILE>_**::
+    Specifies the UEFI application output filename, uses default if not set.
+
 **--kernel-image _<FILE>_**::
     Specifies the kernel image, which to include in the UEFI executable. The default is
     _/lib/modules/<KERNEL-VERSION>/vmlinuz_ or _/boot/vmlinuz-<KERNEL-VERSION>_
@@ -673,6 +676,8 @@ Jeremy Katz
 David Dillow
 
 Will Woods
+
+Léo Le Bouter
 
 SEE ALSO
 --------

--- a/dracut.conf.5.asc
+++ b/dracut.conf.5.asc
@@ -209,6 +209,9 @@ provide a valid _/etc/fstab_.
 *uefi_splash_image=*"_<FILE>_"::
     Specifies the UEFI stub loader's splash image. Requires bitmap (**.bmp**) image format.
 
+*uefi_output=*"_<FILE>_"::
+    Specifies the UEFI application output filename, uses default if not set.
+
 *uefi_secureboot_cert=*"_<FILE>_", *uefi_secureboot_key=*"_<FILE>_"::
     Specifies a certificate and corresponding key, which are used to sign the created UEFI executable.
     Requires both certificate and key need to be specified and _sbsign_ to be installed.
@@ -231,6 +234,8 @@ _/etc/dracut.conf.d/_::
 AUTHOR
 ------
 Harald Hoyer
+
+Léo Le Bouter
 
 See Also
 --------

--- a/dracut.sh
+++ b/dracut.sh
@@ -241,6 +241,8 @@ Creates initial ramdisk images for preloading modules
   --uefi-splash-image [FILE]
                         Use [FILE] as a splash image when creating an UEFI
                         executable
+  --uefi-output [FILE]  Use [FILE] as output filename when creating an UEFI
+                        executable
   --kernel-image [FILE] location of the kernel image
   --regenerate-all      Regenerate all initramfs images at the default location
                         for the kernel versions found on the system
@@ -423,6 +425,7 @@ rearrange_params()
         --long uefi \
         --long uefi-stub: \
         --long uefi-splash-image: \
+        --long uefi-output: \
         --long kernel-image: \
         --long no-hostonly-i18n \
         --long hostonly-i18n \
@@ -627,6 +630,8 @@ while :; do
                        uefi_stub_l="$2";               PARMS_TO_STORE+=" '$2'"; shift;;
         --uefi-splash-image)
                        uefi_splash_image_l="$2";       PARMS_TO_STORE+=" '$2'"; shift;;
+        --uefi-output)
+                       uefi_output_l="$2";             PARMS_TO_STORE+=" '$2'"; shift;;
         --kernel-image)
                        kernel_image_l="$2";            PARMS_TO_STORE+=" '$2'"; shift;;
         --no-machineid)
@@ -811,6 +816,7 @@ stdloglvl=$((stdloglvl + verbosity_mod_l))
 [[ $loginstall_l ]] && loginstall="$loginstall_l"
 [[ $uefi_stub_l ]] && uefi_stub="$uefi_stub_l"
 [[ $uefi_splash_image_l ]] && uefi_splash_image="$uefi_splash_image_l"
+[[ $uefi_output_l ]] && uefi_output="$uefi_output_l"
 [[ $kernel_image_l ]] && kernel_image="$kernel_image_l"
 [[ $machine_id_l ]] && machine_id="$machine_id_l"
 
@@ -830,27 +836,31 @@ if ! [[ $outfile ]]; then
             exit 1
         fi
 
-        BUILD_ID=$(cat $dracutsysrootdir/etc/os-release $dracutsysrootdir/usr/lib/os-release \
-                       | while read -r line || [[ $line ]]; do \
-                       [[ $line =~ BUILD_ID\=* ]] && eval "$line" && echo "$BUILD_ID" && break; \
-                   done)
-        if [[ -z $dracutsysrootdir ]]; then
-            if [[ -d /efi ]] && mountpoint -q /efi; then
-                efidir=/efi/EFI
+        if [[ -z "$uefi_output" ]]; then
+            BUILD_ID=$(cat $dracutsysrootdir/etc/os-release $dracutsysrootdir/usr/lib/os-release \
+                           | while read -r line || [[ $line ]]; do \
+                           [[ $line =~ BUILD_ID\=* ]] && eval "$line" && echo "$BUILD_ID" && break; \
+                       done)
+            if [[ -z $dracutsysrootdir ]]; then
+                if [[ -d /efi ]] && mountpoint -q /efi; then
+                    efidir=/efi/EFI
+                else
+                    efidir=/boot/EFI
+                    if [[ -d $dracutsysrootdir/boot/efi/EFI ]]; then
+                        efidir=/boot/efi/EFI
+                    fi
+                fi
             else
                 efidir=/boot/EFI
                 if [[ -d $dracutsysrootdir/boot/efi/EFI ]]; then
                     efidir=/boot/efi/EFI
                 fi
             fi
+            mkdir -p "$dracutsysrootdir$efidir/Linux"
+            outfile="$dracutsysrootdir$efidir/Linux/linux-$kernel${MACHINE_ID:+-${MACHINE_ID}}${BUILD_ID:+-${BUILD_ID}}.efi"
         else
-            efidir=/boot/EFI
-            if [[ -d $dracutsysrootdir/boot/efi/EFI ]]; then
-                efidir=/boot/efi/EFI
-            fi
+            outfile="$uefi_output"
         fi
-        mkdir -p "$dracutsysrootdir$efidir/Linux"
-        outfile="$dracutsysrootdir$efidir/Linux/linux-$kernel${MACHINE_ID:+-${MACHINE_ID}}${BUILD_ID:+-${BUILD_ID}}.efi"
     else
         if [[ -e "$dracutsysrootdir/boot/vmlinuz-$kernel" ]]; then
             outfile="/boot/initramfs-$kernel.img"


### PR DESCRIPTION
Closes #921

This pull request adds support for an `--uefi-output` command line parameter and an `uefi_output` configuration directive.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it