### PR TITLE
install kpartx's 11-dm-parts.rules for multipath

### DIFF
--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -125,6 +125,6 @@ install() {
     inst_rules 40-multipath.rules 56-multipath.rules \
 	62-multipath.rules 65-multipath.rules \
 	66-kpartx.rules 67-kpartx-compat.rules \
-	11-dm-mpath.rules
+	11-dm-mpath.rules 11-dm-parts.rules
 }
 


### PR DESCRIPTION
This makes /dev/disk/by-uuid links point to the right device.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
