### PR TITLE
feat(github): adding packit support for fedora maintenance

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,58 @@
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# The name of the upstream package
+upstream_package_name: dracut
+
+# The upstream tag versioning scheme 
+upstream_tag_template: "{version}"
+
+# The URL of the upstream project
+upstream_project_url: https://github.com/dracutdevs/dracut
+
+# Relative path to a spec file within the upstream repository
+specfile_path: dracut.spec
+
+# Name of the downstream package
+downstream_package_name: dracut
+
+# The URL of the downstream project
+dist_git_base_url: https://src.fedoraproject.org/
+
+# Sync file(s) from upstream repo to dist-git
+synced_files:
+  # The dracut spec file is maintained upstream so we sync it downstream.
+  - dracut.spec
+  # We sync the packit file downstream be able to optionally use the sync-from-downstream command
+  - .packit.yaml
+
+# We want new releases to be automatically built on rawhide and have few jobs
+# on copr.
+create_pr: false
+jobs:
+- job: propose_downstream
+  trigger: release
+  metadata:
+    dist_git_branches: master
+
+- job: tests
+  trigger: pull_request
+  metadata:
+    targets:
+      - fedora-rawhide
+
+- job: copr_build
+  trigger: pull_request
+  metadata:
+    targets:
+      - fedora-rawhide
+
+- job: copr_build
+  trigger: commit
+  metadata:
+    targets:
+      - fedora-rawhide
+    branch: master
+    owner: "@dracut"
+    project: Dracut
+    preserve_project: True


### PR DESCRIPTION
This pull request adds the initial packit [1][2] support for fedora maintenance which
should get us started of automating the release process from upstream release to fedora.

This PR completes the first 2 steps in packit's onboarding process and is limited to rawhide ( so it should not break anything), the rest of the onboarding process needs to be completed by @haraldh as well as any fine tuning of packit. 
( I just put some sample entries there to get us started ).

## Checklist
- [x] I have tested it locally and it passes the ```packit srpm``` test.

1. https://packit.dev
2. https://packit.dev/docs/guide/