### PR TITLE
Include devfreq drivers in initrd

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -65,6 +65,7 @@ installkernel() {
             _blockfuncs+='|dw_mc_probe|dw_mci_pltfm_register'
             instmods \
                 "=drivers/clk" \
+                "=drivers/devfreq" \
                 "=drivers/dma" \
                 "=drivers/extcon" \
                 "=drivers/gpio" \


### PR DESCRIPTION
Some SoCs now have drivers that user devfreq in early init and fail
if the drivers are missing so make sure we have them in the initrd.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>

This pull request changes...
kernel modules in initrd
## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
Some arm devices that have GPU drivers that use devfreq for scaling