### PR TITLE
fix:  proper return code for inst_multiple in dracut-init.sh

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -258,12 +258,13 @@ inst_symlink() {
 
 inst_multiple() {
     local _ret
-    if ! "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${initdir:+-D "$initdir"} -a ${loginstall:+-L "$loginstall"} ${DRACUT_RESOLVE_DEPS:+-l}  ${DRACUT_FIPS_MODE:+-f} "$@"; then
+    if "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${initdir:+-D "$initdir"} -a ${loginstall:+-L "$loginstall"} ${DRACUT_RESOLVE_DEPS:+-l}  ${DRACUT_FIPS_MODE:+-f} "$@"; then
+        return 0
+    else
         _ret=$?
         derror FAILED: "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${initdir:+-D "$initdir"} -a ${loginstall:+-L "$loginstall"} ${DRACUT_RESOLVE_DEPS:+-l}  ${DRACUT_FIPS_MODE:+-f} ${_hostonly_install:+-H} "$@" || :
         return $_ret
     fi
-    return 0
 }
 
 dracut_install() {


### PR DESCRIPTION
A test of the form

    if ! command; then
        _ret=$?
        ...
        return _ret
    fi

does not capture the return code of `command`, but the negation of the return code, leaving _ret == 0. The test of this form in inst_multiple has been refactored to capture and return the right value.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
