### PR TITLE
90kernel-modules: arm/arm64: Add reset controllers

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -85,6 +85,7 @@ installkernel() {
                 "=drivers/phy" \
                 "=drivers/power" \
                 "=drivers/regulator" \
+                "=drivers/reset" \
                 "=drivers/rpmsg" \
                 "=drivers/rtc" \
                 "=drivers/soc" \


### PR DESCRIPTION
Reset controllers might be needed by some of the devices used in the
initrd. Particularly on the Raspberry Pi 4, 'xhci-pci' depends on a
platform specific reset controller.

Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>