### PR TITLE
fix(network-manager): run as a service if systemd module is present

### DIFF
--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -34,7 +34,13 @@ install() {
     inst /usr/libexec/nm-initrd-generator
     inst_multiple -o teamd dhclient
     inst_hook cmdline 99 "$moddir/nm-config.sh"
-    inst_hook initqueue/settled 99 "$moddir/nm-run.sh"
+    if dracut_module_included "systemd"; then
+        inst_simple "${moddir}/nm-run.sh" "/usr/bin/nm-run.sh"
+        inst_simple "${moddir}/nm-run.service" "${systemdsystemunitdir}/nm-run.service"
+        systemctl -q --root "$initdir" enable nm-run.service
+    else
+        inst_hook initqueue/settled 99 "$moddir/nm-run.sh"
+    fi
     inst_rules 85-nm-unmanaged.rules
     inst_libdir_file "NetworkManager/$_nm_version/libnm-device-plugin-team.so"
     inst_simple "$moddir/nm-lib.sh" "/lib/nm-lib.sh"

--- a/modules.d/35network-manager/nm-run.service
+++ b/modules.d/35network-manager/nm-run.service
@@ -19,6 +19,8 @@ ConditionPathExistsGlob=|/etc/sysconfig/network-scripts/ifcfg-*
 [Service]
 Environment=DRACUT_SYSTEMD=1
 Environment=NEWROOT=/sysroot
+StandardOutput=kmsg+console
+StandardError=kmsg+console
 #run the script and wait before it finishes
 Type=oneshot
 ExecStart=/usr/bin/nm-run.sh

--- a/modules.d/35network-manager/nm-run.service
+++ b/modules.d/35network-manager/nm-run.service
@@ -1,0 +1,27 @@
+[Unit]
+#make sure all devices showed up
+Wants=systemd-udev-settle.service
+After=systemd-udev-settle.service
+
+#pull the network targets into transaction
+Wants=network.target network-online.target
+Before=network.target network-online.target
+
+#run before we try to mount anything from the dracut hooks
+Before=dracut-pre-mount.service
+
+#do not run, if there is no configuration
+ConditionPathExistsGlob=|/usr/lib/NetworkManager/system-connections/*
+ConditionPathExistsGlob=|/run/NetworkManager/system-connections/*
+ConditionPathExistsGlob=|/etc/NetworkManager/system-connections/*
+ConditionPathExistsGlob=|/etc/sysconfig/network-scripts/ifcfg-*
+
+[Service]
+Environment=DRACUT_SYSTEMD=1
+Environment=NEWROOT=/sysroot
+#run the script and wait before it finishes
+Type=oneshot
+ExecStart=/usr/bin/nm-run.sh
+
+[Install]
+WantedBy=initrd.target

--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+type source_hook >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
 if [ -e /tmp/nm.done ]; then
     return
 fi

--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -2,6 +2,8 @@
 
 type source_hook >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
+set -x
+
 if [ -e /tmp/nm.done ]; then
     return
 fi
@@ -11,17 +13,19 @@ for i in /usr/lib/NetworkManager/system-connections/* \
          /etc/NetworkManager/system-connections/* \
          /etc/sysconfig/network-scripts/ifcfg-*; do
   [ -f "$i" ] || continue
-  if getargbool 0 rd.debug -d -y rdinitdebug -d -y rdnetdebug; then
+#  if getargbool 0 rd.debug -d -y rdinitdebug -d -y rdnetdebug; then
       /usr/sbin/NetworkManager --configure-and-quit=initrd --debug --log-level=trace
-  else
-      /usr/sbin/NetworkManager --configure-and-quit=initrd --no-daemon
-  fi
+#  else
+#      /usr/sbin/NetworkManager --configure-and-quit=initrd --no-daemon
+#  fi
 
   if [ -s /run/NetworkManager/initrd/hostname ]; then
       cat /run/NetworkManager/initrd/hostname > /proc/sys/kernel/hostname
   fi
   break
 done
+
+ip a
 
 for _i in /sys/class/net/*
 do

--- a/modules.d/40network/netroot.sh
+++ b/modules.d/40network/netroot.sh
@@ -65,6 +65,9 @@ if [ -z "$2" ]; then
     fi
 
     # Check: do we really know how to handle (net)root?
+    if [ -z "$root" ]; then
+        root=$(getarg root=)
+    fi
     [ -z "$root" ] && die "No or empty root= argument"
     [ -z "$rootok" ] && die "Don't know how to handle 'root=$root'"
 


### PR DESCRIPTION
In the current state, services that depend on network need to
use dracut hooks, since nothing with pull in the network
targets into the transaction.

In the future, it would be nice to provide developers on systemd-only
systems the possibility to not use dracut hooks at all, but simply put
normal systemd services into the initrd.

Also, some modules even right now depend on systemd ordering, like
cryptsetup, so let's make sure, that the ordering inside systemd work
properly as well.


## Changes

## Checklist
- [ partly ] I have tested it locally
- [ nope ] I have reviewed and updated any documentation if relevant
- [ nope ] I am providing new code and test(s) for it
