### PR TITLE
fix(dbus): various fixes

### DIFF
--- a/modules.d/06dbus/module-setup.sh
+++ b/modules.d/06dbus/module-setup.sh
@@ -1,70 +1,114 @@
-#!/bin/bash
+#!/bin/sh
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
 
-# called by dracut
+# Prerequisite check(s) for module.
 check() {
-  require_binaries dbus-daemon || return 1
 
-  return 255
+    # If the binary(s) requirements are not fulfilled
+    # return 1 to not include the binary.
+    require_binaries busctl || return 1
+    require_binaries dbus-daemon || return 1
+    require_binaries dbus-send || return 1
+
+    # If the module dependency requirements are not fulfilled
+    # return 1 to not include the required module(s).
+    if ! dracut_module_included "systemd"; then
+        derror "dbus needs systemd in the initramfs."
+        return 1
+    fi
+
+    if ! dracut_module_included "systemd-sysusers"; then
+        derror "dbus-broker needs systemd-sysusers in the initramfs."
+        return 1
+    fi
+
+    # dbus conflicts with dbus-broker.
+    if dracut_module_included "dbus-broker"; then
+        derror "dbus conflicts with dbus-broker in the initramfs."
+        exit 1
+    fi
+
+    # Return 255 to only include the module, if another module requires it.
+    return 255
 }
 
+# Module dependency requirements.
 depends() {
-  echo systemd
-  return 0
+
+    # This module has external dependency on the systemd module.
+    echo systemd systemd-sysusers
+    # Return 0 to include the dependent systemd module in the initramfs.
+    return 0
 }
 
-adjust_dependencies() {
-  sed -i -e \
-'/^\[Unit\]/aDefaultDependencies=no\
-Conflicts=shutdown.target\
-Before=shutdown.target' \
-    "$initdir"${1}
-
-}
-
+# Install the required file(s) for the module in the initramfs.
 install() {
 
-  inst_multiple \
-    $systemdsystemunitdir/dbus.service \
-    $systemdsystemunitdir/dbus.socket \
-    dbus-send \
-    busctl
-  adjust_dependencies $systemdsystemunitdir/dbus.service
+    # Create dbus related directories.
+    inst_dir $dbus
+    inst_dir $dbusinterfaces
+    inst_dir $dbusservices
+    inst_dir $dbussession
+    inst_dir $dbussystem
+    inst_dir $dbussystemservices
+    inst_dir $dbusconfdir
+    inst_dir $dbusinterfacesconfdir
+    inst_dir $dbusservicesconfdir
+    inst_dir $dbussessionconfdir
+    inst_dir $dbussystemconfdir
+    inst_dir $dbussystemservicesconfdir
 
-  if type -P dbus-daemon >/dev/null; then
-    inst_multiple \
-      dbus-daemon
-  fi
+    inst_multiple -o \
+        # Install the dbus system configuration file.
+        $dbus/system.conf \
+        # Install the dbus users and groups configuration file.
+        $sysusers/messagebus.conf \
+        # The systemd module should be providing this and
+        # depend on the dbus module. Added here until it does.
+        $dbussystem/org.freedesktop.systemd1.conf \
+        $dbusservicesconfdir/org.freedesktop.systemd1.service \
+        $dbussystemservices/org.freedesktop.systemd1.service \
+        # Install the systemd type service unit for dbus.
+        $systemdsystemunitdir/dbus.service \
+        # Install the systemd type socket unit for dbus.
+        $systemdsystemunitdir/dbus.socket \
+        # Install the dbus target.
+        $systemdsystemunitdir/dbus.target.wants
+        # Install the binary executable(s) for dbus.
+        busctl dbus-send dbus-daemon
 
-  if type -P dbus-broker >/dev/null; then
-    inst_multiple \
-      $systemdsystemunitdir/dbus-broker.service \
-      dbus-broker \
-      dbus-broker-launch
-    adjust_dependencies $systemdsystemunitdir/dbus-broker.service
-  fi
+    # Adjusting dependencies for initramfs in the dbus service unit.
+    sed -i -e \
+        '/^\[Unit\]/aDefaultDependencies=no\
+        Conflicts=shutdown.target\
+        Before=shutdown.target' \
+        "$initdir$systemdsystemunitdir/dbus.service"
 
-  inst_dir      /etc/dbus-1/system.d
-  inst_dir      /usr/share/dbus-1/services
-  inst_dir      /usr/share/dbus-1/system-services
-  inst_multiple /etc/dbus-1/system.conf
-  inst_multiple /usr/share/dbus-1/system.conf \
-                /usr/share/dbus-1/services/org.freedesktop.systemd1.service
-  inst_multiple $(find /var/lib/dbus)
+    # Adjusting dependencies for initramfs in the dbus socket unit.
+   sed -i -e \
+       '/^\[Unit\]/aDefaultDependencies=no\
+        Conflicts=shutdown.target\
+        Before=shutdown.target
+        /^\[Socket\]/aRemoveOnStop=yes' \
+        "$initdir$systemdsystemunitdir/dbus.socket"
 
-  grep '^\(d\|message\)bus:' /etc/passwd >> "$initdir/etc/passwd"
-  grep '^\(d\|message\)bus:' /etc/group >> "$initdir/etc/group"
+    # Install the hosts local user configurations if enabled.
+    if [[ $hostonly ]]; then
+        inst_multiple -H -o \
+            $dbusconfdir/system.conf \
+            $systemdsystemconfdir/dbus.socket \
+            $systemdsystemconfdir/dbus.socket.d/*.conf \
+            $systemdsystemconfdir/dbus.service \
+            $systemdsystemconfdir/dbus.service.d/*.conf
+            ${NULL}
+     fi
 
-  sed -i -e \
-'/^\[Unit\]/aDefaultDependencies=no\
-Conflicts=shutdown.target\
-Before=shutdown.target
-/^\[Socket\]/aRemoveOnStop=yes' \
-    "$initdir$systemdsystemunitdir/dbus.socket"
-
-  #We need to make sure that systemd-tmpfiles-setup.service->dbus.socket will not wait local-fs.target to start,
-  #If swap is encrypted, this would make dbus wait the timeout for the swap before loading. This could delay sysinit
-  #services that are dependent on dbus.service.
-  sed -i -Ee \
-    '/^After/s/(After[[:space:]]*=.*)(local-fs.target[[:space:]]*)(.*)/\1-\.mount \3/' \
-    "$initdir$systemdsystemunitdir/systemd-tmpfiles-setup.service"
+    # We need to make sure that systemd-tmpfiles-setup.service->dbus.socket
+    # will not wait for local-fs.target to start if swap is encrypted,
+    # this would make dbus wait the timeout for the swap before loading.
+    # This could delay sysinit services that are dependent on dbus.service.
+    sed -i -Ee \
+        '/^After/s/(After[[:space:]]*=.*)(local-fs.target[[:space:]]*)(.*)/\1-\.mount \3/' \
+        "$initdir$systemdsystemunitdir/systemd-tmpfiles-setup.service"
 }


### PR DESCRIPTION
This pull request removes any reference to the dbus-broker since it's now it's own module and adds a hard conflict with it ( and dbus-broker is doing the same ) which should resolve #1025, this also replaces user/group grep with systemd-sysuser since dbus provides it thus introduces a dependency on systemd-sysusers module.