### PR TITLE
fix(udev-rules): add btrfs udev rules by default

### DIFF
--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -38,6 +38,7 @@ install() {
         60-pcmcia.rules \
         60-persistent-storage.rules \
         61-persistent-storage-edd.rules \
+        64-btrfs.rules \
         70-uaccess.rules \
         71-seat.rules \
         73-seat-late.rules \


### PR DESCRIPTION
Install `64-btrfs.rules` unconditionally to mark btrfs devices ready or not.
    
In case no `btrfs` kernel module is available in the initramfs, the device should not be ready.
    
Depends on: https://github.com/systemd/systemd/pull/18802
    
Fixes: https://github.com/dracutdevs/dracut/issues/947
