### PR TITLE
Revert "90crypt: ship initrd-cryptsetup.target"

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -66,6 +66,7 @@ install() {
         \
         $systemdsystemunitdir/cryptsetup.target \
         $systemdsystemunitdir/cryptsetup-pre.target \
+        $systemdsystemunitdir/remote-cryptsetup.target \
         $systemdsystemunitdir/emergency.target \
         $systemdsystemunitdir/sysinit.target \
         $systemdsystemunitdir/basic.target \

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -151,8 +151,6 @@ install() {
                       $systemdsystemunitdir/systemd-ask-password-console.service \
                       $systemdsystemunitdir/cryptsetup.target \
                       $systemdsystemunitdir/sysinit.target.wants/cryptsetup.target \
-                      $systemdsystemunitdir/initrd-cryptsetup.target \
-                      $systemdsystemunitdir/sysinit.target.wants/initrd-cryptsetup.target \
                       systemd-ask-password systemd-tty-ask-password-agent
     fi
 


### PR DESCRIPTION
This reverts commit 8f56daa8c3c75b167823286553f223e5b46cd6ab.

The addition of `initrd-cryptsetup.target` was reverted in systemd:
https://github.com/systemd/systemd/pull/17467