### PR TITLE
[RFC] cryptroot-ask: unify /etc/crypttab and rd.luks.key

### DIFF
--- a/modules.d/90crypt/cryptroot-ask.sh
+++ b/modules.d/90crypt/cryptroot-ask.sh
@@ -137,7 +137,8 @@ unset allowdiscards
 ask_passphrase=1
 
 if [ -n "$luksfile" -a "$luksfile" != "none" -a -e "$luksfile" ]; then
-    if cryptsetup --key-file "$luksfile" $cryptsetupopts luksOpen "$device" "$luksname"; then
+    if readkey "$luksfile" / "$device" \
+        | cryptsetup -d - $cryptsetupopts luksOpen "$device" "$luksname"; then
         ask_passphrase=0
     fi
 elif [ "$is_keysource" -ne 0 ]; then


### PR DESCRIPTION
dracut feeds whatever it receives in password field of
crypttab(5) to `cryptsetup -d`, treating them as plain-text key file.

Meanwhile, dracut treats the key file from `rd.luks.key` differently,
by have some special rules to decrypt those key files that has extension of
`gpg` and `img`.

Let's begin to treat them the same.

This is a backward-incompatible change for those people
that uses plain-text key-file that has extension of `gpg` and `img`.
However, those setup is questionable to begin with.

---

This pull request changes...

## Changes

*backward-incompatible*:
- TESTED: key-file that ends with gpg will be decrypted by gnupg before feeding into `cryptsetup`
- NOT-TESTED: key-file that ends with img will be decrypted before feeding into `cryptsetup`

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
