### PR TITLE
fix: mdraid improvements

### DIFF
--- a/modules.d/90mdraid/65-md-incremental-imsm.rules
+++ b/modules.d/90mdraid/65-md-incremental-imsm.rules
@@ -39,6 +39,6 @@ RUN+="/sbin/initqueue --timeout --name 50-mdraid_start --onetime --unique /sbin/
 #
 LABEL="md_incremental"
 
-RUN+="/sbin/mdadm $env{rd_MD_OFFROOT} -I $env{DEVNAME}"
+RUN+="/sbin/mdadm -I $env{DEVNAME}"
 
 LABEL="md_end"

--- a/modules.d/90mdraid/md-shutdown.sh
+++ b/modules.d/90mdraid/md-shutdown.sh
@@ -3,12 +3,11 @@
 _do_md_shutdown() {
     local ret
     local final=$1
-    local _offroot=$(strstr "$(mdadm --help-options 2>&1)" offroot && echo --offroot)
     info "Waiting for mdraid devices to be clean."
-    mdadm $_offroot -vv --wait-clean --scan| vinfo
+    mdadm -vv --wait-clean --scan| vinfo
     ret=$?
     info "Disassembling mdraid devices."
-    mdadm $_offroot -vv --stop --scan | vinfo
+    mdadm -vv --stop --scan | vinfo
     ret=$(($ret+$?))
     if [ "x$final" != "x" ]; then
         info "/proc/mdstat:"

--- a/modules.d/90mdraid/mdraid-cleanup.sh
+++ b/modules.d/90mdraid/mdraid-cleanup.sh
@@ -2,7 +2,6 @@
 
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
-_offroot=$(strstr "$(mdadm --help-options 2>&1)" offroot && echo --offroot)
 containers=""
 for md in /dev/md[0-9_]*; do
     [ -b "$md" ] || continue
@@ -12,11 +11,11 @@ for md in /dev/md[0-9_]*; do
         containers="$containers $md"
         continue
     fi
-    mdadm $_offroot -S "$md" >/dev/null 2>&1
+    mdadm -S "$md" >/dev/null 2>&1
 done
 
 for md in $containers; do
-    mdadm $_offroot -S "$md" >/dev/null 2>&1
+    mdadm -S "$md" >/dev/null 2>&1
 done
 
-unset containers udevinfo _offroot
+unset containers udevinfo

--- a/modules.d/90mdraid/mdraid-waitclean.sh
+++ b/modules.d/90mdraid/mdraid-waitclean.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 if getargbool 0 rd.md.waitclean; then
-    _offroot=$(strstr "$(mdadm --help-options 2>&1)" offroot && echo --offroot)
     type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
     containers=""
     for md in /dev/md[0-9_]*; do
@@ -13,13 +12,13 @@ if getargbool 0 rd.md.waitclean; then
             continue
         fi
         info "Waiting for $md to become clean"
-        mdadm $_offroot -W "$md" >/dev/null 2>&1
+        mdadm -W "$md" >/dev/null 2>&1
     done
 
     for md in $containers; do
         info "Waiting for $md to become clean"
-        mdadm $_offroot -W "$md" >/dev/null 2>&1
+        mdadm -W "$md" >/dev/null 2>&1
     done
 
-    unset containers udevinfo _offroot
+    unset containers udevinfo
 fi

--- a/modules.d/90mdraid/mdraid_start.sh
+++ b/modules.d/90mdraid/mdraid_start.sh
@@ -7,7 +7,6 @@ _md_start() {
     local _path_s
     local _path_d
     local _md="$1"
-    local _offroot="$2"
 
     _udevinfo="$(udevadm info --query=env --name="${_md}")"
     strstr "$_udevinfo" "MD_LEVEL=container" && continue
@@ -19,7 +18,7 @@ _md_start() {
     # inactive ?
     [ "$(cat "$_path_s")" != "inactive" ] && continue
 
-    mdadm $_offroot -R "${_md}" 2>&1 | vinfo
+    mdadm -R "${_md}" 2>&1 | vinfo
 
     # still inactive ?
     [ "$(cat "$_path_s")" = "inactive" ] && continue
@@ -30,13 +29,10 @@ _md_start() {
 }
 
 _md_force_run() {
-    local _offroot
     local _md
     local _UUID
     local _MD_UUID=$(getargs rd.md.uuid -d rd_MD_UUID=)
     [ -n "$_MD_UUID" ] || getargbool 0 rd.auto || return
-
-    _offroot=$(strstr "$(mdadm --help-options 2>&1)" offroot && echo --offroot)
 
     if [ -n "$_MD_UUID" ]; then
         _MD_UUID=$(str_replace "$_MD_UUID" "-" "")
@@ -58,13 +54,13 @@ _md_force_run() {
             # check if we should handle this device
             strstr " $_MD_UUID " " $_UUID " || continue
 
-            _md_start "${_md}" "${_offroot}"
+            _md_start "${_md}"
         done
     else
         # try to force-run anything not running yet
         for _md in /dev/md[0-9_]*; do
             [ -b "$_md" ] || continue
-            _md_start "${_md}" "${_offroot}"
+            _md_start "${_md}"
         done
     fi
 }

--- a/modules.d/90mdraid/module-setup.sh
+++ b/modules.d/90mdraid/module-setup.sh
@@ -136,6 +136,9 @@ install() {
         if [ -e $dracutsysrootdir$systemdsystemunitdir/mdadm-last-resort@.timer ]; then
             inst_simple $systemdsystemunitdir/mdadm-last-resort@.timer
         fi
+        if [ -e $dracutsysrootdir$systemdsystemunitdir/mdadm-grow-continue@.service ]; then
+            inst_simple $systemdsystemunitdir/mdadm-grow-continue@.service
+        fi
     fi
     inst_hook pre-shutdown 30 "$moddir/mdmon-pre-shutdown.sh"
     dracut_need_initqueue

--- a/modules.d/90mdraid/parse-md.sh
+++ b/modules.d/90mdraid/parse-md.sh
@@ -60,5 +60,3 @@ if ! getargbool 1 rd.md.ddf -n rd_NO_MDDDF -n noddfmd -n nodmraid; then
     info "no MD RAID for SNIA ddf raids"
     udevproperty rd_NO_MDDDF=1
 fi
-
-strstr "$(mdadm --help-options 2>&1)" offroot && udevproperty rd_MD_OFFROOT=--offroot


### PR DESCRIPTION
## This pull request changes...
First commit adds missing service.
It is a background daemon. It is important to start it during raid assembly. It switches md array to rw mode.
Later process can be safety killed and restarted after switch root.

The second one is small improvement, see:
https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git/commit/?id=3e23ba9d7bd3c2a9fbddc286014480672763e563

## Checklist
- [X] I have tested it locally

## Fixes
We shall avoid creating daemons from udevd context. Fork shall be killed unconditionally but I observe situation when booting hangs for a while (I didn't investigate it deeply). Adding service resolves the problems.