### PR TITLE
dracut-install: ignore bogus preload libs

### DIFF
--- a/install/dracut-install.c
+++ b/install/dracut-install.c
@@ -569,6 +569,9 @@ static int resolve_deps(const char *src)
                 if (strstr(buf, "cannot read header"))
                         break;
 
+                if (strstr(buf, "cannot be preloaded"))
+                        break;
+
                 if (strstr(buf, destrootdir))
                         break;
 


### PR DESCRIPTION
If there are any nonexistent libraries listed in /etc/ld.so.preload, ldd
prints error messages like:

ERROR: ld.so: object '/usr/lib64/libfoo.so.1' from /etc/ld.so.preload cannot be preloaded (cannot open shared object file): ignored.

This causes resolve_deps() to return error, which leads to symlinks
(like usr/bin/awk) not being copied into the initrd.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
