### PR TITLE
chore(cleanup): remove logrotate file

### DIFF
--- a/dracut.logrotate
+++ b/dracut.logrotate
@@ -1,6 +1,0 @@
-/var/log/dracut.log {
-    missingok
-    notifempty
-    size 30k
-    create 0600 root root
-}


### PR DESCRIPTION
Distribution have now switched to systemd which comes with it's own logging system called the journal which has a built in logrotation support hence there is no reason for a dracut to support traditional syslog utility like logrotate anymore thus removing...