### PR TITLE
fix(nbd): change units service type to oneshot

### DIFF
--- a/modules.d/95nbd/module-setup.sh
+++ b/modules.d/95nbd/module-setup.sh
@@ -1,40 +1,69 @@
-#!/bin/bash
+#!/bin/sh
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
 
-# called by dracut
+# Prerequisite check(s) for module.
 check() {
     local _rootdev
 
-    # if an nbd device is not somewhere in the chain of devices root is
+    # If an nbd device is not somewhere in the chain of devices root is
     # mounted on, fail the hostonly check.
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         _rootdev=$(find_root_block_device)
         [[ -b /dev/block/$_rootdev ]] || return 1
         check_block_and_slaves block_is_nbd "$_rootdev" || return 255
     }
+
+    # If the binary(s) requirements are not fulfilled
+    # return 1 to not include the binary.
     require_binaries nbd-client || return 1
 
+    # Return 255 to only include the module, if another module requires it.
+    return 255
+
+}
+
+# Module dependency requirements.
+depends() {
+
+    # This module has external dependency on other module(s).
+    echo network rootfs-block
+    # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 }
 
-# called by dracut
-depends() {
-    # We depend on network modules being loaded
-    echo network rootfs-block
-}
-
-# called by dracut
+# Install the required kernel module(s) for the module.
 installkernel() {
     instmods nbd
 }
 
-# called by dracut
+# Install the required file(s) for the module.
 install() {
-    inst nbd-client
-    inst_hook cmdline 90 "$moddir/parse-nbdroot.sh"
-    inst_script "$moddir/nbdroot.sh" "/sbin/nbdroot"
-    if dracut_module_included "systemd-initrd"; then
-        inst_script "$moddir/nbd-generator.sh" $systemdutildir/system-generators/dracut-nbd-generator
-    fi
-    dracut_need_initqueue
-}
 
+    # Install the required binary for module
+    inst nbd-client
+    # Install the required hook for module
+    inst_hook cmdline 90 "$moddir/parse-nbdroot.sh"
+    # Install the required script for module
+    inst_script "$moddir/nbdroot.sh" "/sbin/nbdroot"
+
+    if dracut_module_included "systemd"; then
+        # Install dracuts systemd generator for module
+        inst_script "$moddir/nbd-generator.sh" $systemdutildir/system-generators/dracut-nbd-generator
+        # Install the type service unit
+        $systemdsystemunitdir/nbd@.service
+
+        # Install the hosts local user configurations if enabled.
+        if [[ $hostonly ]]; then
+            inst_multiple -H -o \
+                /etc/nbdtab \
+                $systemdsystemconfdir/*.mount \
+                $systemdsystemconfdir/nbd@.service \
+                $systemdsystemconfdir/nbd@.service.d/*.conf
+                ${NULL}
+        fi
+    fi
+
+    dracut_need_initqueue
+
+}

--- a/modules.d/95nbd/nbdroot.sh
+++ b/modules.d/95nbd/nbdroot.sh
@@ -112,7 +112,7 @@ if [ "$nbdport" -gt 0 ] 2>/dev/null; then
     if [ -z "$DRACUT_SYSTEMD" ]; then
         nbd-client "$nbdserver" $nbdport /dev/nbd0 $preopts $opts || exit 1
     else
-        systemd-run --no-block --service-type=forking --quiet \
+        systemd-run --no-block --service-type=oneshot --quiet \
                     --description="nbd nbd0" \
                     -p 'DefaultDependencies=no' \
                     -p 'KillMode=none' \
@@ -122,7 +122,7 @@ else
     if [ -z "$DRACUT_SYSTEMD" ]; then
         nbd-client -name "$nbdport" "$nbdserver" /dev/nbd0 $preopts $opts || exit 1
     else
-        systemd-run --no-block --service-type=forking --quiet \
+        systemd-run --no-block --service-type=oneshot --quiet \
                     --description="nbd nbd0" \
                     -p 'DefaultDependencies=no' \
                     -p 'KillMode=none' \


### PR DESCRIPTION
Recently upstream changed the nbd-client from using the ioctl() interface to use the netlink interface to configure the NBD device, an upstream change which required changes the upstream systemd units from Type=forking to Type=oneshot, this PR reflects that change. Further information about this upstream change can be found here https://github.com/NetworkBlockDevice/nbd/issues/91. That change should fix #1032 

In addition to the above change this PR ( now ) also changes /bin/bash to sh, adds a missing license header, adds documentation to the code and a missing host only section which should be a much more complete implementation of the module.