### PR TITLE
50drm hostonly support for platform bus

### DIFF
--- a/modules.d/50drm/module-setup.sh
+++ b/modules.d/50drm/module-setup.sh
@@ -33,13 +33,13 @@ installkernel() {
     if [[ $hostonly ]]; then
         for i in /sys/bus/{pci/devices,platform/devices,virtio/devices,soc/devices/soc?}/*/modalias; do
             [[ -e $i ]] || continue
-            if hostonly="" dracut_instmods --silent -s "drm_crtc_init|drm_dev_register" -S "iw_handler_get_spy" $(<"$i"); then
+            if hostonly="" dracut_instmods --silent -s "drm_crtc_init|drm_dev_register|drm_encoder_init" -S "iw_handler_get_spy" $(<"$i"); then
                 if strstr "$(modinfo -F filename $(<"$i") 2>/dev/null)" radeon.ko; then
                     hostonly='' instmods amdkfd
                 fi
             fi
         done
     else
-        dracut_instmods -o -s "drm_crtc_init|drm_dev_register" "=drivers/gpu/drm" "=drivers/staging"
+        dracut_instmods -o -s "drm_crtc_init|drm_dev_register|drm_encoder_init" "=drivers/gpu/drm" "=drivers/staging"
     fi
 }

--- a/modules.d/50drm/module-setup.sh
+++ b/modules.d/50drm/module-setup.sh
@@ -31,7 +31,7 @@ installkernel() {
     # as we could e.g. be in the installer; nokmsboot boot parameter will disable
     # loading of the driver if needed
     if [[ $hostonly ]]; then
-        for i in /sys/bus/{pci/devices,virtio/devices,soc/devices/soc?}/*/modalias; do
+        for i in /sys/bus/{pci/devices,platform/devices,virtio/devices,soc/devices/soc?}/*/modalias; do
             [[ -e $i ]] || continue
             if hostonly="" dracut_instmods --silent -s "drm_crtc_init|drm_dev_register" -S "iw_handler_get_spy" $(<"$i"); then
                 if strstr "$(modinfo -F filename $(<"$i") 2>/dev/null)" radeon.ko; then

--- a/modules.d/50drm/module-setup.sh
+++ b/modules.d/50drm/module-setup.sh
@@ -33,8 +33,8 @@ installkernel() {
     if [[ $hostonly ]]; then
         for i in /sys/bus/{pci/devices,virtio/devices,soc/devices/soc?}/*/modalias; do
             [[ -e $i ]] || continue
-            if hostonly="" dracut_instmods --silent -s "drm_crtc_init|drm_dev_register" -S "iw_handler_get_spy" $(<$i); then
-                if strstr "$(modinfo -F filename $(<$i) 2>/dev/null)" radeon.ko; then
+            if hostonly="" dracut_instmods --silent -s "drm_crtc_init|drm_dev_register" -S "iw_handler_get_spy" $(<"$i"); then
+                if strstr "$(modinfo -F filename $(<"$i") 2>/dev/null)" radeon.ko; then
                     hostonly='' instmods amdkfd
                 fi
             fi


### PR DESCRIPTION
This pull request adds support for checking platform bus for modalias used by hostonly mode for drm drivers.

## Changes
- Fix ambiguous redirect related to space in variable.
- Iterate over modalias from plaform bus 
- Add drm_encoder_init to the computation for drm drivers related to display.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


