### PR TITLE
fix(skipcpio): "edit skipcpio.c strstr memmem"

### DIFF
--- a/skipcpio/skipcpio.c
+++ b/skipcpio/skipcpio.c
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
                         if (s <= 0)
                                 break;
 
-                        h = strstr(buf, CPIO_END);
+                        h = memmem(buf, sizeof(buf), CPIO_END, sizeof(CPIO_END));
                         if (h) {
                                 pos = (h - buf) + pos + CPIO_ENDLEN;
                                 fseek(f, pos, SEEK_SET);


### PR DESCRIPTION
because CPIO_END might follow a NULL byte in buf

This pull request changes `skipcpio` by replacing `strstr` with `memmem` in the logic that searches for the `TRAILER!!!` within the buffer that scans the given file. Using `strstr` will erroneously return a false negative if `NULL` byte precedes it within `buf`.

I note that the `memmem` function is specific to glibc. I also note that `_GNU_SOURCE` is already defined.
