### PR TITLE
dracut.spec: include the 04watchdog-modules module

### DIFF
--- a/dracut.spec
+++ b/dracut.spec
@@ -348,6 +348,7 @@ install -m 0755 51-dracut-rescue-postinst.sh $RPM_BUILD_ROOT%{_sysconfdir}/kerne
 %{dracutlibdir}/modules.d/03modsign
 %{dracutlibdir}/modules.d/03rescue
 %{dracutlibdir}/modules.d/04watchdog
+%{dracutlibdir}/modules.d/04watchdog-modules
 %{dracutlibdir}/modules.d/05busybox
 %{dracutlibdir}/modules.d/06rngd
 %{dracutlibdir}/modules.d/10i18n


### PR DESCRIPTION
Fix the following:
```
$ make rpm
...
RPM build errors:
    Installed (but unpackaged) file(s) found:
   /usr/lib/dracut/modules.d/04watchdog-modules/module-setup.sh
```