### PR TITLE
95fcoe: don't install if there is no FCoE hostonly devices

### DIFF
--- a/modules.d/95fcoe-uefi/module-setup.sh
+++ b/modules.d/95fcoe-uefi/module-setup.sh
@@ -2,22 +2,15 @@
 
 # called by dracut
 check() {
-    local _fcoe_ctlr
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
-        for c in /sys/bus/fcoe/devices/ctlr_* ; do
-            [ -L $c ] || continue
-            _fcoe_ctlr=$c
-        done
-        [ -z "$_fcoe_ctlr" ] && return 255
+    is_fcoe() {
+        block_is_fcoe $1 || return 1
     }
+
     [[ $hostonly ]] || [[ $mount_needs ]] && {
+        for_each_host_dev_and_slaves is_fcoe || return 255
         [ -d /sys/firmware/efi ] || return 255
-        for c in /sys/bus/fcoe/devices/ctlr_* ; do
-            [ -L $c ] || continue
-            fcoe_ctlr=$c
-        done
-        [ -z "$fcoe_ctlr" ] && return 255
     }
+
     require_binaries dcbtool fipvlan lldpad ip readlink || return 1
     return 0
 }

--- a/modules.d/95fcoe/module-setup.sh
+++ b/modules.d/95fcoe/module-setup.sh
@@ -2,13 +2,12 @@
 
 # called by dracut
 check() {
-    local _fcoe_ctlr
+    is_fcoe() {
+        block_is_fcoe $1 || return 1
+    }
+
     [[ $hostonly ]] || [[ $mount_needs ]] && {
-        for c in /sys/bus/fcoe/devices/ctlr_* ; do
-            [ -L $c ] || continue
-            _fcoe_ctlr=$c
-        done
-        [ -z "$_fcoe_ctlr" ] && return 255
+        for_each_host_dev_and_slaves is_fcoe || return 255
     }
 
     require_binaries dcbtool fipvlan lldpad ip readlink fcoemon fcoeadm || return 1


### PR DESCRIPTION
## Changes
When in hostonly mode, 95fcoe module will still be installed even there
is no FCoE hostonly device. So use the new block_is_fcoe helper to check
for hostonly device in hostonly mode, avoid installing unneccessary module.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
