### PR TITLE
fix(fcoe): rd.nofcoe=0 should disable fcoe

### DIFF
--- a/modules.d/95fcoe/lldpad.sh
+++ b/modules.d/95fcoe/lldpad.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if getargbool 0 rd.nofcoe ; then
+if ! getargbool 1 rd.nofcoe ; then
 	info "rd.nofcoe=0: skipping lldpad activation"
 	return 0
 fi

--- a/modules.d/95fcoe/parse-fcoe.sh
+++ b/modules.d/95fcoe/parse-fcoe.sh
@@ -13,7 +13,7 @@
 # fcoe=eth0:nodcb:vn2vn
 # fcoe=4a:3f:4c:04:f8:d7:nodcb:fabric
 
-if getargbool 0 rd.nofcoe ; then
+if ! getargbool 1 rd.nofcoe ; then
 	info "rd.nofcoe=0: skipping fcoe"
 	return 0
 fi


### PR DESCRIPTION
8446c8f9 Changed the default behavior, but also flipped meaning of 0/1.
Right now rd.nofcoe=0 enables fcoe, which is the opposite what manpage
says.


