### PR TITLE
dmsquash-live/iso-scan: Provide an easy reference to iso-scan device.

### DIFF
--- a/modules.d/90dmsquash-live/iso-scan.sh
+++ b/modules.d/90dmsquash-live/iso-scan.sh
@@ -22,6 +22,7 @@ do_iso_scan() {
         mount -t auto -o ro "$dev" "/run/initramfs/isoscan" || continue
         if [ -f "/run/initramfs/isoscan/$isofile" ]; then
             losetup -f "/run/initramfs/isoscan/$isofile"
+            ln -s $dev /run/initramfs/isoscandev
             rm -f -- "$job"
             exit 0
         else


### PR DESCRIPTION
With commit 3c8c807, `/run/initramfs/isoscan` and `/run/initramfs/live`
mountpoints are unmounted upon `rd.live.ram` boots.

## Changes
Save a reference link to the iso-scan device in `/run/initramfs/isoscandev` to easily remount
the source, if desired.

## Checklist

- [x] I have tested it locally
- [] I have reviewed and updated any documentation if relevant
- [] I am providing new code and test(s) for it

Fixes #
