### PR TITLE
ci: use our own version of commisery

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Run Commisery
-      uses: KevinDeJong-TomTom/commisery-action@master
+      uses: dracutdevs/commisery-action@master
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         pull_request: ${{ github.event.number }}


### PR DESCRIPTION
This should hopefully fix:
* not checking the PR github title
* not error on the auto merge commit message
