### PR TITLE
feat(systemd-modules-load): introducing systemd-modules-load module

### DIFF
--- a/dracut.spec
+++ b/dracut.spec
@@ -337,6 +337,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/modules.d/01systemd-initrd
 %{dracutlibdir}/modules.d/01systemd-coredump
 %{dracutlibdir}/modules.d/01systemd-repart
+%{dracutlibdir}/modules.d/01systemd-modules-load
 %{dracutlibdir}/modules.d/03modsign
 %{dracutlibdir}/modules.d/03rescue
 %{dracutlibdir}/modules.d/04watchdog

--- a/modules.d/01systemd-modules-load/module-setup.sh
+++ b/modules.d/01systemd-modules-load/module-setup.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Prerequisite check(s) for module.
+check() {
+
+    # If the binary(s) requirements are not fulfilled the module can't be installed
+    require_binaries $systemdutildir/systemd-modules-load || return 1
+
+    # Return 255 to only include the module, if another module requires it.
+    return 255
+
+}
+
+# Module dependency requirements.
+depends() {
+
+    # This module has external dependency on the systemd module.
+    echo systemd
+    # Return 0 to include the dependent systemd module in the initramfs.
+    return 0
+
+}
+
+# Install the required file(s) for the module in the initramfs.
+install() {
+
+        # Create systemd-modules-load related directories.
+        inst_dir    $modulesload
+        inst_dir    $modulesloadconfdir
+
+        # Install related files for systemd-modules-load
+        inst_multiple -o \
+            $systemdsystemunitdir/systemd-modules-load.service \
+            $systemdutildir/systemd-modules-load
+
+        # Install local user configurations if host only is enabled..
+        if [[ $hostonly ]]; then
+            inst_multiple -H -o \
+            $systemdsystemconfdir/systemd-modules-load.service \
+            $systemdsystemconfdir/systemd-systemd-modules-load.d/*.conf \
+            ${NULL}
+        fi
+
+        # Enable the systemd type service unit for systemd-modules-load.
+        $SYSTEMCTL -q --root "$initdir" enable systemd-modules-load.service
+
+}


### PR DESCRIPTION
Introducing systemd-modules-load which is an early boot service
that loads kernel modules from a static list, which is required for
kernel modules that do for example not support automatic module loading
( like key type parsers ).

This is a standalone systemd module which means it depends on no other module than systemd.