### PR TITLE
fix: always use mkdir -p

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1015,7 +1015,7 @@ trap '
 trap 'exit 1;' SIGINT
 
 readonly initdir="${DRACUT_TMPDIR}/initramfs"
-mkdir "$initdir"
+mkdir -p "$initdir"
 
 # shellcheck disable=SC2154
 if [[ $early_microcode = yes ]] || { [[ $acpi_override = yes ]] && [[ -d $acpi_table_dir ]] ;}; then
@@ -2133,7 +2133,7 @@ dinfo "*** Creating image file '$outfile' ***"
 
 if [[ $uefi = yes ]]; then
     readonly uefi_outdir="$DRACUT_TMPDIR/uefi"
-    mkdir "$uefi_outdir"
+    mkdir -p "$uefi_outdir"
 fi
 
 if [[ $DRACUT_REPRODUCIBLE ]]; then

--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -56,7 +56,7 @@ mount_boot()
 
         [ -e "$boot" ] || return 1
 
-        mkdir /boot
+        mkdir -p /boot
         fips_info "Mounting $boot as /boot"
         mount -oro "$boot" /boot || return 1
     elif [ -d "$NEWROOT/boot" ]; then

--- a/modules.d/80cms/cmssetup.sh
+++ b/modules.d/80cms/cmssetup.sh
@@ -111,7 +111,7 @@ function readcmsfile() # $1=dasdport $2=filename
     devname=$(cd /sys/bus/ccw/devices/$dev/block; set -- *; [ -b /dev/$1 ] && echo $1)
     devname=${devname:-dasda}
 
-    [[ -d /mnt ]] || mkdir /mnt
+    [[ -d /mnt ]] || mkdir -p /mnt
     if cmsfs-fuse --to=UTF-8 -a /dev/$devname /mnt; then
         cat /mnt/$2 > /run/initramfs/$2
         umount /mnt || umount -l /mnt

