### PR TITLE
fix(plymouth): install binaries with dependencies

### DIFF
--- a/modules.d/50plymouth/module-setup.sh
+++ b/modules.d/50plymouth/module-setup.sh
@@ -41,6 +41,8 @@ install() {
 
     inst_multiple readlink
 
+    inst_multiple plymouthd plymouth plymouth-set-default-theme
+
     if ! dracut_module_included "systemd"; then
         inst_hook pre-trigger 10 "$moddir"/plymouth-pretrigger.sh
         inst_hook pre-pivot 90 "$moddir"/plymouth-newroot.sh


### PR DESCRIPTION
If plymouth is used then its own installation script is preferred.
While plymouth's own variant of inst_binary resolves the library
dependencies properly, its inst_library shell function doesn't
actually install them in some cases properly.

Make sure to install both the required binaries and their
dependencies. In the worst case, it's a NOP.

Signed-off-by: Zoltán Böszörményi <zboszor@pr.hu>

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
