### PR TITLE
Harden dracut against GZIP environment variable

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -24,6 +24,7 @@
 # store for logging
 
 unset BASH_ENV
+unset GZIP
 
 # Verify bash version, current minimum is 4
 if (( BASH_VERSINFO[0] < 4 )); then


### PR DESCRIPTION
When a GZIP environment variable is set, this leads to various breakage:

In case 'pigz' is installed and GZIP is defined as a path, e.g.
/usr/local/bin/gzip, then dracut will fail with the following message:

   ~~~
   pigz: abort: cannot provide files in GZIP environment variable
   ~~~

In case 'pigz' isn't installed and regular 'gzip' is used and GZIP is
defined as a path, e.g. /usr/local/bin/gzip, then the path will be
zipped and dracut will fail for no obvious reason.  Trying again, dracut
will then fail with following message:

   ~~~
   gzip: /usr/local/bin/gzip.gz already exists;	not overwritten
   ~~~

In any case, GZIP environment should be unset to avoid breakage or
unwanted behaviour. This variable is anyway obsolescent, from gzip(1)
manpage.

Signed-off-by: Renaud Métrich <rmetrich@redhat.com>

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
