### PR TITLE
fix(kernel-network-modules): also install modules from mdio subdirectory

### DIFF
--- a/modules.d/90kernel-network-modules/module-setup.sh
+++ b/modules.d/90kernel-network-modules/module-setup.sh
@@ -37,6 +37,7 @@ installkernel() {
     dracut_instmods -o -P ".*${_unwanted_drivers}.*" -s "$_net_symbols" "=drivers/net"
     #instmods() will take care of hostonly
     instmods \
+        =drivers/net/mdio \
         =drivers/net/phy \
         =drivers/net/team \
         =drivers/net/ethernet \


### PR DESCRIPTION
## Changes

A recent change in Linux kernel v5.10 split the MDIO drivers from the PHY
subdirectory into a new MDIO subdirectory [0]. This caused MDIO drivers
to not be included in the initramfs.

Also include the modules of this new subdirectory to prevent this issue.

[0]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a9770eac511

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
