### PR TITLE
90kernel-modules: arm: add drivers/hwmon for arm/arm64

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -69,6 +69,7 @@ installkernel() {
                 "=drivers/dma" \
                 "=drivers/extcon" \
                 "=drivers/gpio" \
+                "=drivers/hwmon" \
                 "=drivers/hwspinlock" \
                 "=drivers/i2c/busses" \
                 "=drivers/mfd" \


### PR DESCRIPTION
In the case of the s805x the drivers/hwmon directory contains the
scpi_hwmon kernel module.
On a running system, lsmod would output the following dependencies:
 arm_scpi               24576  2 clk_scpi,scpi_hwmon

It means that if the clock driver is bundled in the initramfs it will
bring arm_scpi. But if scpi_hwmon is missing the scpi will be incomplete
and it can lead to crashes.

When the hwmon is bundled, no crash occurs

Signed-off-by: Nicolas Chauvet <kwizart@gmail.com>

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
