### PR TITLE
fix(spec): add new systemd-coredump module to spec

### DIFF
--- a/dracut.spec
+++ b/dracut.spec
@@ -334,6 +334,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %endif
 %{dracutlibdir}/modules.d/01systemd-sysusers
 %{dracutlibdir}/modules.d/01systemd-initrd
+%{dracutlibdir}/modules.d/01systemd-coredump
 %{dracutlibdir}/modules.d/03modsign
 %{dracutlibdir}/modules.d/03rescue
 %{dracutlibdir}/modules.d/04watchdog


### PR DESCRIPTION
939b7e11d introduced a new module, but it was not added to the spec file, which makes make rpm to fail.

## Checklist
- [ yep ] I have tested it locally
- [ nope ] I have reviewed and updated any documentation if relevant
- [ nope ] I am providing new code and test(s) for it


