### PR TITLE
95fcoe: ensure needed modules are installed

### DIFF
--- a/modules.d/95fcoe/module-setup.sh
+++ b/modules.d/95fcoe/module-setup.sh
@@ -23,7 +23,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods fcoe 8021q edd
+    instmods fcoe libfcoe 8021q edd bnx2fc
 }
 
 get_vlan_parent() {


### PR DESCRIPTION
If fcoe module is loaded, the initramfs will always try load libfcoe
and bnx2fc, so also ensure they are installed if needed.

## Changes
Try install libfcoe and bnx2fc when 95fcoe is installed.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
