### PR TITLE
Introduce a --hostonly-nics option

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -175,6 +175,8 @@ Creates initial ramdisk images for preloading modules
   --hostonly-i18n       Install only needed keyboard and font files according
                         to the host configuration (default).
   --no-hostonly-i18n    Install all keyboard and font files available.
+  --hostonly-nics [LIST]
+                        Only enable listed NICs in the initramfs.
   --persistent-policy [POLICY]
                         Use [POLICY] to address disks and partitions.
                         POLICY can be any directory name found in /dev/disk.
@@ -424,6 +426,7 @@ rearrange_params()
         --long kernel-image: \
         --long no-hostonly-i18n \
         --long hostonly-i18n \
+        --long hostonly-nics: \
         --long no-machineid \
         --long version \
         -- "$@")
@@ -587,6 +590,8 @@ while :; do
                        hostonly_cmdline_l="yes" ;;
         --hostonly-i18n)
                        i18n_install_all_l="no" ;;
+        --hostonly-nics)
+                       hostonly_nics_l+=("$2");           PARMS_TO_STORE+=" '$2'"; shift;;
         --no-hostonly-i18n)
                        i18n_install_all_l="yes" ;;
         --no-hostonly-cmdline)
@@ -755,6 +760,7 @@ unset NPATH
 (( ${#fstab_lines_l[@]} )) && fstab_lines+=( "${fstab_lines_l[@]}" )
 (( ${#install_items_l[@]} )) && install_items+=" ${install_items_l[@]} "
 (( ${#install_optional_items_l[@]} )) && install_optional_items+=" ${install_optional_items_l[@]} "
+(( ${#hostonly_nics_l[@]} )) && hostonly_nics+=" ${hostonly_nics_l[@]} "
 
 # these options override the stuff in the config file
 (( ${#dracutmodules_l[@]} )) && dracutmodules="${dracutmodules_l[@]}"

--- a/modules.d/90kernel-network-modules/module-setup.sh
+++ b/modules.d/90kernel-network-modules/module-setup.sh
@@ -41,7 +41,6 @@ installkernel() {
         =drivers/net/team \
         =drivers/net/ethernet \
         ecb arc4 bridge stp llc ipv6 bonding 8021q ipvlan macvlan af_packet virtio_net xennet
-    hostonly="" instmods iscsi_ibft crc32c iscsi_boot_sysfs
 }
 
 # called by dracut

--- a/modules.d/90kernel-network-modules/module-setup.sh
+++ b/modules.d/90kernel-network-modules/module-setup.sh
@@ -14,15 +14,27 @@ depends() {
 installkernel() {
     # Include wired net drivers, excluding wireless
     local _arch=${DRACUT_ARCH:-$(uname -m)}
-    local _net_drivers='eth_type_trans|register_virtio_device|usbnet_open'
+    local _net_symbols='eth_type_trans|register_virtio_device|usbnet_open'
     local _unwanted_drivers='/(wireless|isdn|uwb|net/ethernet|net/phy|net/team)/'
+    local _net_drivers
 
     if [ "$_arch" = "s390" -o "$_arch" = "s390x" ]; then
-        _s390drivers="=drivers/s390/net"
+        dracut_instmods -o -P ".*${_unwanted_drivers}.*" -s "$_net_symbols" "=drivers/s390/net"
     fi
 
-    dracut_instmods -o -P ".*${_unwanted_drivers}.*" -s "$_net_drivers" "=drivers/net" ${_s390drivers:+"$_s390drivers"}
+    if [[ $hostonly_mode == 'strict' ]] && [[ $hostonly_nics ]]; then
+        for _nic in $hostonly_nics; do
+            _net_drivers=$(get_dev_module /sys/class/net/$_nic)
+            if ! [[ $_net_drivers ]]; then
+                derror "--hostonly-nics contains invalid NIC '$_nic'"
+                continue
+            fi
+            hostonly="" instmods $_net_drivers
+        done
+        return 0
+    fi
 
+    dracut_instmods -o -P ".*${_unwanted_drivers}.*" -s "$_net_symbols" "=drivers/net"
     #instmods() will take care of hostonly
     instmods \
         =drivers/net/phy \


### PR DESCRIPTION
This pull request changes...

## Changes
Introduce a --hostonly-nics param, with this param, if strict hostonly mode is used, it will only install driver for specified **NIC.000p**

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
