### PR TITLE
chore(.packit.yml): adding all fedora release + centos to packit

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -45,13 +45,16 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-      - fedora-rawhide
+      - fedora-development
+      - fedora-eln
 
 - job: copr_build
   trigger: commit
   metadata:
     targets:
-      - fedora-rawhide
+      - fedora-all
+      - fedora-development
+      - fedora-eln
     branch: master
     owner: "@dracut"
     project: Dracut


### PR DESCRIPTION
Since packit is now working let's extend it to cover more releases.

With this config change,copr builds will happen on pull requests
for all fedora development branches and the next major RHEL release
( fedora-eln ) and on commits, copr builds will happen on all fedora
release and the next major RHEL release.