### PR TITLE
fix(99squash): don't throw errors when requirements aren't met

### DIFF
--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -2,18 +2,18 @@
 
 check() {
     if ! dracut_module_included "systemd-initrd"; then
-        derror "dracut-squash only supports systemd bases initramfs"
+        dinfo "dracut-squash module requires systemd-based initramfs"
         return 1
     fi
 
     if ! type -P mksquashfs >/dev/null || ! type -P unsquashfs >/dev/null ; then
-        derror "dracut-squash module requires squashfs-tools"
+        dinfo "dracut-squash module requires squashfs-tools"
         return 1
     fi
 
     for i in CONFIG_SQUASHFS CONFIG_BLK_DEV_LOOP CONFIG_OVERLAY_FS ; do
         if ! check_kernel_config $i; then
-            derror "dracut-squash module requires kernel configuration $i (y or m)"
+            dinfo "dracut-squash module requires kernel configuration $i (y or m)"
             return 1
         fi
     done


### PR DESCRIPTION
Failing to meet requirements for for 99squash should trigger info messages, not errors that are printed even in quiet mode.

This pull request changes...

## Changes
- `derror` to `dinfo` in the `check` script for `99squash`

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
