### PR TITLE
ci: force binary files for grep on disk images

### DIFF
--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -14,7 +14,7 @@ test_run() {
         -watchdog i6300esb -watchdog-action poweroff \
         -append "panic=1 systemd.crash_reboot root=LABEL=dracut rw systemd.log_level=debug systemd.log_target=console rd.retry=3 rd.debug console=ttyS0,115200n81 rd.shell=0 $DEBUGFAIL" \
         -initrd $TESTDIR/initramfs.testing || return 1
-    grep -F -m 1 -q dracut-root-block-success $TESTDIR/result || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success $TESTDIR/result || return 1
 }
 
 test_setup() {
@@ -79,7 +79,7 @@ test_setup() {
         -drive format=raw,index=0,media=disk,file=$TESTDIR/root.ext3 \
         -append "root=/dev/dracut/root rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -F -m 1 -q dracut-root-block-created $TESTDIR/root.ext3 || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/root.ext3 || return 1
 
 
     (

--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -10,7 +10,7 @@ test_run() {
         -drive format=raw,index=0,media=disk,file=$TESTDIR/root.ext3 \
         -append "panic=1 systemd.crash_reboot root=LABEL=dracut rw loglevel=77 systemd.log_level=debug systemd.log_target=console rd.retry=3 rd.info console=ttyS0,115200n81 selinux=0 init=/sbin/init rd.shell=0 $DEBUGFAIL" \
         -initrd $TESTDIR/initramfs.testing
-    grep -F -m 1 -q dracut-root-block-success $TESTDIR/root.ext3 || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success $TESTDIR/root.ext3 || return 1
 }
 
 test_setup() {
@@ -76,7 +76,7 @@ test_setup() {
         -drive format=raw,index=0,media=disk,file=$TESTDIR/root.ext3 \
         -append "root=/dev/fakeroot rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -F -m 1 -q dracut-root-block-created $TESTDIR/root.ext3 || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/root.ext3 || return 1
 
 
     (

--- a/test/TEST-03-USR-MOUNT/test.sh
+++ b/test/TEST-03-USR-MOUNT/test.sh
@@ -22,7 +22,7 @@ client_run() {
         -append "panic=1 systemd.crash_reboot root=LABEL=dracut $client_opts loglevel=7 rd.retry=3 rd.info console=ttyS0,115200n81 selinux=0 rd.debug rd.shell=0 $DEBUGFAIL" \
         -initrd $TESTDIR/initramfs.testing
 
-    if ! grep -F -m 1 -q dracut-root-block-success $TESTDIR/result; then
+    if ! grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success $TESTDIR/result; then
         echo "CLIENT TEST END: $test_name [FAILED]"
         return 1
     fi
@@ -109,7 +109,7 @@ test_setup() {
         -drive format=raw,index=1,media=disk,file=$TESTDIR/usr.btrfs \
         -append "root=/dev/dracut/root rw rootfstype=btrfs quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    if ! grep -F -m 1 -q dracut-root-block-created $TESTDIR/root.btrfs; then
+    if ! grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/root.btrfs; then
         echo "Could not create root filesystem"
         return 1
     fi

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -23,7 +23,7 @@ client_run() {
         -append "panic=1 systemd.crash_reboot root=LABEL=dracut $client_opts rd.retry=3 console=ttyS0,115200n81 selinux=0 $DEBUGOUT rd.shell=0 $DEBUGFAIL" \
         -initrd $TESTDIR/initramfs.testing
 
-    if ! grep -F -m 1 -q dracut-root-block-success $TESTDIR/result; then
+    if ! grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success $TESTDIR/result; then
         echo "CLIENT TEST END: $test_name [FAILED]"
         return 1
     fi
@@ -249,7 +249,7 @@ EOF
         -drive format=raw,index=2,media=disk,file=$TESTDIR/result \
         -append "root=/dev/fakeroot rw rootfstype=btrfs quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    if ! grep -F -m 1 -q dracut-root-block-created $TESTDIR/result; then
+    if ! grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/result; then
         echo "Could not create root filesystem"
         return 1
     fi

--- a/test/TEST-10-RAID/test.sh
+++ b/test/TEST-10-RAID/test.sh
@@ -12,7 +12,7 @@ test_run() {
         -drive format=raw,index=0,media=disk,file=$DISKIMAGE \
         -append "panic=1 systemd.crash_reboot root=/dev/dracut/root rd.auto rw rd.retry=10 console=ttyS0,115200n81 selinux=0 rd.shell=0 $DEBUGFAIL" \
         -initrd $TESTDIR/initramfs.testing
-    grep -F -m 1 -q dracut-root-block-success $DISKIMAGE || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success $DISKIMAGE || return 1
 }
 
 test_setup() {
@@ -76,7 +76,7 @@ test_setup() {
         -drive format=raw,index=0,media=disk,file=$DISKIMAGE \
         -append "root=/dev/cannotreach rw rootfstype=ext2 console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -F -m 1 -q dracut-root-block-created $DISKIMAGE || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $DISKIMAGE || return 1
     eval $(grep -F -a -m 1 ID_FS_UUID $DISKIMAGE)
 
     (

--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -11,7 +11,7 @@ test_run() {
         -drive format=raw,index=0,media=disk,file=$TESTDIR/root.ext2 \
         -append "panic=1 systemd.crash_reboot root=/dev/dracut/root rw rd.auto=1 quiet rd.retry=3 rd.info console=ttyS0,115200n81 selinux=0 rd.debug rd.shell=0 $DEBUGFAIL" \
         -initrd $TESTDIR/initramfs.testing
-    grep -F -m 1 -q dracut-root-block-success $TESTDIR/root.ext2 || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success $TESTDIR/root.ext2 || return 1
 }
 
 test_setup() {
@@ -72,7 +72,7 @@ test_setup() {
     $testdir/run-qemu -drive format=raw,index=0,media=disk,file=$TESTDIR/root.ext2 \
                       -append "root=/dev/fakeroot rw rootfstype=ext2 quiet console=ttyS0,115200n81 selinux=0" \
                       -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -F -m 1 -q dracut-root-block-created $TESTDIR/root.ext2 || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/root.ext2 || return 1
     (
         export initdir=$TESTDIR/overlay
         . $basedir/dracut-init.sh

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -20,7 +20,7 @@ client_run() {
         -drive format=raw,index=3,media=disk,file=$TESTDIR/disk3.img.new \
         -append "panic=1 systemd.crash_reboot $* systemd.log_target=kmsg root=LABEL=root rw rd.retry=10 rd.info console=ttyS0,115200n81 log_buf_len=2M selinux=0 rd.shell=0 $DEBUGFAIL " \
         -initrd $TESTDIR/initramfs.testing
-    if ! grep -F -m 1 -q dracut-root-block-success $TESTDIR/marker.img; then
+    if ! grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success $TESTDIR/marker.img; then
         echo "CLIENT TEST END: $@ [FAIL]"
         return 1;
     fi
@@ -118,7 +118,7 @@ test_setup() {
         -append "root=/dev/fakeroot rw rootfstype=ext2 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
 
-    grep -F -m 1 -q dracut-root-block-created $TESTDIR/marker.img || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/marker.img || return 1
     eval $(grep -F --binary-files=text -m 1 MD_UUID $TESTDIR/marker.img)
     eval $(grep -F -a -m 1 ID_FS_UUID $TESTDIR/marker.img)
     echo $ID_FS_UUID > $TESTDIR/luksuuid

--- a/test/TEST-13-ENC-RAID-LVM/test.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test.sh
@@ -19,7 +19,7 @@ test_run() {
         -drive format=raw,index=1,media=disk,file=$TESTDIR/check-success.img \
         -append "panic=1 systemd.crash_reboot root=/dev/dracut/root rw rd.auto rd.retry=20 console=ttyS0,115200n81 selinux=0 rd.debug rootwait $LUKSARGS rd.shell=0 $DEBUGFAIL" \
         -initrd $TESTDIR/initramfs.testing
-    grep -F -m 1 -q dracut-root-block-success $TESTDIR/check-success.img || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success $TESTDIR/check-success.img || return 1
     echo "CLIENT TEST END: [OK]"
 
     dd if=/dev/zero of=$TESTDIR/check-success.img bs=1M count=1
@@ -30,7 +30,7 @@ test_run() {
         -drive format=raw,index=1,media=disk,file=$TESTDIR/check-success.img \
         -append "panic=1 systemd.crash_reboot root=/dev/dracut/root rw quiet rd.auto rd.retry=20 rd.info console=ttyS0,115200n81 selinux=0 rd.debug  $DEBUGFAIL" \
         -initrd $TESTDIR/initramfs.testing
-    grep -F -m 1 -q dracut-root-block-success $TESTDIR/check-success.img || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success $TESTDIR/check-success.img || return 1
     echo "CLIENT TEST END: [OK]"
 
     dd if=/dev/zero of=$TESTDIR/check-success.img bs=1M count=1
@@ -41,7 +41,7 @@ test_run() {
         -drive format=raw,index=1,media=disk,file=$TESTDIR/check-success.img \
         -append "panic=1 systemd.crash_reboot root=/dev/dracut/root rw quiet rd.auto rd.retry=10 rd.info console=ttyS0,115200n81 selinux=0 rd.debug  $DEBUGFAIL rd.luks.uuid=failme" \
         -initrd $TESTDIR/initramfs.testing
-    grep -F -m 1 -q dracut-root-block-success $TESTDIR/check-success.img && return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success $TESTDIR/check-success.img && return 1
     echo "CLIENT TEST END: [OK]"
 
     return 0
@@ -105,7 +105,7 @@ test_setup() {
     $testdir/run-qemu -drive format=raw,index=0,media=disk,file=$TESTDIR/root.ext2 \
                       -append "root=/dev/fakeroot rw rootfstype=ext2 quiet console=ttyS0,115200n81 selinux=0" \
                       -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -F -m 1 -q dracut-root-block-created $TESTDIR/root.ext2 || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/root.ext2 || return 1
     cryptoUUIDS=$(grep -F --binary-files=text  -m 3 ID_FS_UUID $TESTDIR/root.ext2)
     for uuid in $cryptoUUIDS; do
         eval $uuid

--- a/test/TEST-14-IMSM/test.sh
+++ b/test/TEST-14-IMSM/test.sh
@@ -20,7 +20,7 @@ client_run() {
         -append "panic=1 systemd.crash_reboot $* root=LABEL=root rw debug rd.retry=5 rd.debug console=ttyS0,115200n81 selinux=0 rd.info rd.shell=0 $DEBUGFAIL" \
         -initrd $TESTDIR/initramfs.testing
 
-    if ! grep -F -m 1 -q dracut-root-block-success $TESTDIR/marker.img; then
+    if ! grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success $TESTDIR/marker.img; then
         echo "CLIENT TEST END: $@ [FAIL]"
         return 1;
     fi
@@ -112,7 +112,7 @@ test_setup() {
         -drive format=raw,index=2,media=disk,file=$TESTDIR/disk2 \
         -append "root=/dev/dracut/root rw rootfstype=ext2 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -F -m 1 -q dracut-root-block-created $TESTDIR/marker.img || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/marker.img || return 1
     eval $(grep -F --binary-files=text -m 1 MD_UUID $TESTDIR/marker.img)
 
     if [[ -z $MD_UUID ]]; then

--- a/test/TEST-15-BTRFSRAID/test.sh
+++ b/test/TEST-15-BTRFSRAID/test.sh
@@ -14,7 +14,7 @@ test_run() {
         -drive format=raw,index=1,media=disk,file=$DISKIMAGE \
         -append "panic=1 systemd.crash_reboot root=LABEL=root rw rd.retry=3 rd.info console=ttyS0,115200n81 selinux=0 rd.shell=0 $DEBUGFAIL" \
         -initrd $TESTDIR/initramfs.testing
-    grep -F -m 1 -q dracut-root-block-success $MARKER_DISKIMAGE || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success $MARKER_DISKIMAGE || return 1
 }
 
 test_setup() {
@@ -81,7 +81,7 @@ test_setup() {
         -append "root=/dev/fakeroot rw quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
 
-    dd if=$DISKIMAGE bs=512 count=4 skip=2048 | grep -F -m 1 -q dracut-root-block-created || return 1
+    dd if=$DISKIMAGE bs=512 count=4 skip=2048 | grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created || return 1
 
     (
         export initdir=$TESTDIR/overlay

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -34,7 +34,7 @@ test_run() {
         #     -append "root=live:CDLABEL=LiveCD live quiet rhgb selinux=0 rd.live.check" \
         #     -initrd "$TESTDIR"/initramfs.testing
 
-    grep -F -m 1 -q dracut-root-block-success -- "$TESTDIR"/root.img || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success -- "$TESTDIR"/root.img || return 1
 }
 
 test_setup() {

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -11,7 +11,7 @@ test_run() {
         -drive format=raw,index=0,media=disk,file=$TESTDIR/root.ext2 \
         -append "panic=1 systemd.crash_reboot root=/dev/dracut/root rw rd.auto=1 quiet rd.retry=3 rd.info console=ttyS0,115200n81 selinux=0 rd.debug rd.shell=0 $DEBUGFAIL" \
         -initrd $TESTDIR/initramfs.testing
-    grep -F -m 1 -q dracut-root-block-success $TESTDIR/root.ext2 || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success $TESTDIR/root.ext2 || return 1
 }
 
 test_setup() {
@@ -72,7 +72,7 @@ test_setup() {
     $testdir/run-qemu -drive format=raw,index=0,media=disk,file=$TESTDIR/root.ext2 \
                       -append "root=/dev/fakeroot rw rootfstype=ext2 quiet console=ttyS0,115200n81 selinux=0" \
                       -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -F -m 1 -q dracut-root-block-created $TESTDIR/root.ext2 || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/root.ext2 || return 1
     (
         export initdir=$TESTDIR/overlay
         . $basedir/dracut-init.sh

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -74,7 +74,7 @@ client_test() {
         -append "rd.net.timeout.dhcp=3 panic=1 systemd.crash_reboot rd.shell=0 $cmdline $DEBUGFAIL rd.retry=10 quiet ro console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.testing
 
-    if [[ $? -ne 0 ]] || ! grep -F -m 1 -q nfs-OK $TESTDIR/client.img; then
+    if [[ $? -ne 0 ]] || ! grep -U --binary-files=binary -F -m 1 -q nfs-OK $TESTDIR/client.img; then
         echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"
         return 1
     fi
@@ -364,7 +364,7 @@ test_setup() {
         -drive format=raw,index=0,media=disk,file=$TESTDIR/server.ext3 \
         -append "root=/dev/dracut/root rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -F -m 1 -q dracut-root-block-created $TESTDIR/server.ext3 || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/server.ext3 || return 1
 
 
 

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -67,7 +67,7 @@ run_client() {
         -acpitable file=ibft.table \
         -append "panic=1 systemd.crash_reboot rw rd.auto rd.retry=50 console=ttyS0,115200n81 selinux=0 rd.debug=0 rd.shell=0 $DEBUGFAIL $*" \
         -initrd $TESTDIR/initramfs.testing
-    if ! grep -F -m 1 -q iscsi-OK $TESTDIR/client.img; then
+    if ! grep -U --binary-files=binary -F -m 1 -q iscsi-OK $TESTDIR/client.img; then
         echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"
         return 1
     fi
@@ -193,7 +193,7 @@ test_setup() {
         -drive format=raw,index=3,media=disk,file=$TESTDIR/iscsidisk3.img \
         -append "root=/dev/fakeroot rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -F -m 1 -q dracut-root-block-created $TESTDIR/client.img || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/client.img || return 1
     rm -- $TESTDIR/client.img
     rm -rf -- $TESTDIR/overlay
 
@@ -262,7 +262,7 @@ test_setup() {
         -drive format=raw,index=0,media=disk,file=$TESTDIR/server.ext3 \
         -append "root=/dev/dracut/root rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -F -m 1 -q dracut-root-block-created $TESTDIR/server.ext3 || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/server.ext3 || return 1
     rm -rf -- $TESTDIR/overlay
 
     # Make an overlay with needed tools for the test harness

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -66,7 +66,7 @@ run_client() {
         -net socket,connect=127.0.0.1:12331 \
         -append "panic=1 systemd.crash_reboot rw rd.auto rd.retry=50 console=ttyS0,115200n81 selinux=0 rd.debug=0 rd.shell=0 $DEBUGFAIL $*" \
         -initrd $TESTDIR/initramfs.testing
-    if ! grep -F -m 1 -q iscsi-OK $TESTDIR/client.img; then
+    if ! grep -U --binary-files=binary -F -m 1 -q iscsi-OK $TESTDIR/client.img; then
         echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"
         return 1
     fi
@@ -209,7 +209,7 @@ test_setup() {
         -drive format=raw,index=3,media=disk,file=$TESTDIR/iscsidisk3.img \
         -append "root=/dev/fakeroot rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -F -m 1 -q dracut-root-block-created $TESTDIR/client.img || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/client.img || return 1
     rm -- $TESTDIR/client.img
 
     # Make server root
@@ -277,7 +277,7 @@ test_setup() {
         -drive format=raw,index=0,media=disk,file=$TESTDIR/server.ext3 \
         -append "root=/dev/dracut/root rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -F -m 1 -q dracut-root-block-created $TESTDIR/server.ext3 || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/server.ext3 || return 1
     rm -rf -- $TESTDIR/overlay
 
     # Make an overlay with needed tools for the test harness

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -83,7 +83,7 @@ client_test() {
         -append "panic=1 systemd.crash_reboot rd.shell=0 $cmdline $DEBUGFAIL rd.auto rd.info rd.retry=10 ro console=ttyS0,115200n81  selinux=0  " \
         -initrd $TESTDIR/initramfs.testing
 
-    if [[ $? -ne 0 ]] || ! grep -F -m 1 -q nbd-OK $TESTDIR/flag.img; then
+    if [[ $? -ne 0 ]] || ! grep -U --binary-files=binary -F -m 1 -q nbd-OK $TESTDIR/flag.img; then
         echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"
         return 1
     fi
@@ -271,7 +271,7 @@ make_encrypted_root() {
         -drive format=raw,index=1,media=disk,file=$TESTDIR/flag.img \
         -append "root=/dev/fakeroot rw quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -F -m 1 -q dracut-root-block-created $TESTDIR/flag.img || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/flag.img || return 1
     grep -F -a -m 1 ID_FS_UUID $TESTDIR/flag.img > $TESTDIR/luks.uuid
 }
 
@@ -339,7 +339,7 @@ make_client_root() {
         -drive format=raw,index=1,media=disk,file=$TESTDIR/flag.img \
         -append "root=/dev/dracut/root rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -F -m 1 -q dracut-root-block-created $TESTDIR/flag.img || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/flag.img || return 1
     rm -fr "$TESTDIR"/overlay
 }
 
@@ -422,7 +422,7 @@ EOF
         -drive format=raw,index=1,media=disk,file=$TESTDIR/flag.img \
         -append "root=/dev/dracut/root rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -F -m 1 -q dracut-root-block-created $TESTDIR/flag.img || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/flag.img || return 1
     rm -fr "$TESTDIR"/overlay
 }
 

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -310,7 +310,7 @@ test_setup() {
         -drive format=raw,index=0,media=disk,file=$TESTDIR/server.ext3 \
         -append "root=/dev/dracut/root rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -F -m 1 -q dracut-root-block-created $TESTDIR/server.ext3 || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/server.ext3 || return 1
     rm -fr "$TESTDIR"/overlay
 
     # Make an overlay with needed tools for the test harness

--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
+++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
@@ -329,7 +329,7 @@ test_setup() {
         -drive format=raw,index=0,media=disk,file=$TESTDIR/server.ext3 \
         -append "root=/dev/dracut/root rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -F -m 1 -q dracut-root-block-created $TESTDIR/server.ext3 || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created $TESTDIR/server.ext3 || return 1
     rm -fr "$TESTDIR"/overlay
 
     # Make an overlay with needed tools for the test harness


### PR DESCRIPTION
Because some of the CI tests fail randomly while grepping for the
test success marker, let's be specific of the file format grep will
search to eleminate all failure sources.
