### PR TITLE
ci: add testing with Fedora 33

### DIFF
--- a/.github/workflows/fedora-33.yml
+++ b/.github/workflows/fedora-33.yml
@@ -1,0 +1,56 @@
+## The test container is created with https://github.com/dracutdevs/fedora-container
+
+name: Fedora-33
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - '*'
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/haraldh/dracut-fedora:33
+      options: "--privileged"
+    timeout-minutes: 45
+    strategy:
+      matrix:
+        test: [
+          "01",
+          "02",
+          "03",
+          "04",
+          "10",
+          "11",
+          "12",
+          "13",
+          "14",
+          "15",
+          "17",
+          "20",
+          "21",
+          "30",
+          "31",
+          "35",
+          "36",
+          "40",
+          "41",
+          "50",
+          "51",
+          "60",
+          "61",
+          "99",
+        ]
+      fail-fast: false
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: "TEST-${{ matrix.test }}"
+        run: ./fedora-test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}


### PR DESCRIPTION
To test a more recent version of Fedora, add Fedora 33.
