### PR TITLE
sysroot fixes

### DIFF
--- a/dracut.8.asc
+++ b/dracut.8.asc
@@ -599,6 +599,9 @@ _SYSTEMD_VERSION_::
 _SYSTEMCTL_::
     overrides the systemctl binary. Used for **--sysroot**.
 
+_NM_VERSION_::
+    overrides the NetworkManager version. Used for **--sysroot**.
+
 _DRACUT_INSTALL_PATH_::
     overrides **PATH** environment for **dracut-install** to look for
     binaries relative to **--sysroot**. In a cross-compiled environment

--- a/dracut.8.asc
+++ b/dracut.8.asc
@@ -596,6 +596,9 @@ Default:
 _SYSTEMD_VERSION_::
     overrides systemd version. Used for **--sysroot**.
 
+_SYSTEMCTL_::
+    overrides the systemctl binary. Used for **--sysroot**.
+
 _DRACUT_INSTALL_PATH_::
     overrides **PATH** environment for **dracut-install** to look for
     binaries relative to **--sysroot**. In a cross-compiled environment

--- a/dracut.sh
+++ b/dracut.sh
@@ -756,6 +756,8 @@ done
 [[ -z "$dracutsysrootdir" ]] && export PATH="${NPATH#:}"
 unset NPATH
 
