### PR TITLE
ci: more disk space for test 30 iscsi

### DIFF
--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -129,9 +129,9 @@ test_setup() {
     fi
 
     # Create the blank file to use as a root filesystem
-    dd if=/dev/zero of=$TESTDIR/root.ext3 bs=1M count=45
-    dd if=/dev/zero of=$TESTDIR/iscsidisk2.img bs=1M count=45
-    dd if=/dev/zero of=$TESTDIR/iscsidisk3.img bs=1M count=45
+    dd if=/dev/zero of=$TESTDIR/root.ext3 bs=1M count=100
+    dd if=/dev/zero of=$TESTDIR/iscsidisk2.img bs=1M count=50
+    dd if=/dev/zero of=$TESTDIR/iscsidisk3.img bs=1M count=50
 
     kernel=$KVERSION
     # Create what will eventually be our root filesystem onto an overlay


### PR DESCRIPTION
```
mke2fs 1.45.6 (20-Mar-2020)

Filesystem too small for a journal
Discarding device blocks:          done
Creating filesystem with 1024 1k blocks and 128 inodes

Allocating group tables: 0/1   done
Writing inode tables: 0/1   done
Writing superblocks and filesystem accounting information: 0/1   done

cp: error writing '/sysroot/usr/bin/bash': No space left on device
cp: error writing '/sysroot/usr/bin/grep': No space left on device
cp: error writing '/sysroot/usr/bin/ping': No space left on device
[…]
```