### PR TITLE
feat(kernel-modules): add drivers memory for ARM

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -79,6 +79,7 @@ installkernel() {
                 "=drivers/hwmon" \
                 "=drivers/hwspinlock" \
                 "=drivers/i2c/busses" \
+                "=drivers/memory" \
                 "=drivers/mfd" \
                 "=drivers/mmc/core" \
                 "=drivers/phy" \


### PR DESCRIPTION
External Memory Controller drivers can be built as a module.

On Tegra, this allows tegra_drm to load faster and without defered probes,
instead of waiting for the rootfs for the tegra*_emc dependency.

Tested on jetson-tk1 and ac100.

Signed-off-by: Nicolas Chauvet <kwizart@gmail.com>

This pull request changes...

## Changes

Note: Building Tegra EMC drivers as a module is possible with mainline for 5.11+.

