### PR TITLE
configure: Find FTS library with --as-needed

### DIFF
--- a/configure
+++ b/configure
@@ -85,7 +85,7 @@ EOF
 
 found=no
 for lib in "-lc" "-lfts"; do
-	${CC} $CFLAGS -Wl,$lib $LDFLAGS conftest.c >/dev/null 2>&1
+	${CC} $CFLAGS $LDFLAGS conftest.c -Wl,$lib >/dev/null 2>&1
 	ret=$?
 	if test $ret -eq 0; then
 		FTS_LIBS="$lib"


### PR DESCRIPTION
When LDFLAGS contains ``-Wl,--as-needed``, the FTS library will be
ignored if it is specified before the .c source.

Signed-off-by: A. Wilcox <AWilcox@Wilcox-Tech.com>
Fixes: 62f27ee6f145 ("configure: find cflags and libs for fts on musl")

Obsoletes #781. Code is identical, but rebased on top of master.

- [x] I have tested it locally