### PR TITLE
95nvmf: rework FC connection handling

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -874,6 +874,8 @@ NVMf
     _<traddr>_ and the optionally _<host_traddr>_ or _<trsvcid>_.
     The first argument specifies the transport to use; currently only
     'rdma', 'fc', or 'tcp' are supported.
+    The _<traddr>_ parameter can be set to 'auto' to select
+    autodiscovery; in that case all other parameters are ignored.
     This parameter can be specified multiple times.
 
 NBD

--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -861,6 +861,21 @@ FCoE
 +
 NOTE: letters in the MAC-address must be lowercase!
 
+NVMf
+~~~~
+**rd.nvmf.hostnqn=**__<hostNQN>__::
+    NVMe host NQN to use
+
+**rd.nvmf.hostid=**__<hostID>__::
+    NVMe host id to use
+
+**rd.nvmf.discover=**__{rdma|fc|tcp}__,__<traddr>__,[__<host_traddr>__],[__<trsvcid>__]::
+    Discover and connect to a NVMe-over-Fabric controller specified by
+    _<traddr>_ and the optionally _<host_traddr>_ or _<trsvcid>_.
+    The first argument specifies the transport to use; currently only
+    'rdma', 'fc', or 'tcp' are supported.
+    This parameter can be specified multiple times.
+
 NBD
 ~~~
 **root=**??? **netroot=**nbd:__<server>__:__<port/exportname>__[:__<fstype>__[:__<mountopts>__[:__<nbdopts>__]]]::

--- a/modules.d/95nvmf/95-nvmf-initqueue.rules
+++ b/modules.d/95nvmf/95-nvmf-initqueue.rules
@@ -1,0 +1,10 @@
+#
+# nvmf-initqueue.rules
+#
+# D-Bus doesn't run in the initrd, which means that we cannot use our
+# usual trick of starting custom systemd services.
+# So use a rule to create initqueue entries instead.
+
+ACTION=="change", SUBSYSTEM=="fc", ENV{FC_EVENT}=="nvmediscovery", \
+      ENV{NVMEFC_HOST_TRADDR}=="*", ENV{NVMEFC_TRADDR}=="*", \
+      RUN+="/sbin/initqueue --onetime --unique --name nvmf-connect-$env{NVMEFC_TRADDR}-$env{NVMEFC_HOST_TRADDR} /usr/sbin/nvme connect-all --transport=fc --traddr=$env{NVMEFC_TRADDR} --host-traddr=$env{NVMEFC_HOST_TRADDR}"

--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -110,12 +110,9 @@ install() {
     inst_multiple ip sed
 
     inst_multiple nvme
-    inst_multiple -o \
-        "$systemdsystemunitdir/nvm*-connect@.service" \
-        "$systemdsystemunitdir/nvm*-connect.target"
     inst_hook cmdline 99 "$moddir/parse-nvmf-boot-connections.sh"
     inst_simple "/etc/nvme/discovery.conf"
-    inst_rules /usr/lib/udev/rules.d/70-nvm*-autoconnect.rules
     inst_rules /usr/lib/udev/rules.d/71-nvmf-iopolicy-netapp.rules
+    inst_rules "$moddir/95-nvmf-initqueue.rules"
     dracut_need_initqueue
 }

--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -57,6 +57,31 @@ installkernel() {
 cmdline() {
     local _hostnqn
     local _hostid
+
+    gen_nvmf_cmdline() {
+        local _dev=$1
+        local trtype
+
+        [[ -L "/sys/dev/block/$_dev" ]] || return 0
+        cd -P "/sys/dev/block/$_dev" || return 0
+        if [ -f partition ] ; then
+            cd ..
+        fi
+        for d in device/nvme* ; do
+            [ -L "$d" ] || continue
+            if readlink "$d" | grep -q nvme-fabrics ; then
+                trtype=$(cat "$d"/transport)
+                break
+            fi
+        done
+
+        [ -z "$trtype" ] && return 0
+        nvme list-subsys ${PWD##*/} | while read x dev trtype traddr host_traddr state ana; do
+            [ "$trtype" != "${trtype#NQN}" ] && continue
+            echo -n " nvmf.discover=$trtype,${traddr#traddr=},${host_traddr#host_traddr=}"
+        done
+    }
+
     if [ -f /etc/nvme/hostnqn ] ; then
         _hostnqn=$(cat /etc/nvme/hostnqn)
         echo -n " nvmf.hostnqn=${_hostnqn}"
@@ -65,7 +90,12 @@ cmdline() {
         _hostid=$(cat /etc/nvme/hostid)
         echo -n " nvmf.hostid=${_hostid}"
     fi
-    echo ""
+
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
+        pushd . >/dev/null
+        for_each_host_dev_and_slaves gen_nvmf_cmdline
+        popd >/dev/null
+    }
 }
 
 # called by dracut

--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -109,6 +109,8 @@ install() {
 
     inst_multiple ip sed
 
+    inst_script "${moddir}/nvmf-autoconnect.sh" /sbin/nvmf-autoconnect.sh
+
     inst_multiple nvme
     inst_hook cmdline 99 "$moddir/parse-nvmf-boot-connections.sh"
     inst_simple "/etc/nvme/discovery.conf"

--- a/modules.d/95nvmf/nvmf-autoconnect.sh
+++ b/modules.d/95nvmf/nvmf-autoconnect.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+[ -f /sys/class/fc/fc_udev_device/nvme_discovery ] || exit 1
+echo add > /sys/class/fc/fc_udev_device/nvme_discovery
+exit 0

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -132,6 +132,6 @@ if [ -f "/etc/nvme/discovery.conf" ] ; then
 else
     # No nvme command line arguments present, try autodiscovery
     if [ "$trtype" = "fc" ] ; then
-        /sbin/initqueue --finished --onetime --unique --name nvme-fc-autoconnect echo 1 > /sys/class/fc/fc_udev_device/nvme_discovery
+        /sbin/initqueue --finished --onetime --unique --name nvme-fc-autoconnect /sbin/nvmf-autoconnect.sh
     fi
 fi


### PR DESCRIPTION
This pull request reworks the FC-NVMe connection handling. The original design of creating custom systemd services on the fly and activate them via udev doesn't work in the initrd due to the lack of dbus.
This patchset reworks the connection handling by using initqueue jobs to establish the initial connections.
Also the manpage is updated to document the nvmf commandline options.
