### PR TITLE
docs: fix dracut.cmdline.7

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -176,7 +176,7 @@ Misc
 [[dracutkerneldebug]]
 Debug
 ~~~~~
-If you are dropped to an emergency shell, the file 
+If you are dropped to an emergency shell, the file
 _/run/initramfs/rdsosreport.txt_ is created, which can be saved to a (to be
 mounted by hand) partition (usually /boot) or a USB stick. Additional debugging
 info can be produced by adding **rd.debug** to the kernel command line.
@@ -582,7 +582,7 @@ USB Android phone::
 
     single-dhcp::: Send DHCP on all available interfaces in parallel, as
     opposed to one after another. After the first DHCP response is received,
-    stop DHCP on all other interfaces. This gives the fastest boot time by 
+    stop DHCP on all other interfaces. This gives the fastest boot time by
     using the IP on interface for which DHCP succeeded first during early boot.
     Caveat: Does not apply to Network Manager and to SUSE using wicked.
 
@@ -1109,7 +1109,7 @@ used to persist the changes made to the device specified by the
 **root=live:__<url>__** option.
 +
 The default _pathspec_, when _auto_ or no _:<pathspec>_ is given, is
-`/<+++<b>rd.live.dir</b>+++>/overlay-<label>-<uuid>`, where _<label>_ is the
+`/<rd.live.dir>/overlay-<label>-<uuid>`, where _<label>_ is the
 device LABEL, and _<uuid>_ is the device UUID.
 * _none_ (the word itself) specifies that no overlay will be used, such as when
 an uncompressed, writable live root filesystem is available.


### PR DESCRIPTION
```
asciidoc: WARNING: dracut.cmdline.7.asc: line 1115: nested inline passthrough
```
