### PR TITLE
fix(kernel-modules): Optionally add /usr/lib/modules.d to initramfs

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -141,7 +141,8 @@ installkernel() {
 
 # called by dracut
 install() {
-    inst_multiple -o "/lib/modprobe.d/*.conf"
+    [[ -d /lib/modprobe.d ]] && inst_multiple -o "/lib/modprobe.d/*.conf"
+    [[ -d /usr/lib/modprobe.d ]] && inst_multiple -o "/usr/lib/modprobe.d/*.conf"
     [[ $hostonly ]] && inst_multiple -H -o /etc/modprobe.d/*.conf /etc/modprobe.conf
     if ! dracut_module_included "systemd"; then
         inst_hook cmdline 01 "$moddir/parse-kernel.sh"


### PR DESCRIPTION
On SUSE, there is no /lib/modules.d, only /usr/lib/modules.d.

Upstream-Bug: http://bugzilla.opensuse.org/show_bug.cgi?id=1180822

Reference: bsc#1180822

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it