### PR TITLE
Allow LiveOS image from a nbd device

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -78,7 +78,11 @@ if [ -f $livedev ]; then
     esac
     [ -e /sys/fs/$fstype ] || modprobe $fstype
 else
-    if [ "$(blkid -o value -s TYPE $livedev)" != "ntfs" ]; then
+    livedev_fstype=$(blkid -o value -s TYPE $livedev)
+    if [ "$livedev_fstype" = "squashfs" ]; then
+       # no mount needed - we've already got the LiveOS image in $livedev
+       SQUASHED=$livedev
+    elif [ "$livedev_fstype" != "ntfs" ]; then
         mount -n -t $fstype -o ${liverw:-ro} $livedev /run/initramfs/live
     else
         # Symlinking /usr/bin/ntfs-3g as /sbin/mount.ntfs seems to boot

--- a/modules.d/95nbd/nbdroot.sh
+++ b/modules.d/95nbd/nbdroot.sh
@@ -109,25 +109,9 @@ if strstr "$(nbd-client --help 2>&1)" "systemd-mark"; then
 fi
 
 if [ "$nbdport" -gt 0 ] 2>/dev/null; then
-    if [ -z "$DRACUT_SYSTEMD" ]; then
-        nbd-client "$nbdserver" $nbdport /dev/nbd0 $preopts $opts || exit 1
-    else
-        systemd-run --no-block --service-type=forking --quiet \
-                    --description="nbd nbd0" \
-                    -p 'DefaultDependencies=no' \
-                    -p 'KillMode=none' \
-                    --unit="nbd0" -- nbd-client "$nbdserver" $nbdport /dev/nbd0 $preopts $opts >/dev/null 2>&1 || exit 1
-    fi
+    nbd-client "$nbdserver" $nbdport /dev/nbd0 $preopts $opts || exit 1
 else
-    if [ -z "$DRACUT_SYSTEMD" ]; then
-        nbd-client -name "$nbdport" "$nbdserver" /dev/nbd0 $preopts $opts || exit 1
-    else
-        systemd-run --no-block --service-type=forking --quiet \
-                    --description="nbd nbd0" \
-                    -p 'DefaultDependencies=no' \
-                    -p 'KillMode=none' \
-                    --unit="nbd0" --  nbd-client -name "$nbdport" "$nbdserver" /dev/nbd0 $preopts $opts >/dev/null 2>&1 || exit 1
-    fi
+    nbd-client -name "$nbdport" "$nbdserver" /dev/nbd0 $preopts $opts || exit 1
 fi
 
 # NBD doesn't emit uevents when it gets connected, so kick it


### PR DESCRIPTION
This pull request changes...

## Changes

Allows to use an nbd device exporting an squashfs image in a overlay setup.

## Checklist
- [X] I have tested it locally
- [  ] I have reviewed and updated any documentation if relevant
- [  ] I am providing new code and test(s) for it