### PR TITLE
feat(nbd): support ipv6 link local nbds

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -575,7 +575,7 @@ USB Android phone::
 * enp0s29u1u2
 =====================
 
-**ip=**__{dhcp|on|any|dhcp6|auto6|either6|single-dhcp}__::
+**ip=**__{dhcp|on|any|dhcp6|auto6|either6|link6|single-dhcp}__::
     dhcp|on|any::: get ip from dhcp server from all interfaces. If root=dhcp,
     loop sequentially through all interfaces (eth0, eth1, ...) and use the first
     with a valid DHCP root-path.
@@ -592,12 +592,15 @@ USB Android phone::
 
     either6::: if auto6 fails, then dhcp6
 
-**ip=**__<interface>__:__{dhcp|on|any|dhcp6|auto6}__[:[__<mtu>__][:__<macaddr>__]]::
+    link6::: bring up interface for IPv6 link-local addressing
+
+**ip=**__<interface>__:__{dhcp|on|any|dhcp6|auto6|link6}__[:[__<mtu>__][:__<macaddr>__]]::
     This parameter can be specified multiple times.
 +
 =====================
 dhcp|on|any|dhcp6::: get ip from dhcp server on a specific interface
 auto6::: do IPv6 autoconfiguration
+link6::: bring up interface for IPv6 link local address
 <macaddr>::: optionally **set** <macaddr> on the <interface>. This
 cannot be used in conjunction with the **ifname** argument for the
 same <interface>.

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -123,6 +123,19 @@ do_ipv6auto() {
     return $ret
 }
 
+do_ipv6link() {
+    local ret
+    load_ipv6
+    echo 0 > /proc/sys/net/ipv6/conf/$netif/forwarding
+    echo 0 > /proc/sys/net/ipv6/conf/$netif/accept_ra
+    echo 0 > /proc/sys/net/ipv6/conf/$netif/accept_redirects
+    linkup $netif
+
+    [ -n "$hostname" ] && echo "echo $hostname > /proc/sys/kernel/hostname" > /tmp/net.$netif.hostname
+
+    return $ret
+}
+
 # Handle static ip configuration
 do_static() {
     strglobin $ip '*:*:*' && load_ipv6
@@ -449,6 +462,8 @@ for p in $(getargs ip=); do
                 do_ipv6auto ;;
             either6)
                 do_ipv6auto || do_dhcp -6 ;;
+            link6)
+                do_ipv6link ;;
             *)
                 do_static ;;
         esac

--- a/modules.d/35network-legacy/parse-ip-opts.sh
+++ b/modules.d/35network-legacy/parse-ip-opts.sh
@@ -75,7 +75,7 @@ for p in $(getargs ip=); do
                 [ -z "$mask" ] && \
                     die "Sorry, automatic calculation of netmask is not yet supported"
                 ;;
-            auto6);;
+            auto6|link6);;
             either6);;
             dhcp|dhcp6|on|any|single-dhcp) \
                 [ -n "$NEEDBOOTDEV" ] && [ -z "$dev" ] && \

--- a/modules.d/95nbd/nbd-generator.sh
+++ b/modules.d/95nbd/nbd-generator.sh
@@ -14,7 +14,13 @@ GENERATOR_DIR="$2"
 ROOTFLAGS="$(getarg rootflags)"
 
 nroot=${root#nbd:}
-nbdserver=${nroot%%:*}; nroot=${nroot#*:}
+nbdserver=${nroot%%:*};
+if [ "${nbdserver%"${nbdserver#?}"}" = "[" ]; then
+    nbdserver=${nroot#[}
+    nbdserver=${nbdserver%%]:*}\]; nroot=${nroot#*]:}
+else
+    nroot=${nroot#*:}
+fi
 nbdport=${nroot%%:*}; nroot=${nroot#*:}
 nbdfstype=${nroot%%:*}; nroot=${nroot#*:}
 nbdflags=${nroot%%:*}

--- a/modules.d/99fs-lib/fs-lib.sh
+++ b/modules.d/99fs-lib/fs-lib.sh
@@ -247,7 +247,11 @@ write_fs_tab() {
         fi
     fi
 
-    echo "$_root /sysroot $_rootfstype $_rootflags $_fspassno 0" >> /etc/fstab
+    if grep -q "$_root /sysroot" /etc/fstab; then
+        echo "$_root /sysroot $_rootfstype $_rootflags $_fspassno 0" >> /etc/fstab
+    else
+        return
+    fi
 
     if type systemctl >/dev/null 2>/dev/null; then
         systemctl daemon-reload


### PR DESCRIPTION
For https://github.com/SFTtech/stiefelsystem we use NBD over IPv6-linklocal. This was not supported in dracut.

## Changes
* Add v6 linklocal support for network module (already upstream in network manager)
* Add v6 support for NBD
* Some minor fixes discovered along the way

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it