### PR TITLE
Configure the runner for team interfaces

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -667,9 +667,13 @@ interface name. Better name it "bootnet" or "bluesocket".
     Bond without parameters assumes
     bond=bond0:eth0,eth1:mode=balance-rr
 
-**team=**__<teammaster>__:__<teamslaves>__::
+**team=**__<teammaster>__:__<teamslaves>__[:__<teamrunner>__]::
     Setup team device <teammaster> on top of <teamslaves>.
     <teamslaves> is a comma-separated list of physical (ethernet) interfaces.
+    <teamrunner> is the runner type to be used (see *teamd.conf*(5)); defaults to
+    activebackup.
+    Team without parameters assumes
+    team=team0:eth0,eth1:activebackup
 
 **bridge=**__<bridgename>__:__<ethnames>__::
     Setup bridge <bridgename> with <ethnames>. <ethnames> is a comma-separated

--- a/modules.d/35network-legacy/parse-team.sh
+++ b/modules.d/35network-legacy/parse-team.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 #
 # Format:
-#       team=<teammaster>:<teamslaves>
+#       team=<teammaster>:<teamslaves>[:<teamrunner>]
 #
 #       teamslaves is a comma-separated list of physical (ethernet) interfaces
+#       teamrunner is the runner type to be used (see teamd.conf(5)); defaults to activebackup
+#
+#       team without parameters assumes team=team0:eth0,eth1:activebackup
 #
 
 parseteam() {
@@ -15,8 +18,11 @@ parseteam() {
     done
 
     case $# in
-    2)  teammaster=$1; teamslaves=$(str_replace "$2" "," " ") ;;
-    *)  die "team= requires two parameters" ;;
+    0)  teammaster=team0; teamslaves="eth0 eth1"; teamrunner="activebackup" ;;
+    1)  teammaster=$1; teamslaves="eth0 eth1"; teamrunner="activebackup" ;;
+    2)  teammaster=$1; teamslaves=$(str_replace "$2" "," " "); teamrunner="activebackup" ;;
+    3)  teammaster=$1; teamslaves=$(str_replace "$2" "," " "); teamrunner=$3 ;;
+    *)  die "team= requires zero to three parameters" ;;
     esac
     return 0
 }
@@ -26,16 +32,18 @@ for team in $(getargs team); do
 
     unset teammaster
     unset teamslaves
+    unset teamrunner
 
     parseteam "$team" || continue
 
     echo "teammaster=$teammaster" > /tmp/team.${teammaster}.info
     echo "teamslaves=\"$teamslaves\"" >> /tmp/team.${teammaster}.info
+    echo "teamrunner=\"$teamrunner\"" >> /tmp/team.${teammaster}.info
 
     if ! [ -e /etc/teamd/${teammaster}.conf ]; then
-        warn "Team master $teammaster specified, but no /etc/teamd/$teammaster.conf present. Using activebackup."
+        warn "Team master $teammaster specified, but no /etc/teamd/$teammaster.conf present. Using $teamrunner."
         mkdir -p /etc/teamd
-        printf -- "%s" '{"runner": {"name": "activebackup"}, "link_watch": {"name": "ethtool"}}' > "/etc/teamd/${teammaster}.conf"
+        printf -- "%s" "{\"runner\": {\"name\": \"$teamrunner\"}, \"link_watch\": {\"name\": \"ethtool\"}}" > "/tmp/${teammaster}.conf"
     fi
 done
 


### PR DESCRIPTION
Cfr. [Bug 1881463 - [RFE] Requesting ability to configure the runner for team interfaces in dracut.cmdline/installations](https://bugzilla.redhat.com/show_bug.cgi?id=1881463)

Requesting the ability to configure the runners for a team interface similar to bond.

       bond=<bondname>[:<bondslaves>:[:<options>[:<mtu>]]]

vs

       team=<teammaster>:<teamslaves>

This impacts the ability of users to perform network installations when LACP is required. There is no way to get to stage2 and get the kickstart without configuring this first and we can't do it in dracut.

## Changes
Added a parameter for configuring the runner and aligned the default values with bonding config:

       team=<teammaster>:<teamslaves>[:<teamrunner>]
              Setup team device <teammaster> on top of <teamslaves>.
              <teamslaves> is a comma-separated list of physical (ethernet) interfaces.
              <teamrunner> is the runner type to be used (see teamd.conf(5)); defaults to activebackup.
              Team without parameters assumes team=team0:eth0,eth1:activebackup

## Checklist
- [ ] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes [Bug 1881463 - [RFE] Requesting ability to configure the runner for team interfaces in dracut.cmdline/installations](https://bugzilla.redhat.com/show_bug.cgi?id=1881463)
