### PR TITLE
fix(35network-manager): avoid restarting NetworkManager 

### DIFF
--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if [ -e /tmp/nm.done ]; then
+    return
+fi
+
 for i in /usr/lib/NetworkManager/system-connections/* \
          /run/NetworkManager/system-connections/* \
          /etc/NetworkManager/system-connections/* \


### PR DESCRIPTION
This pull request changes...

## Changes

Force NetworkManager run only once in initrd.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

## Fixes

- On EL8.3 the NetworkManager keep restarting even if it exits successfully while waiting for Clevis to unlock. This patch ensures NetworkManager runs only once in initrd.