### PR TITLE
chore(labeler): remove the needs review label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,3 @@
-needs review:
-  - "*"
-
 repository:
   - ./*
 


### PR DESCRIPTION
There is no longer need to have pull requests labeled with the needs
review label since reviews are now mandatory on pull request.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
