### PR TITLE
Prevent creating unexpected files on the host when running dracut

### DIFF
--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -6,13 +6,15 @@ if [ -n "$NEWROOT" ]; then
     [ -d $NEWROOT ] || mkdir -p -m 0755 $NEWROOT
 fi
 
-if ! [ -d /run/initramfs ]; then
-    mkdir -p -m 0755 /run/initramfs/log
-    ln -sfn /run/initramfs/log /var/log
-fi
+if [ -z "$PREFIX" ]; then
+    if ! [ -d /run/initramfs ]; then
+        mkdir -p -m 0755 /run/initramfs/log
+        ln -sfn /run/initramfs/log /var/log
+    fi
 
-[ -d /run/lock ] || mkdir -p -m 0755 /run/lock
-[ -d /run/log ] || mkdir -p -m 0755 /run/log
+    [ -d /run/lock ] || mkdir -p -m 0755 /run/lock
+    [ -d /run/log ] || mkdir -p -m 0755 /run/log
+fi
 
 debug_off() {
     set +x


### PR DESCRIPTION
Library file `modules.d/99base/dracut-lib.sh` contains initialization code that makes sure certain directories and links are created when a system runs from the produced initramfs. This file is normally sourced only from initramfs scripts. However, `modules.d/99base/module-setup.sh` includes it also when an initramfs image is being created to gain access to some of the functions in this library. This can result in creating unexpected directories and links on the current root file system when the dracut command is executed.

For instance, during a system installation when dracut is invoked to create an initial initramfs, the target sysroot might not contain directory `/run/initramfs` but have `/var/log`. This situation results in the code in `modules.d/99base/dracut-lib.sh` creating an unexpected link `/var/log/log` that points to `/run/initramfs/log`. This link is then also present on the installed system.

The patch fixes the problem by skipping the described logic in `modules.d/99base/dracut-lib.sh` when the `PREFIX` variable is non-empty which indicates that a target initramfs is being prepared. The variable is set by `modules.d/99base/module-setup.sh` prior to including `dracut-lib.sh`.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it