### PR TITLE
fix(90kernel-modules): install generic crypto modules with hostonly unset

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -131,7 +131,8 @@ installkernel() {
         [[ $arch == x86_64 ]] && arch=x86
         [[ $arch == s390x ]] && arch=s390
         [[ $arch == aarch64 ]] && arch=arm64
-        instmods "=crypto" "=arch/$arch/crypto" "=drivers/crypto"
+        hostonly='' instmods "=crypto"
+        instmods "=arch/$arch/crypto" "=drivers/crypto"
     fi
     :
 }


### PR DESCRIPTION
Otherwise e.g. the xts(aes) implementation provided by the vmx_crypto
module (which does usually get included on ppc64le) fails to initialize
when xts is built as a module (CONFIG_CRYPTO_XTS=m), because it can't
instantiate the fallback generic xts(aes) implementation (needs the
generic xts module).

## Changes
(see commit message)

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
  - not sure if this can be easily tested, as it requires running a kernel with a specific config and some HW crypto driver that requires a fallback algorithm implementation