+export SYSTEMCTL=${SYSTEMCTL:-systemctl}
+
 # these options add to the stuff in the config file
 (( ${#add_dracutmodules_l[@]} )) && add_dracutmodules+=" ${add_dracutmodules_l[@]} "
 (( ${#force_add_dracutmodules_l[@]} )) && force_add_dracutmodules+=" ${force_add_dracutmodules_l[@]} "

--- a/dracut.sh
+++ b/dracut.sh
@@ -748,11 +748,12 @@ for i in $DRACUT_PATH; do
     if [ -L "$dracutsysrootdir$i" ]; then
         rl=$(readlink -f $dracutsysrootdir$i)
     fi
+    rl="${rl#$dracutsysrootdir}"
     if [[ "$NPATH" != *:$rl* ]] ; then
         NPATH+=":$rl"
     fi
 done
-export PATH="${NPATH#:}"
+[[ -z "$dracutsysrootdir" ]] && export PATH="${NPATH#:}"
 unset NPATH
 
 # these options add to the stuff in the config file

--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -227,8 +227,8 @@ install() {
     ln_r $systemdutildir/systemd "/sbin/init"
 
     inst_binary true
-    ln_r $(type -P true) "/usr/bin/loginctl"
-    ln_r $(type -P true) "/bin/loginctl"
+    ln_r $(find_binary true) "/usr/bin/loginctl"
+    ln_r $(find_binary true) "/bin/loginctl"
     inst_rules \
         70-uaccess.rules \
         71-seat.rules \

--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -244,7 +244,7 @@ install() {
         systemd-ask-password-plymouth.service \
         ; do
         [[ -f $systemdsystemunitdir/$i ]] || continue
-        systemctl -q --root "$initdir" add-wants "$i" systemd-vconsole-setup.service
+        $SYSTEMCTL -q --root "$initdir" add-wants "$i" systemd-vconsole-setup.service
     done
 
     mkdir -p "$initdir/etc/systemd"
@@ -256,5 +256,5 @@ install() {
         echo "RateLimitBurst=0"
     } >> "$initdir/etc/systemd/journald.conf"
 
-    systemctl -q --root "$initdir" set-default multi-user.target
+    $SYSTEMCTL -q --root "$initdir" set-default multi-user.target
 }

--- a/modules.d/01systemd-initrd/module-setup.sh
+++ b/modules.d/01systemd-initrd/module-setup.sh
@@ -36,5 +36,5 @@ install() {
         $systemdsystemunitdir/initrd-udevadm-cleanup-db.service \
         $systemdsystemunitdir/initrd-parse-etc.service
 
-    systemctl -q --root "$initdir" set-default initrd.target
+    $SYSTEMCTL -q --root "$initdir" set-default initrd.target
 }

--- a/modules.d/01systemd-sysusers/module-setup.sh
+++ b/modules.d/01systemd-sysusers/module-setup.sh
@@ -55,6 +55,6 @@ install() {
         fi
 
         # Enable the systemd type service unit for sysusers.
-        systemctl -q --root "$initdir" enable systemd-sysusers.service
+        $SYSTEMCTL -q --root "$initdir" enable systemd-sysusers.service
 
 }

--- a/modules.d/02caps/module-setup.sh
+++ b/modules.d/02caps/module-setup.sh
@@ -15,7 +15,7 @@ depends() {
 install() {
     if ! dracut_module_included "systemd"; then
         inst_hook pre-pivot 00 "$moddir/caps.sh"
-        inst $(type -P capsh 2>/dev/null) /usr/sbin/capsh
+        inst $(find_binary capsh 2>/dev/null) /usr/sbin/capsh
         # capsh wants bash and we need bash also
         inst /bin/bash
     else

--- a/modules.d/02systemd-networkd/module-setup.sh
+++ b/modules.d/02systemd-networkd/module-setup.sh
@@ -65,7 +65,7 @@ install() {
         systemd-networkd.socket
 #       systemd-timesyncd.service
     do
-        systemctl -q --root "$initdir" enable "$i"
+        $SYSTEMCTL -q --root "$initdir" enable "$i"
     done
 }
 

--- a/modules.d/05busybox/module-setup.sh
+++ b/modules.d/05busybox/module-setup.sh
@@ -16,7 +16,7 @@ depends() {
 install() {
     local _i _path _busybox
     local _progs=()
-    _busybox=$(type -P busybox)
+    _busybox=$(find_binary busybox)
     inst $_busybox /usr/bin/busybox
     for _i in $($_busybox --list); do
         [[ ${_i} == busybox ]] && continue

--- a/modules.d/06dbus-daemon/module-setup.sh
+++ b/modules.d/06dbus-daemon/module-setup.sh
@@ -87,8 +87,8 @@ install() {
         "$initdir$systemdsystemunitdir/dbus.socket"
 
     # Adding the user and group for dbus
-    grep '^\(d\|message\)bus:' /etc/passwd >> "$initdir/etc/passwd"
-    grep '^\(d\|message\)bus:' /etc/group >> "$initdir/etc/group"
+    grep '^\(d\|message\)bus:' $dracutsysrootdir/etc/passwd >> "$initdir/etc/passwd"
+    grep '^\(d\|message\)bus:' $dracutsysrootdir/etc/group >> "$initdir/etc/group"
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then

--- a/modules.d/06rngd/module-setup.sh
+++ b/modules.d/06rngd/module-setup.sh
@@ -36,5 +36,5 @@ install() {
     # make sure dependant libs are installed too
     inst_libdir_file opensc-pkcs11.so
 
-    systemctl -q --root "$initdir" add-wants sysinit.target rngd.service
+    $SYSTEMCTL -q --root "$initdir" add-wants sysinit.target rngd.service
 }

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -24,7 +24,7 @@ installkernel() {
 install() {
     local _nm_version
 
-    _nm_version=$(NetworkManager --version)
+    _nm_version=${NM_VERSION:-$(NetworkManager --version)}
 
     # We don't need `ip` but having it is *really* useful for people debugging
     # in an emergency shell.

--- a/modules.d/35network-wicked/module-setup.sh
+++ b/modules.d/35network-wicked/module-setup.sh
@@ -36,13 +36,13 @@ install() {
     inst_dir /usr/lib/wicked/bin
     inst_dir /var/lib/wicked
 
-    inst_multiple /etc/wicked/*.xml
-    inst_multiple /etc/wicked/extensions/*
-    inst_multiple /etc/dbus-1/system.d/org.opensuse.Network*
-    inst_multiple /usr/share/wicked/schema/*
-    inst_multiple /usr/lib/wicked/bin/*
-    inst_multiple /usr/libexec/wicked/bin/*
-    inst_multiple /usr/sbin/wicked*
+    inst_multiple "/etc/wicked/*.xml"
+    inst_multiple "/etc/wicked/extensions/*"
+    inst_multiple "/etc/dbus-1/system.d/org.opensuse.Network*"
+    inst_multiple "/usr/share/wicked/schema/*"
+    inst_multiple "/usr/lib/wicked/bin/*"
+    inst_multiple "/usr/libexec/wicked/bin/*"
+    inst_multiple "/usr/sbin/wicked*"
 
     wicked_units="
         $systemdsystemunitdir/wickedd.service \

--- a/modules.d/50gensplash/module-setup.sh
+++ b/modules.d/50gensplash/module-setup.sh
@@ -40,7 +40,7 @@ install() {
         return ${_ret}
     }
 
-    type -P splash_geninitramfs >/dev/null || return 1
+    find_binary splash_geninitramfs >/dev/null || return 1
 
     _opts=''
     if [[ ${DRACUT_GENSPLASH_THEME} ]]; then

--- a/modules.d/50plymouth/module-setup.sh
+++ b/modules.d/50plymouth/module-setup.sh
@@ -2,7 +2,7 @@
 
 pkglib_dir() {
     local _dirs="/usr/lib/plymouth /usr/libexec/plymouth/"
-    if type -P dpkg-architecture &>/dev/null; then
+    if find_binary dpkg-architecture &>/dev/null; then
         _dirs+=" /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/plymouth"
     fi
     for _dir in $_dirs; do

--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -140,7 +140,7 @@ installkernel() {
 
 # called by dracut
 install() {
-    inst_multiple -o /lib/modprobe.d/*.conf
+    inst_multiple -o "/lib/modprobe.d/*.conf"
     [[ $hostonly ]] && inst_multiple -H -o /etc/modprobe.d/*.conf /etc/modprobe.conf
     if ! dracut_module_included "systemd"; then
         inst_hook cmdline 01 "$moddir/parse-kernel.sh"

--- a/modules.d/90lvm/module-setup.sh
+++ b/modules.d/90lvm/module-setup.sh
@@ -119,7 +119,7 @@ install() {
 
     inst_libdir_file "libdevmapper-event-lvm*.so"
 
-    if [[ $hostonly ]] && type -P lvs &>/dev/null; then
+    if [[ $hostonly ]] && find_binary lvs &>/dev/null; then
         for dev in "${!host_fs_types[@]}"; do
             [ -e /sys/block/${dev#/dev/}/dm/name ] || continue
             dev=$(</sys/block/${dev#/dev/}/dm/name)

--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -112,8 +112,8 @@ install() {
     if dracut_module_included "systemd"; then
         inst_simple "${moddir}/multipathd-configure.service" "${systemdsystemunitdir}/multipathd-configure.service"
         inst_simple "${moddir}/multipathd.service" "${systemdsystemunitdir}/multipathd.service"
-        systemctl -q --root "$initdir" enable multipathd-configure.service
-        systemctl -q --root "$initdir" enable multipathd.service
+        $SYSTEMCTL -q --root "$initdir" enable multipathd-configure.service
+        $SYSTEMCTL -q --root "$initdir" enable multipathd.service
     else
         inst_hook pre-trigger 02 "$moddir/multipathd.sh"
         inst_hook cleanup   02 "$moddir/multipathd-stop.sh"

--- a/modules.d/90nvdimm/module-setup.sh
+++ b/modules.d/90nvdimm/module-setup.sh
@@ -27,5 +27,5 @@ installkernel() {
 
 # called by dracut
 install() {
-    inst_multiple -o ndctl /etc/ndctl/keys/tpm.handle /etc/ndctl/keys/*.blob
+    inst_multiple -o ndctl /etc/ndctl/keys/tpm.handle "/etc/ndctl/keys/*.blob"
 }

--- a/modules.d/95fcoe/module-setup.sh
+++ b/modules.d/95fcoe/module-setup.sh
@@ -103,7 +103,7 @@ install() {
         local _fcoeconf=$(cmdline)
         [[ $_fcoeconf ]] && printf "%s\n" "$_fcoeconf" >> "${initdir}/etc/cmdline.d/95fcoe.conf"
     fi
-    inst_multiple /etc/fcoe/cfg-*
+    inst_multiple "/etc/fcoe/cfg-*"
 
     inst "$moddir/fcoe-up.sh" "/sbin/fcoe-up"
     inst "$moddir/fcoe-edd.sh" "/sbin/fcoe-edd"

--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -228,14 +228,14 @@ install() {
                 iscsid.socket \
                 iscsiuio.socket \
             ; do
-            systemctl -q --root "$initdir" enable "$i"
+            $SYSTEMCTL -q --root "$initdir" enable "$i"
         done
         
         for i in \
                 iscsid.service \
                 iscsiuio.service \
             ; do
-            systemctl -q --root "$initdir" add-wants basic.target "$i"
+            $SYSTEMCTL -q --root "$initdir" add-wants basic.target "$i"
         done
 
         # Make sure iscsid is started after dracut-cmdline and ready for the initqueue

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -59,8 +59,8 @@ install() {
     [[ $hostonly ]] && inst_rules 70-persistent-net.rules
 
     if dracut_module_included "systemd"; then
-        inst_multiple -o ${systemdutildir}/network/*.link
-        [[ $hostonly ]] && inst_multiple -H -o /etc/systemd/network/*.link
+        inst_multiple -o ${systemdutildir}"/network/*.link"
+        [[ $hostonly ]] && inst_multiple -H -o "/etc/systemd/network/*.link"
     fi
 
     {

--- a/modules.d/98dracut-systemd/module-setup.sh
+++ b/modules.d/98dracut-systemd/module-setup.sh
@@ -54,7 +54,7 @@ install() {
         dracut-pre-udev.service \
         ; do
         inst_simple "$moddir/${i}" "$systemdsystemunitdir/${i}"
-        systemctl -q --root "$initdir" add-wants initrd.target "$i"
+        $SYSTEMCTL -q --root "$initdir" add-wants initrd.target "$i"
     done
 
     inst_simple "$moddir/dracut-tmpfiles.conf" "$tmpfilesdir/dracut-tmpfiles.conf"

--- a/modules.d/98syslog/module-setup.sh
+++ b/modules.d/98syslog/module-setup.sh
@@ -15,12 +15,12 @@ depends() {
 install() {
     local _i
     local _installs
-    if type -P rsyslogd >/dev/null; then
+    if find_binary rsyslogd >/dev/null; then
         _installs="rsyslogd"
         inst_libdir_file rsyslog/lmnet.so rsyslog/imklog.so rsyslog/imuxsock.so rsyslog/imjournal.so
-    elif type -P syslogd >/dev/null; then
+    elif find_binary syslogd >/dev/null; then
         _installs="syslogd"
-    elif type -P syslog-ng >/dev/null; then
+    elif find_binary syslog-ng >/dev/null; then
         _installs="syslog-ng"
     else
         derror "Could not find any syslog binary although the syslogmodule" \

--- a/modules.d/99memstrack/module-setup.sh
+++ b/modules.d/99memstrack/module-setup.sh
@@ -23,5 +23,5 @@ install() {
     inst_hook cleanup 99 "$moddir/memstrack-report.sh"
 
     inst "$moddir/memstrack.service" "$systemdsystemunitdir/memstrack.service"
-    systemctl -q --root "$initdir" add-wants initrd.target memstrack.service
+    $SYSTEMCTL -q --root "$initdir" add-wants initrd.target memstrack.service
 }

--- a/modules.d/99memstrack/module-setup.sh
+++ b/modules.d/99memstrack/module-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 check() {
-    if type -P memstrack >/dev/null; then
+    if find_binary memstrack >/dev/null; then
         dinfo "memstrack is available"
         return 0
     fi

--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -6,7 +6,7 @@ check() {
         return 1
     fi
 
-    if ! type -P mksquashfs >/dev/null || ! type -P unsquashfs >/dev/null ; then
+    if ! find_binary mksquashfs >/dev/null || ! find_binary unsquashfs >/dev/null ; then
         derror "dracut-squash module requires squashfs-tools"
         return 1
     fi

--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -37,5 +37,5 @@ install() {
     inst $moddir/init.sh /squash/init.sh
 
     inst "$moddir/squash-mnt-clear.service" "$systemdsystemunitdir/squash-mnt-clear.service"
-    systemctl -q --root "$initdir" add-wants initrd-switch-root.target squash-mnt-clear.service
+    $SYSTEMCTL -q --root "$initdir" add-wants initrd-switch-root.target squash-mnt-clear.service
 }


### PR DESCRIPTION
The file pattern passed to inst_multiple (if not quoted) is immediately substituted by the shell.
When dracutsysrootdir is set and the same package is not installed on the host then the files are obviously not found on the host system. dracut-install complains loudly in this case.

This can also create an issue if the package versions on the build host and the cross-compiled system differ in their file lists. In this case the file list is generated according to the host and not according to the sysroot.

Found during a test build on Yocto with wicked added for testing.

Handle file globbing in `dracut-install`'s `install_all()` function.

Fixed modules that were using file globbing with inst_multiple: 35network-wicked, 90kernel-modules, 90nvdimm, 95fcoe, 95udev-rules

Also fixed the dbus module so it uses dbus or messagebus UID/GID from dracutsysrootdir.

EDIT: Further fixes:
1. don't set PATH (valid for host) from NPATH (valid for sysroot) if dracutsysrootdir is set
2. use find_binary instead of type -P for modules' check and install functions in module-setup.sh
3. allow overriding the systemctl command. Yocto has its own Python script masquerading as systemctl but it lacks the `add-wants` subcommand that dracut needs.

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
