### PR TITLE
90crypt: pull in remote-cryptsetup.target enablement

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -151,6 +151,7 @@ install() {
                       $systemdsystemunitdir/systemd-ask-password-console.service \
                       $systemdsystemunitdir/cryptsetup.target \
                       $systemdsystemunitdir/sysinit.target.wants/cryptsetup.target \
+                      $systemdsystemunitdir/initrd-root-fs.target.wants/remote-cryptsetup.target \
                       systemd-ask-password systemd-tty-ask-password-agent
     fi
 


### PR DESCRIPTION
This is enabled upstream in
https://github.com/systemd/systemd/pull/17149.