### PR TITLE
99memstrack: use /bin/bash

### DIFF
--- a/modules.d/99memstrack/memstrack-report.sh
+++ b/modules.d/99memstrack/memstrack-report.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 . /lib/dracut-lib.sh
 
 if ! [ "$DEBUG_MEM_LEVEL" -ge 4 ]; then

--- a/modules.d/99memstrack/module-setup.sh
+++ b/modules.d/99memstrack/module-setup.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 check() {
     if type -P memstrack >/dev/null; then


### PR DESCRIPTION
/usr/local/bin causes trouble for distros that do not use /usr/bin == /bin
/usr/bin/env likewise, plus the use of env is not needed here


This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it