### PR TITLE
Don't print when a module is explicitly omitted (by default)

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -839,7 +839,7 @@ check_module() {
     [[ $2 ]] || mods_checked_as_dep+=" $_mod "
 
     if [[ " $omit_dracutmodules " == *\ $_mod\ * ]]; then
-        dinfo "dracut module '$_mod' will not be installed, because it's in the list to be omitted!"
+        ddebug "dracut module '$_mod' will not be installed, because it's in the list to be omitted!"
         return 1
     fi
 


### PR DESCRIPTION
dracut builds today are fairly verbose to start, but on top of
that many of the messages tend to liberally use the
exclamation point `!` which calls attention to them.

I see these a lot when looking at rpm-ostree build logs
and it'd be nicer if we were quiet when there wasn't
an actual problem.

In this specific case, if the builder is explicitly adding
`--omit=foo`, there's no reason for us to say:

`dracut: dracut module 'foo' will not be installed, because it's in the list to be omitted!`

We already print the command line to start, so the information
is there.

(Not tested locally)