### PR TITLE
fix(35network-legacy): add default bonding miimon value

### DIFF
--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -237,7 +237,8 @@ if [ -z "$NO_BOND_MASTER" ]; then
                 fi
             done
 
-            modprobe -q -b bonding
+            # Load bonding module with default miimon value
+            modprobe -q -b bonding miimon=100
             echo "+$bondname" >  /sys/class/net/bonding_masters 2>/dev/null
             ip link set $bondname down
 


### PR DESCRIPTION
Bonding driver does not populate miimon value in initramfs correctly, causing bonds creates there to be un-statusable and not fail over properly in rootfs. 
Adding miimon=100 to bonding driver options lets the kernel know to status the links every 100ms, this allows network managers to show status and fail over the bonds.

Fixes:
#641 
#1033 