### PR TITLE
Revert "Retrieve service, rpc and protcol entries via getent in hostonly mode"

### DIFF
--- a/modules.d/95cifs/module-setup.sh
+++ b/modules.d/95cifs/module-setup.sh
@@ -37,13 +37,7 @@ install() {
     local _i
     local _nsslibs
     inst_multiple -o mount.cifs
-    inst_multiple /etc/nsswitch.conf
-    if [ $hostonly ]; then
-        getent services > ${initdir}/etc/services
-        getent protocols > ${initdir}/etc/protocols
-    else
-        inst_multiple /etc/services /etc/protocols
-    fi
+    inst_multiple /etc/services /etc/nsswitch.conf /etc/protocols
 
     inst_libdir_file 'libcap-ng.so*'
 

--- a/modules.d/95nfs/module-setup.sh
+++ b/modules.d/95nfs/module-setup.sh
@@ -77,16 +77,8 @@ cmdline() {
 install() {
     local _i
     local _nsslibs
-    inst_multiple -o portmap rpcbind rpc.statd mount.nfs \
-        mount.nfs4 umount rpc.idmapd sed /etc/netconfig chmod "$tmpfilesdir/rpcbind.conf"
-    inst_multiple /etc/nsswitch.conf /etc/idmapd.conf
-    if [ $hostonly ]; then
-        getent services > ${initdir}/etc/services
-        getent protocols > ${initdir}/etc/protocols
-        getent rpc > ${initdir}/etc/rpc
-    else
-        inst_multiple /etc/services /etc/protocols /etc/rpc
-    fi
+    inst_multiple -o rpc.idmapd mount.nfs mount.nfs4 umount sed /etc/netconfig chmod "$tmpfilesdir/rpcbind.conf"
+    inst_multiple /etc/services /etc/nsswitch.conf /etc/rpc /etc/protocols /etc/idmapd.conf
 
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _netconf="$(cmdline)"


### PR DESCRIPTION
The underlying issues this was trying to solve is to get a cheap
workaround for the fact that (open)SUSE with atomic support moved
/etc stock files to /usr/etc in order to improve compatibility. But
now that even nsswitch.conf moved, this is no longer enough. And it
might be more trouble to support once it's in an official release.

So let's rather drop it now.

This reverts commit e0524af2bf83184e18d068bea4356a719d2385c2.