### PR TITLE
fix: skip empty modalias files in drm module setup

### DIFF
--- a/modules.d/50drm/module-setup.sh
+++ b/modules.d/50drm/module-setup.sh
@@ -33,6 +33,7 @@ installkernel() {
     if [[ $hostonly ]]; then
         for i in /sys/bus/{pci/devices,platform/devices,virtio/devices,soc/devices/soc?}/*/modalias; do
             [[ -e $i ]] || continue
+            [[ -n $(<"$i") ]] || continue
             if hostonly="" dracut_instmods --silent -s "drm_crtc_init|drm_dev_register|drm_encoder_init" -S "iw_handler_get_spy" $(<"$i"); then
                 if strstr "$(modinfo -F filename $(<"$i") 2>/dev/null)" radeon.ko; then
                     hostonly='' instmods amdkfd


### PR DESCRIPTION
## Changes

on my system (ThinkPad X201s) I have several modalias entries that are
empty:

    /sys/bus/platform/devices/dock.0/modalias
    /sys/bus/platform/devices/dock.1/modalias
    /sys/bus/platform/devices/dock.2/modalias

executing the drm module setup thus results in the following errors

    dracut-install: No SOURCE argument given

when calling dracut_instmods and hostonly mode is enabled.

Skip those entries, as there are no modules to load in this case
anyways.

Note: it is not sufficient to use [['s -s test (file size is greater
than zero), as all those files are 4096B if you stat them.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes https://bugs.debian.org/982146