--- a/modules.d/90crypt/crypt-lib.sh
+++ b/modules.d/90crypt/crypt-lib.sh
@@ -200,7 +200,7 @@ readkey() {
         local mntp="/mnt/$(str_replace "keydev-$keydev-$keypath" '/' '-')"
 
         if [ ! -d "$mntp" ]; then
-            mkdir "$mntp"
+            mkdir -p "$mntp"
             mount -r "$keydev" "$mntp" || die 'Mounting rem. dev. failed!'
         fi
     fi

--- a/modules.d/90dmsquash-live/dmsquash-generator.sh
+++ b/modules.d/90dmsquash-live/dmsquash-generator.sh
@@ -52,7 +52,7 @@ esac
 
 GENERATOR_DIR="$2"
 [ -z "$GENERATOR_DIR" ] && exit 1
-[ -d "$GENERATOR_DIR" ] || mkdir "$GENERATOR_DIR"
+[ -d "$GENERATOR_DIR" ] || mkdir -p "$GENERATOR_DIR"
 
 getargbool 0 rd.live.overlay.readonly -d -y readonly_overlay && readonly_overlay="--readonly" || readonly_overlay=""
 getargbool 0 rd.live.overlay.overlayfs && overlayfs="yes"

--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -125,7 +125,7 @@ do_live_overlay() {
 
     # need to know where to look for the overlay
     if [ -z "$setup" -a -n "$devspec" -a -n "$pathspec" -a -n "$overlay" ]; then
-        mkdir -m 0755 /run/initramfs/overlayfs
+        mkdir -m 0755 -p /run/initramfs/overlayfs
         opt=''
         [ -n "$readonly_overlay" ] && opt=-r
         mount -n -t auto $devspec /run/initramfs/overlayfs || :
@@ -210,8 +210,8 @@ do_live_overlay() {
             fi
         fi
         if [ -n "$overlayfs" ]; then
-            mkdir -m 0755 /run/overlayfs
-            mkdir -m 0755 /run/ovlwork
+            mkdir -m 0755 -p /run/overlayfs
+            mkdir -m 0755 -p /run/ovlwork
             if [ -n "$readonly_overlay" ] && ! [ -h /run/overlayfs-r ]; then
                 info "No persistent overlay found."
                 unset -v readonly_overlay
@@ -241,7 +241,7 @@ do_live_overlay() {
 
     if [ -n "$thin_snapshot" ]; then
         modprobe dm_thin_pool
-        mkdir -m 0755 /run/initramfs/thin-overlay
+        mkdir -m 0755 -p /run/initramfs/thin-overlay
 
         # In block units (512b)
         thin_data_sz=$(( $overlay_size * 1024 * 1024 / 512 ))
@@ -326,7 +326,7 @@ if [ -n "$FSIMG" ]; then
     if [ -n "$writable_fsimg" ]; then
         # mount the provided filesystem read/write
         echo "Unpacking live filesystem (may take some time)" > /dev/kmsg
-        mkdir -m 0755 /run/initramfs/fsimg/
+        mkdir -m 0755 -p /run/initramfs/fsimg/
         if [ -n "$SQUASHED" ]; then
             cp -v $FSIMG /run/initramfs/fsimg/rootfs.img
         else
@@ -368,7 +368,7 @@ fi
 ROOTFLAGS="$(getarg rootflags)"
 
 if [ -n "$overlayfs" ]; then
-    mkdir -m 0755 /run/rootfsbase
+    mkdir -m 0755 -p /run/rootfsbase
     if [ -n "$reset_overlay" ] && [ -h /run/overlayfs ]; then
         ovlfs=$(readlink /run/overlayfs)
         info "Resetting the OverlayFS overlay directory."

--- a/modules.d/90livenet/livenet-generator.sh
+++ b/modules.d/90livenet/livenet-generator.sh
@@ -41,7 +41,7 @@ esac
 GENERATOR_DIR="$2"
 [ -z "$GENERATOR_DIR" ] && exit 1
 
-[ -d "$GENERATOR_DIR" ] || mkdir "$GENERATOR_DIR"
+[ -d "$GENERATOR_DIR" ] || mkdir -p "$GENERATOR_DIR"
 
 getargbool 0 rd.live.overlay.readonly -d -y readonly_overlay && readonly_overlay="--readonly" || readonly_overlay=""
 getargbool 0 rd.live.overlay.overlayfs && overlayfs="yes"

--- a/modules.d/90mdraid/mdmon-pre-udev.sh
+++ b/modules.d/90mdraid/mdmon-pre-udev.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # save state dir for mdmon/mdadm for the real root
-[ -d /run/mdadm ] || mkdir -m 0755 /run/mdadm
+[ -d /run/mdadm ] || mkdir -m 0755 -p /run/mdadm
 # backward compat link

--- a/modules.d/95nbd/nbd-generator.sh
+++ b/modules.d/95nbd/nbd-generator.sh
@@ -9,7 +9,7 @@ type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 GENERATOR_DIR="$2"
 [ -z "$GENERATOR_DIR" ] && exit 1
 
-[ -d "$GENERATOR_DIR" ] || mkdir "$GENERATOR_DIR"
+[ -d "$GENERATOR_DIR" ] || mkdir -p "$GENERATOR_DIR"
 
 ROOTFLAGS="$(getarg rootflags)"
 

--- a/modules.d/95nfs/module-setup.sh
+++ b/modules.d/95nfs/module-setup.sh
@@ -88,7 +88,7 @@ install() {
     if [[ -f $dracutsysrootdir/lib/modprobe.d/nfs.conf ]]; then
         inst_multiple /lib/modprobe.d/nfs.conf
     else
-        [[ -d $initdir/etc/modprobe.d ]] || mkdir "$initdir"/etc/modprobe.d
+        [[ -d $initdir/etc/modprobe.d ]] || mkdir -p "$initdir"/etc/modprobe.d
         echo "alias nfs4 nfs" > "$initdir"/etc/modprobe.d/nfs.conf
     fi
 

--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -53,17 +53,17 @@ fi
 [ ! -h /dev/stderr ] && ln -s /proc/self/fd/2 /dev/stderr >/dev/null 2>&1
 
 if ! ismounted /dev/pts; then
-    mkdir -m 0755 /dev/pts
+    mkdir -m 0755 -p /dev/pts
     mount -t devpts -o gid=5,mode=620,noexec,nosuid devpts /dev/pts >/dev/null
 fi
 
 if ! ismounted /dev/shm; then
-    mkdir -m 0755 /dev/shm
+    mkdir -m 0755 -p /dev/shm
     mount -t tmpfs -o mode=1777,noexec,nosuid,nodev,strictatime tmpfs /dev/shm >/dev/null
 fi
 
 if ! ismounted /run; then
-    mkdir -m 0755 /newrun
+    mkdir -m 0755 -p /newrun
     if ! str_starts "$(readlink -f /bin/sh)" "/run/"; then
         mount -t tmpfs -o mode=0755,noexec,nosuid,nodev,strictatime tmpfs /newrun >/dev/null
     else
@@ -99,7 +99,7 @@ if [ $UDEVVERSION -gt 166 ]; then
     [ -d /run/udev ] || mkdir -p -m 0755 /run/udev
     [ -d $UDEVRULESD ] || mkdir -p -m 0755 $UDEVRULESD
 else
-    mkdir -m 0755 /dev/.udev /dev/.udev/rules.d
+    mkdir -m 0755 -p /dev/.udev /dev/.udev/rules.d
     export UDEVRULESD=/dev/.udev/rules.d
 fi
 
@@ -368,7 +368,7 @@ debug_on
 
 if ! [ -d "$NEWROOT"/run ]; then
     NEWRUN=/dev/.initramfs
-    mkdir -m 0755 "$NEWRUN"
+    mkdir -m 0755 -p "$NEWRUN"
     mount --rbind /run/initramfs "$NEWRUN"
 fi
 

--- a/modules.d/99shutdown/shutdown.sh
+++ b/modules.d/99shutdown/shutdown.sh
@@ -22,9 +22,9 @@ if [ "$(stat -c '%T' -f /)" = "tmpfs" ]; then
     mount -o remount,rw /
 fi
 
-mkdir /oldsys
+mkdir -p /oldsys
 for i in sys proc run dev; do
-    mkdir /oldsys/$i
+    mkdir -p /oldsys/$i
     mount --move /oldroot/$i /oldsys/$i
 done
 

--- a/test/TEST-03-USR-MOUNT/create-root.sh
+++ b/test/TEST-03-USR-MOUNT/create-root.sh
@@ -27,7 +27,7 @@ btrfs device scan /dev/sda2
 btrfs device scan /dev/sdb2
 mkdir -p /root
 mount -t btrfs /dev/sda2 /root
-[ -d /root/usr ] || mkdir /root/usr
+[ -d /root/usr ] || mkdir -p /root/usr
 mount -t btrfs /dev/sdb2 /root/usr
 btrfs subvolume create /root/usr/usr
 umount /root/usr

--- a/test/TEST-04-FULL-SYSTEMD/create-root.sh
+++ b/test/TEST-04-FULL-SYSTEMD/create-root.sh
@@ -28,7 +28,7 @@ btrfs device scan /dev/sda2
 btrfs device scan /dev/sdb2
 mkdir -p /root
 mount -t btrfs /dev/sda2 /root
-[ -d /root/usr ] || mkdir /root/usr
+[ -d /root/usr ] || mkdir -p /root/usr
 mount -t btrfs /dev/sdb2 /root/usr
 btrfs subvolume create /root/usr/usr
 umount /root/usr

--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -45,7 +45,7 @@ test_setup() {
         inst ./test-init.sh /sbin/init
         find_binary plymouth >/dev/null && inst_multiple plymouth
         cp -a /etc/ld.so.conf* $initdir/etc
-        mkdir $initdir/run
+        mkdir -p $initdir/run
         ldconfig -r "$initdir"
     )
 

--- a/test/TEST-12-RAID-DEG/create-root.sh
+++ b/test/TEST-12-RAID-DEG/create-root.sh
@@ -27,7 +27,7 @@ mke2fs -L root /dev/dracut/root
 mkdir -p /sysroot
 mount /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
-mkdir /sysroot/run
+mkdir -p /sysroot/run
 umount /sysroot
 lvm lvchange -a n /dev/dracut/root
 udevadm settle

--- a/test/TEST-14-IMSM/test.sh
+++ b/test/TEST-14-IMSM/test.sh
@@ -83,7 +83,7 @@ test_setup() {
         inst ./test-init.sh /sbin/init
         find_binary plymouth >/dev/null && inst_multiple plymouth
         cp -a /etc/ld.so.conf* $initdir/etc
-        mkdir $initdir/run
+        mkdir -p $initdir/run
         ldconfig -r "$initdir"
     )
 

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -45,7 +45,7 @@ test_setup() {
         inst ./test-init.sh /sbin/init
         find_binary plymouth >/dev/null && inst_multiple plymouth
         cp -a /etc/ld.so.conf* $initdir/etc
-        mkdir $initdir/run
+        mkdir -p $initdir/run
         ldconfig -r "$initdir"
     )
 

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -372,7 +372,7 @@ test_setup() {
     (
         export initdir=$TESTDIR/overlay
         . $basedir/dracut-init.sh
-        mkdir $TESTDIR/overlay
+        mkdir -p $TESTDIR/overlay
         inst_multiple poweroff shutdown
         inst_hook shutdown-emergency 000 ./hard-off.sh
         inst_hook emergency 000 ./hard-off.sh


### PR DESCRIPTION
Ensuring that directory creations dont trigger error if directory
previously existed as well as create parent directories if needed.

Majority of the code already does this, this takes care of the rest where it didn't.