### PR TITLE
multipathd: fix the comparison

### DIFF
--- a/modules.d/90multipath/multipathd.sh
+++ b/modules.d/90multipath/multipathd.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "$(getarg rd.multipath)x" == "default" ] && [ ! -e /etc/multipath.conf ]; then
+if [ "$(getarg rd.multipath)" = "default" ] && [ ! -e /etc/multipath.conf ]; then
     mkdir -p /etc/multipath/multipath.conf.d
     mpathconf --enable
 fi


### PR DESCRIPTION
From shellcheck:
/usr/lib/dracut/modules.d/90multipath/multipathd.sh:3:32: warning[SC2039]: In POSIX sh, == in place of = is undefined.
/usr/lib/dracut/modules.d/90multipath/multipathd.sh:3:32: warning[SC2193]: The arguments to this comparison can never be equal.

