### PR TITLE
fix(1007): adding shared keyring mode to type unit

### DIFF
--- a/modules.d/98dracut-systemd/dracut-pre-pivot.service
+++ b/modules.d/98dracut-systemd/dracut-pre-pivot.service
@@ -30,6 +30,7 @@ StandardInput=null
 StandardError=journal+console
 KillMode=process
 RemainAfterExit=yes
+KeyringMode=shared
 
 # Bash ignores SIGTERM, so we send SIGHUP instead, to ensure that bash
 # terminates cleanly.


### PR DESCRIPTION
This pull request adds a shared keyring mode to dracut-pre-pivot.service as requested thus fixes #1007 
