### PR TITLE
Remove uses of bash (and bash specific syntax) in runtime scripts

### DIFF
--- a/modules.d/90multipath/multipath-shutdown.sh
+++ b/modules.d/90multipath/multipath-shutdown.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 for i in $(multipath -l -v1); do
     if ! dmsetup table $i | sed -n '/.*queue_if_no_path.*/q1' ; then

--- a/modules.d/98dracut-systemd/dracut-cmdline-ask.sh
+++ b/modules.d/98dracut-systemd/dracut-cmdline-ask.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
@@ -15,8 +15,8 @@ echo
 echo
 echo "Enter additional kernel command line parameter (end with ctrl-d or .)"
 while read -e -p "> " line || [ -n "$line" ]; do
-    [[ "$line" == "." ]] && break
-    [[ "$line" ]] && printf -- "%s\n" "$line" >> /etc/cmdline.d/99-cmdline-ask.conf
+    [ "$line" = "." ] && break
+    [ -n "$line" ] && printf -- "%s\n" "$line" >> /etc/cmdline.d/99-cmdline-ask.conf
 done
 
 exit 0


### PR DESCRIPTION
dracutinstall picks up interpreters and includes bash despite
the users' wishes or expectations, as modules should not require
bashisms at runtime.

## Checklist
- [x] I have tested it locally

Fixes #951