### PR TITLE
fcoe: rename rd.nofcoe to rd.fcoe

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -868,7 +868,7 @@ iscsistart -b --param node.session.timeo.replacement_timeout=30
 
 FCoE
 ~~~~
-**rd.nofcoe=0**::
+**rd.fcoe=0**::
     disable FCoE and lldpad
 
 **fcoe=**__<edd|interface|MAC>__:__{dcb|nodcb}__:__{fabric|vn2vn}__::

--- a/modules.d/95fcoe/lldpad.sh
+++ b/modules.d/95fcoe/lldpad.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if getargbool 0 rd.nofcoe ; then
+if ! getargbool 1 rd.nofcoe ; then
 	info "rd.nofcoe=0: skipping lldpad activation"
 	return 0
 fi

--- a/modules.d/95fcoe/lldpad.sh
+++ b/modules.d/95fcoe/lldpad.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if ! getargbool 1 rd.nofcoe ; then
-	info "rd.nofcoe=0: skipping lldpad activation"
+if ! getargbool 1 rd.fcoe -d -n rd.nofcoe ; then
+	info "rd.fcoe=0: skipping lldpad activation"
 	return 0
 fi
 

--- a/modules.d/95fcoe/parse-fcoe.sh
+++ b/modules.d/95fcoe/parse-fcoe.sh
@@ -13,7 +13,7 @@
 # fcoe=eth0:nodcb:vn2vn
 # fcoe=4a:3f:4c:04:f8:d7:nodcb:fabric
 
-if getargbool 0 rd.nofcoe ; then
+if ! getargbool 1 rd.nofcoe ; then
 	info "rd.nofcoe=0: skipping fcoe"
 	return 0
 fi

--- a/modules.d/95fcoe/parse-fcoe.sh
+++ b/modules.d/95fcoe/parse-fcoe.sh
@@ -13,8 +13,8 @@
 # fcoe=eth0:nodcb:vn2vn
 # fcoe=4a:3f:4c:04:f8:d7:nodcb:fabric
 
-if ! getargbool 1 rd.nofcoe ; then
-	info "rd.nofcoe=0: skipping fcoe"
+if ! getargbool 1 rd.fcoe -d -n rd.nofcoe ; then
+	info "rd.fcoe=0: skipping fcoe"
 	return 0
 fi
 


### PR DESCRIPTION
    fcoe: rename rd.nofcoe to rd.fcoe
    
    The current name of this bool is kinda stupid. Based on the manpage
    setting it to 0 turns off fcoe, which means that nofcoe=1 should mean
    that it is on.
    
    Let's just do the same thing as with rd.lvm=0, rd.luks=0,....
