### PR TITLE
fix(watchdog-modules): numeric argument required

### DIFF
--- a/modules.d/04watchdog/module-setup.sh
+++ b/modules.d/04watchdog/module-setup.sh
@@ -7,7 +7,8 @@ check() {
 
 # called by dracut
 depends() {
-    return "watchdog-modules"
+    echo watchdog-modules
+    return 0
 }
 
 # called by dracut


### PR DESCRIPTION
Fix error `/usr/lib/dracut/modules.d/04watchdog/module-setup.sh: line 10: return: watchdog-modules: numeric argument required`.
