### PR TITLE
90crypt: pull in remote-cryptsetup.target enablement

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -144,6 +144,8 @@ install() {
     inst_script "$moddir/crypt-run-generator.sh" "/sbin/crypt-run-generator"
 
     if dracut_module_included "systemd"; then
+        # the cryptsetup targets are already pulled in by 00systemd, but not
+        # the enablement symlinks
         inst_multiple -o \
                       $systemdutildir/system-generators/systemd-cryptsetup-generator \
                       $systemdutildir/systemd-cryptsetup \
@@ -151,6 +153,8 @@ install() {
                       $systemdsystemunitdir/systemd-ask-password-console.service \
                       $systemdsystemunitdir/cryptsetup.target \
                       $systemdsystemunitdir/sysinit.target.wants/cryptsetup.target \
+                      $systemdsystemunitdir/remote-cryptsetup.target \
+                      $systemdsystemunitdir/initrd-root-device.target.wants/remote-cryptsetup.target \
                       systemd-ask-password systemd-tty-ask-password-agent
     fi
 


### PR DESCRIPTION
This should've been part of #964. As mentioned there, the
`initrd-cryptsetup.target` approach was reverted in the end, and we went
back to relying in `remote-cryptsetup.target`:

https://github.com/systemd/systemd/pull/17467

So we do need to ship the enablement symlink for it.