### PR TITLE
Install less module for strict hostonly mode

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -526,7 +526,6 @@ check_block_and_slaves() {
     if [[ -f /sys/dev/block/$2/../dev ]] && [[ /sys/dev/block/$2/../subsystem -ef /sys/class/block ]]; then
         check_block_and_slaves $1 $(<"/sys/dev/block/$2/../dev") && return 0
     fi
-    [[ -d /sys/dev/block/$2/slaves ]] || return 1
     for _x in /sys/dev/block/$2/slaves/*; do
         [[ -f $_x/dev ]] || continue
         [[ $_x/subsystem -ef /sys/class/block ]] || continue
@@ -545,7 +544,6 @@ check_block_and_slaves_all() {
     if [[ -f /sys/dev/block/$2/../dev ]] && [[ /sys/dev/block/$2/../subsystem -ef /sys/class/block ]]; then
         check_block_and_slaves_all $1 $(<"/sys/dev/block/$2/../dev") && _ret=0
     fi
-    [[ -d /sys/dev/block/$2/slaves ]] || return 1
     for _x in /sys/dev/block/$2/slaves/*; do
         [[ -f $_x/dev ]] || continue
         [[ $_x/subsystem -ef /sys/class/block ]] || continue

--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -889,3 +889,8 @@ block_is_fcoe() {
 block_is_netdevice() {
     block_is_nbd "$1" || block_is_iscsi "$1" || block_is_fcoe "$1"
 }
+
+# get the corresponding kernel modules of a /sys/class/*/* or/dev/* device
+get_dev_module() {
+    udevadm info -a "$1" | sed -n 's/\s*DRIVERS=="\(\S\+\)"/\1/p'
+}

--- a/modules.d/04watchdog-modules/module-setup.sh
+++ b/modules.d/04watchdog-modules/module-setup.sh
@@ -18,41 +18,18 @@ install() {
 installkernel() {
     local -A _drivers
     local _alldrivers _wdtdrv _wdtppath _dir
-    [[ -d /sys/class/watchdog/ ]] || return
-    for _dir in /sys/class/watchdog/*; do
-        [[ -d "$_dir" ]] || continue
-        [[ -f "$_dir/state" ]] || continue
-        # device/modalias will return driver of this device
-        _wdtdrv=$(< "$_dir/device/modalias")
-        # There can be more than one module represented by same
-        # modalias. Currently load all of them.
-        # TODO: Need to find a way to avoid any unwanted module
-        # represented by modalias
-        _wdtdrv=$(modprobe --set-version "$kernel" -R $_wdtdrv 2>/dev/null)
+
+    for _wd in /sys/class/watchdog/*; do
+        ! [ -e $_wd ] && continue
+        _wdtdrv=$(get_dev_module $_wd)
         if [[ $_wdtdrv ]]; then
             instmods $_wdtdrv
             for i in $_wdtdrv; do
                 _drivers[$i]=1
             done
         fi
-        # however in some cases, we also need to check that if there is
-        # a specific driver for the parent bus/device.  In such cases
-        # we also need to enable driver for parent bus/device.
-        _wdtppath=$(readlink -f "$_dir/device")
-        while [[ -d "$_wdtppath" ]] && [[ "$_wdtppath" != "/sys" ]]; do
-            _wdtppath=$(readlink -f "$_wdtppath/..")
-            [[ -f "$_wdtppath/modalias" ]] || continue
-
-            _wdtdrv=$(< "$_wdtppath/modalias")
-            _wdtdrv=$(modprobe --set-version "$kernel" -R $_wdtdrv 2>/dev/null)
-            if [[ $_wdtdrv ]]; then
-                instmods $_wdtdrv
-                for i in $_wdtdrv; do
-                    _drivers[$i]=1
-                done
-            fi
-        done
     done
+
     # ensure that watchdog module is loaded as early as possible
     _alldrivers="${!_drivers[*]}"
     [[ $_alldrivers ]] && echo "rd.driver.pre=${_alldrivers// /,}" > ${initdir}/etc/cmdline.d/00-watchdog.conf

--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -8,6 +8,9 @@ check() {
 # called by dracut
 depends() {
     echo -n "kernel-network-modules "
+
+    is_qemu_virtualized && echo -n "qemu-net "
+
     if ! dracut_module_included "network-legacy" && [ -x "$dracutsysrootdir/usr/libexec/nm-initrd-generator" ] ; then
         echo "network-manager"
     else

--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -35,8 +35,9 @@ installkernel() {
     install_block_modules () {
         instmods \
             scsi_dh_rdac scsi_dh_emc scsi_dh_alua \
+            =drivers/usb/storage \
             =ide nvme vmd \
-            virtio_blk
+            virtio_blk virtio_scsi
 
         dracut_instmods -o -s "${_blockfuncs}" "=drivers"
     }
@@ -48,7 +49,6 @@ installkernel() {
             ohci-hcd ohci-pci \
             uhci-hcd \
             xhci-hcd xhci-pci xhci-plat-hcd \
-            "=drivers/pinctrl" \
             ${NULL}
 
         hostonly=$(optional_hostonly) instmods \
@@ -56,15 +56,15 @@ installkernel() {
             "=drivers/tty/serial" \
             "=drivers/input/serio" \
             "=drivers/input/keyboard" \
-            "=drivers/usb/storage" \
             "=drivers/pci/host" \
             "=drivers/pci/controller" \
+            "=drivers/pinctrl" \
             ${NULL}
 
         instmods \
             yenta_socket \
             atkbd i8042 usbhid firewire-ohci pcmcia hv-vmbus \
-            virtio virtio_ring virtio_pci virtio_scsi pci_hyperv \
+            virtio virtio_ring virtio_pci pci_hyperv \
             "=drivers/pcmcia"
 
         if [[ "${DRACUT_ARCH:-$(uname -m)}" == arm* || "${DRACUT_ARCH:-$(uname -m)}" == aarch64 ]]; then

--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -3,6 +3,7 @@
 # called by dracut
 installkernel() {
     local _blockfuncs='ahci_platform_get_resources|ata_scsi_ioctl|scsi_add_host|blk_cleanup_queue|register_mtd_blktrans|scsi_esp_register|register_virtio_device|usb_stor_disconnect|mmc_add_host|sdhci_add_host|scsi_add_host_with_dma'
+    local _hostonly_drvs
 
     find_kernel_modules_external () {
         local _OLDIFS
@@ -19,13 +20,19 @@ installkernel() {
         IFS=$_OLDIFS
     }
 
-    is_block_dev() {
-        [ -e /sys/dev/block/$1 ] && return 0
+    record_block_dev_drv() {
+        for _mod in $(get_dev_module /dev/block/$1); do
+            [[ " $_hostonly_drvs " != *$_mod* ]] && _hostonly_drvs+=" $_mod"
+        done
+        [[ "$_hostonly_drvs" ]] && return 0
         return 1
     }
 
+    install_block_modules_strict () {
+        hostonly='' instmods $_hostonly_drvs
+    }
+
     install_block_modules () {
-        hostonly='' instmods sg sr_mod sd_mod scsi_dh ata_piix
         instmods \
             scsi_dh_rdac scsi_dh_emc scsi_dh_alua \
             =ide nvme vmd \
@@ -93,8 +100,18 @@ installkernel() {
 
         find_kernel_modules_external | instmods
 
-        if ! [[ $hostonly ]] || for_each_host_dev_and_slaves is_block_dev; then
-            install_block_modules
+        # if not on hostonly mode, or there are hostonly block device
+        # install block drivers
+        if ! [[ $hostonly ]] || \
+            for_each_host_dev_and_slaves_all record_block_dev_drv;
+        then
+            hostonly='' instmods sg sr_mod sd_mod scsi_dh ata_piix
+
+            if [[ "$hostonly_mode" == "strict" ]]; then
+                install_block_modules_strict
+            else
+                install_block_modules
+            fi
         fi
 
         # if not on hostonly mode, install all known filesystems,

--- a/modules.d/90qemu-net/module-setup.sh
+++ b/modules.d/90qemu-net/module-setup.sh
@@ -17,5 +17,5 @@ check() {
 # called by dracut
 installkernel() {
     # qemu specific modules
-    hostonly='' instmods virtio_net e1000 8139cp pcnet32 e100 ne2k_pci
+    hostonly=$(optional_hostonly) instmods virtio_net e1000 8139cp pcnet32 e100 ne2k_pci
 }

--- a/modules.d/90qemu-net/module-setup.sh
+++ b/modules.d/90qemu-net/module-setup.sh
@@ -2,10 +2,15 @@
 
 # called by dracut
 check() {
-    if [[ $hostonly ]] || [[ $mount_needs ]]; then
+    if [[ $hostonly ]]; then
+        return 255
+    fi
+
+    if [[ $mount_needs ]]; then
         is_qemu_virtualized && return 0
         return 255
     fi
+
     return 0
 }
 

--- a/modules.d/95nfs/module-setup.sh
+++ b/modules.d/95nfs/module-setup.sh
@@ -38,7 +38,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    hostonly='' instmods =net/sunrpc =fs/nfs ipv6 nfs_acl nfs_layout_nfsv41_files
+    hostonly=$(optional_hostonly) instmods =net/sunrpc =fs/nfs ipv6 nfs_acl nfs_layout_nfsv41_files
 }
 
 cmdline() {


### PR DESCRIPTION
This pull request changes...

## Changes
Install less module for strict hostonly mode. Strict hostonly mode is used by kdump, which expect the initramfs to be as small as possible. 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
