### PR TITLE
90crypt: ship initrd-cryptsetup.target

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -66,7 +66,6 @@ install() {
         \
         $systemdsystemunitdir/cryptsetup.target \
         $systemdsystemunitdir/cryptsetup-pre.target \
-        $systemdsystemunitdir/remote-cryptsetup.target \
         $systemdsystemunitdir/emergency.target \
         $systemdsystemunitdir/sysinit.target \
         $systemdsystemunitdir/basic.target \

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -151,6 +151,8 @@ install() {
                       $systemdsystemunitdir/systemd-ask-password-console.service \
                       $systemdsystemunitdir/cryptsetup.target \
                       $systemdsystemunitdir/sysinit.target.wants/cryptsetup.target \
+                      $systemdsystemunitdir/initrd-cryptsetup.target \
+                      $systemdsystemunitdir/sysinit.target.wants/initrd-cryptsetup.target \
                       systemd-ask-password systemd-tty-ask-password-agent
     fi
 

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -151,7 +151,6 @@ install() {
                       $systemdsystemunitdir/systemd-ask-password-console.service \
                       $systemdsystemunitdir/cryptsetup.target \
                       $systemdsystemunitdir/sysinit.target.wants/cryptsetup.target \
-                      $systemdsystemunitdir/initrd-root-fs.target.wants/remote-cryptsetup.target \
                       systemd-ask-password systemd-tty-ask-password-agent
     fi
 


### PR DESCRIPTION
This was added in https://github.com/systemd/systemd/pull/17149 and is
the designated cryptsetup target for all encrypted volumes that need to
be opened in the initrd.

So it effectively replaces `cryptsetup.target` and
`remote-cryptsetup.target` there. I've removed the latter since it was
added recently (by me) in #930, but kept `cryptsetup.target` since we've
been shipping it for a long time now.
