### PR TITLE
fix: correctly handle kernel parameters

### DIFF
--- a/.github/workflows/fedora-32.yml
+++ b/.github/workflows/fedora-32.yml
@@ -36,6 +36,7 @@ jobs:
           "36",
           "40",
           "41",
+          "98",
         ]
       fail-fast: false
     steps:

--- a/.github/workflows/fedora-33.yml
+++ b/.github/workflows/fedora-33.yml
@@ -37,6 +37,7 @@ jobs:
           "36",
           "40",
           "41",
+          "98",
         ]
       fail-fast: false
     steps:

--- a/.github/workflows/fedora-latest.yml
+++ b/.github/workflows/fedora-latest.yml
@@ -36,6 +36,7 @@ jobs:
           "36",
           "40",
           "41",
+          "98",
         ]
       fail-fast: false
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ test*.img
 /*.sign
 *.o
 skipcpio/skipcpio
+/util/util
+/dracut-util
+.idea/

--- a/dracut.spec
+++ b/dracut.spec
@@ -21,7 +21,8 @@ Group: System/Base
 
 # The entire source code is GPLv2+
 # except install/* which is LGPLv2+
-License: GPLv2+ and LGPLv2+
+# except util/* which is GPLv2
+License: GPLv2+ and LGPLv2+ and GPLv2
 
 URL: https://dracut.wiki.kernel.org/
 
@@ -295,6 +296,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/dracut-logger.sh
 %{dracutlibdir}/dracut-initramfs-restore
 %{dracutlibdir}/dracut-install
+%{dracutlibdir}/dracut-util
 %{dracutlibdir}/skipcpio
 %config(noreplace) %{_sysconfdir}/dracut.conf
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?rhel}

--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -18,18 +18,8 @@ mount_boot()
 
     if [ -n "$boot" ]; then
         case "$boot" in
-        LABEL=*)
-            boot="$(echo $boot | sed 's,/,\\x2f,g')"
-            boot="/dev/disk/by-label/${boot#LABEL=}"
-            ;;
-        UUID=*)
-            boot="/dev/disk/by-uuid/${boot#UUID=}"
-            ;;
-        PARTUUID=*)
-            boot="/dev/disk/by-partuuid/${boot#PARTUUID=}"
-            ;;
-        PARTLABEL=*)
-            boot="/dev/disk/by-partlabel/${boot#PARTLABEL=}"
+        LABEL=* | UUID=* | PARTUUID=* | PARTLABEL=*)
+            boot="$(label_uuid_to_dev "$boot")"
             ;;
         /dev/*)
             ;;

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -499,12 +499,12 @@ if [ -z "$NO_AUTO_DHCP" ] && [ ! -e /tmp/net.${netif}.up ]; then
         # No ip lines, no bootdev -> default to dhcp
         ip=$(getarg ip)
 
-        if getargs 'ip=dhcp6' || [ -z "$ip" -a "$netroot" = "dhcp6" ]; then
+        if getargs 'ip=dhcp6' >/dev/null || [ -z "$ip" -a "$netroot" = "dhcp6" ]; then
             load_ipv6
             do_dhcp -6
             ret=$?
         fi
-        if getargs 'ip=dhcp' || [ -z "$ip" -a "$netroot" != "dhcp6" ]; then
+        if getargs 'ip=dhcp' >/dev/null || [ -z "$ip" -a "$netroot" != "dhcp6" ]; then
             do_dhcp -4
             ret=$?
         fi

--- a/modules.d/90crypt/parse-crypt.sh
+++ b/modules.d/90crypt/parse-crypt.sh
@@ -8,13 +8,10 @@ _cryptgetargsname() {
     local _o _found _key
     unset _o
     unset _found
-    CMDLINE=$(getcmdline)
     _key="$1"
     set --
-    for _o in $CMDLINE; do
-        if [ "$_o" = "$_key" ]; then
-            _found=1;
-        elif [ "${_o%=*}" = "${_key%=}" ]; then
+    for _o in $(getargs rd.luks.name); do
+        if [ "${_o%=*}" = "${_key%=}" ]; then
             [ -n "${_o%=*}" ] && set -- "$@" "${_o#*=}";
             _found=1;
         fi
@@ -56,7 +53,7 @@ else
             unset _uuid
 
             uuid=${uuid##luks-}
-            if luksname=$(_cryptgetargsname "rd.luks.name=$uuid="); then
+            if luksname=$(_cryptgetargsname "$uuid="); then
                 luksname="${luksname#$uuid=}"
             else
                 luksname="luks-$uuid"
@@ -94,7 +91,7 @@ else
             unset _serialid
 
             serialid=${serialid##luks-}
-            if luksname=$(_cryptgetargsname "rd.luks.name=$serialid="); then
+            if luksname=$(_cryptgetargsname "$serialid="); then
                 luksname="${luksname#$serialid=}"
             else
                 luksname="luks-$serialid"
@@ -132,7 +129,7 @@ else
             unset _luksid
 
             luksid=${luksid##luks-}
-            if luksname=$(_cryptgetargsname "rd.luks.name=$luksid="); then
+            if luksname=$(_cryptgetargsname "$luksid="); then
                 luksname="${luksname#$luksid=}"
             else
                 luksname="luks-$luksid"

--- a/modules.d/90dmsquash-live/dmsquash-generator.sh
+++ b/modules.d/90dmsquash-live/dmsquash-generator.sh
@@ -16,27 +16,13 @@ fi
 [ "${liveroot%%:*}" = "live" ] || exit 0
 
 case "$liveroot" in
-    live:LABEL=*|LABEL=*) \
-        root="${root#live:}"
-        root="${root//\//\\x2f}"
-        root="live:/dev/disk/by-label/${root#LABEL=}"
+    live:LABEL=*|LABEL=* | live:UUID=*|UUID=* | live:PARTUUID=*|PARTUUID=* | live:PARTLABEL=*|PARTLABEL=*)
+        root="live:$(label_uuid_to_dev "${root#live:}")"
         rootok=1 ;;
-    live:CDLABEL=*|CDLABEL=*) \
+    live:CDLABEL=*|CDLABEL=*)
         root="${root#live:}"
-        root="${root//\//\\x2f}"
+        root="$(echo "$root" | sed 's,/,\\x2f,g;s, ,\\x20,g')"
         root="live:/dev/disk/by-label/${root#CDLABEL=}"
-        rootok=1 ;;
-    live:UUID=*|UUID=*) \
-        root="${root#live:}"
-        root="live:/dev/disk/by-uuid/${root#UUID=}"
-        rootok=1 ;;
-    live:PARTUUID=*|PARTUUID=*) \
-        root="${root#live:}"
-        root="live:/dev/disk/by-partuuid/${root#PARTUUID=}"
-        rootok=1 ;;
-    live:PARTLABEL=*|PARTLABEL=*) \
-        root="${root#live:}"
-        root="live:/dev/disk/by-partlabel/${root#PARTLABEL=}"
         rootok=1 ;;
     live:/*.[Ii][Ss][Oo]|/*.[Ii][Ss][Oo])
         root="${root#live:}"

--- a/modules.d/90dmsquash-live/parse-dmsquash-live.sh
+++ b/modules.d/90dmsquash-live/parse-dmsquash-live.sh
@@ -18,27 +18,13 @@ fi
 modprobe -q loop
 
 case "$liveroot" in
-    live:LABEL=*|LABEL=*) \
-        root="${root#live:}"
-        root="${root//\//\\x2f}"
-        root="live:/dev/disk/by-label/${root#LABEL=}"
+    live:LABEL=*|LABEL=* | live:UUID=*|UUID=* | live:PARTUUID=*|PARTUUID=* | live:PARTLABEL=*|PARTLABEL=*)
+        root="live:$(label_uuid_to_dev "${root#live:}")"
         rootok=1 ;;
-    live:CDLABEL=*|CDLABEL=*) \
+    live:CDLABEL=*|CDLABEL=*)
         root="${root#live:}"
-        root="${root//\//\\x2f}"
+        root="$(echo "$root" | sed 's,/,\\x2f,g;s, ,\\x20,g')"
         root="live:/dev/disk/by-label/${root#CDLABEL=}"
-        rootok=1 ;;
-    live:UUID=*|UUID=*) \
-        root="${root#live:}"
-        root="live:/dev/disk/by-uuid/${root#UUID=}"
-        rootok=1 ;;
-    live:PARTUUID=*|PARTUUID=*) \
-        root="${root#live:}"
-        root="live:/dev/disk/by-partuuid/${root#PARTUUID=}"
-        rootok=1 ;;
-    live:PARTLABEL=*|PARTLABEL=*) \
-        root="${root#live:}"
-        root="live:/dev/disk/by-partlabel/${root#PARTLABEL=}"
         rootok=1 ;;
     live:/*.[Ii][Ss][Oo]|/*.[Ii][Ss][Oo])
         root="${root#live:}"

--- a/modules.d/91zipl/parse-zipl.sh
+++ b/modules.d/91zipl/parse-zipl.sh
@@ -9,12 +9,22 @@ if [ -n "$zipl_arg" ] ; then
     LABEL=*) \
         zipl_env="ENV{ID_FS_LABEL}"
         zipl_val=${zipl_arg#LABEL=}
-        zipl_arg="/dev/disk/by-label/${zipl_val}"
+        zipl_arg="$(label_uuid_to_dev "${zipl_val}")"
         ;;
     UUID=*) \
         zipl_env="ENV{ID_FS_UUID}"
         zipl_val=${zipl_arg#UUID=}
-        zipl_arg="/dev/disk/by-uuid/${zipl_val}"
+        zipl_arg="$(label_uuid_to_dev "${zipl_val}")"
+        ;;
+    PARTLABEL=*) \
+        zipl_env="ENV{ID_FS_PARTLABEL}"
+        zipl_val=${zipl_arg#PARTLABEL=}
+        zipl_arg="$(label_uuid_to_dev "${zipl_val}")"
+        ;;
+    PARTUUID=*) \
+        zipl_env="ENV{ID_FS_PARTUUID}"
+        zipl_val=${zipl_arg#PARTUUID=}
+        zipl_arg="$(label_uuid_to_dev "${zipl_val}")"
         ;;
     /dev/mapper/*) \
         zipl_env="ENV{DM_NAME}"

--- a/modules.d/95resume/parse-resume.sh
+++ b/modules.d/95resume/parse-resume.sh
@@ -7,17 +7,8 @@ else
     unset resume
 fi
 
-case "$resume" in
-    LABEL=*) \
-        resume="$(echo $resume | sed 's,/,\\x2f,g')"
-        resume="/dev/disk/by-label/${resume#LABEL=}" ;;
-    UUID=*) \
-        resume="/dev/disk/by-uuid/${resume#UUID=}" ;;
-    PARTUUID=*) \
-        resume="/dev/disk/by-partuuid/${resume#PARTUUID=}" ;;
-    PARTLABEL=*) \
-        resume="/dev/disk/by-partlabel/${resume#PARTLABEL=}" ;;
-esac
+
+resume="$(label_uuid_to_dev "$resume")"
 
 if splash=$(getarg splash=); then
     export splash

--- a/modules.d/95rootfs-block/parse-block.sh
+++ b/modules.d/95rootfs-block/parse-block.sh
@@ -1,29 +1,11 @@
 #!/bin/sh
 
-case "$root" in
-    block:LABEL=*|LABEL=*)
-        root="${root#block:}"
-        root="$(echo $root | sed 's,/,\\x2f,g')"
-        root="block:/dev/disk/by-label/${root#LABEL=}"
-        rootok=1 ;;
-    block:UUID=*|UUID=*)
-        root="${root#block:}"
-        root="${root#UUID=}"
-        root="$(echo $root | tr "[:upper:]" "[:lower:]")"
-        root="block:/dev/disk/by-uuid/${root#UUID=}"
-        rootok=1 ;;
-    block:PARTUUID=*|PARTUUID=*)
-        root="${root#block:}"
-        root="${root#PARTUUID=}"
-        root="$(echo $root | tr "[:upper:]" "[:lower:]")"
-        root="block:/dev/disk/by-partuuid/${root}"
-        rootok=1 ;;
-    block:PARTLABEL=*|PARTLABEL=*)
-        root="${root#block:}"
-        root="block:/dev/disk/by-partlabel/${root#PARTLABEL=}"
+case "${root#block:}" in
+    LABEL=* | UUID=* | PARTUUID=* | PARTLABEL=*)
+        root="block:$(label_uuid_to_dev "$root")"
         rootok=1 ;;
     /dev/*)
-        root="block:${root}"
+        root="block:${root#block:}"
         rootok=1 ;;
 esac
 

--- a/modules.d/95rootfs-block/rootfallback.sh
+++ b/modules.d/95rootfs-block/rootfallback.sh
@@ -3,29 +3,7 @@
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
 for root in $(getargs rootfallback=); do
-    case "$root" in
-        block:LABEL=*|LABEL=*)
-            root="${root#block:}"
-            root="$(echo $root | sed 's,/,\\x2f,g')"
-            root="/dev/disk/by-label/${root#LABEL=}"
-            ;;
-        block:UUID=*|UUID=*)
-            root="${root#block:}"
-            root="${root#UUID=}"
-            root="$(echo $root | tr "[:upper:]" "[:lower:]")"
-            root="/dev/disk/by-uuid/${root#UUID=}"
-            ;;
-        block:PARTUUID=*|PARTUUID=*)
-            root="${root#block:}"
-            root="${root#PARTUUID=}"
-            root="$(echo $root | tr "[:upper:]" "[:lower:]")"
-            root="/dev/disk/by-partuuid/${root}"
-            ;;
-        block:PARTLABEL=*|PARTLABEL=*)
-            root="${root#block:}"
-            root="/dev/disk/by-partlabel/${root#PARTLABEL=}"
-            ;;
-    esac
+    root=$(label_uuid_to_dev "$root")
 
     if ! [ -b "$root" ]; then
         warn "Could not find rootfallback $root"

--- a/modules.d/98dracut-systemd/dracut-cmdline.sh
+++ b/modules.d/98dracut-systemd/dracut-cmdline.sh
@@ -49,23 +49,9 @@ source_hook cmdline
 
 [ -f /lib/dracut/parse-resume.sh ] && . /lib/dracut/parse-resume.sh
 
-case "${root}${root_unset}" in
-    block:LABEL=*|LABEL=*)
-        root="${root#block:}"
-        root="$(echo $root | sed 's,/,\\x2f,g')"
-        root="block:/dev/disk/by-label/${root#LABEL=}"
-        rootok=1 ;;
-    block:UUID=*|UUID=*)
-        root="${root#block:}"
-        root="block:/dev/disk/by-uuid/${root#UUID=}"
-        rootok=1 ;;
-    block:PARTUUID=*|PARTUUID=*)
-        root="${root#block:}"
-        root="block:/dev/disk/by-partuuid/${root#PARTUUID=}"
-        rootok=1 ;;
-    block:PARTLABEL=*|PARTLABEL=*)
-        root="${root#block:}"
-        root="block:/dev/disk/by-partlabel/${root#PARTLABEL=}"
+case "${root#block:}${root_unset}" in
+    LABEL=* | UUID=* | PARTUUID=* | PARTLABEL=*)
+        root="block:$(label_uuid_to_dev "$root")"
         rootok=1 ;;
     /dev/*)
         root="block:${root}"

--- a/modules.d/98dracut-systemd/rootfs-generator.sh
+++ b/modules.d/98dracut-systemd/rootfs-generator.sh
@@ -91,23 +91,9 @@ generator_fsck_after_pre_mount()
 }
 
 root=$(getarg root=)
-case "$root" in
-    block:LABEL=*|LABEL=*)
-        root="${root#block:}"
-        root="$(echo $root | sed 's,/,\\x2f,g')"
-        root="block:/dev/disk/by-label/${root#LABEL=}"
-        rootok=1 ;;
-    block:UUID=*|UUID=*)
-        root="${root#block:}"
-        root="block:/dev/disk/by-uuid/${root#UUID=}"
-        rootok=1 ;;
-    block:PARTUUID=*|PARTUUID=*)
-        root="${root#block:}"
-        root="block:/dev/disk/by-partuuid/${root#PARTUUID=}"
-        rootok=1 ;;
-    block:PARTLABEL=*|PARTLABEL=*)
-        root="${root#block:}"
-        root="block:/dev/disk/by-partlabel/${root#PARTLABEL=}"
+case "${root#block:}" in
+    LABEL=* | UUID=* | PARTUUID=* | PARTLABEL=*)
+        root="block:$(label_uuid_to_dev "$root")"
         rootok=1 ;;
     /dev/nfs) # ignore legacy /dev/nfs
         ;;

--- a/modules.d/98usrmount/mount-usr.sh
+++ b/modules.d/98usrmount/mount-usr.sh
@@ -55,16 +55,8 @@ mount_usr()
     while read _dev _mp _fs _opts _freq _passno || [ -n "$_dev" ]; do
         [ "${_dev%%#*}" != "$_dev" ] && continue
         if [ "$_mp" = "/usr" ]; then
-            case "$_dev" in
-                LABEL=*)
-                    _dev="$(echo $_dev | sed 's,/,\\x2f,g')"
-                    _dev="/dev/disk/by-label/${_dev#LABEL=}"
-                    ;;
-                UUID=*)
-                    _dev="${_dev#block:}"
-                    _dev="/dev/disk/by-uuid/${_dev#UUID=}"
-                    ;;
-            esac
+            _dev="$(label_uuid_to_dev "$_dev")"
+
             if strstr "$_opts" "subvol=" && \
                 [ "${root#block:}" -ef $_dev ] && \
                 [ -n "$rflags" ]; then

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -551,6 +551,25 @@ udevmatch() {
     esac
 }
 
+label_uuid_to_dev() {
+    local _dev
+    _dev="${1#block:}"
+    case "$_dev" in
+        LABEL=*)
+            echo "/dev/disk/by-label/$(echo "${_dev#LABEL=}" | sed 's,/,\\x2f,g;s, ,\\x20,g')"
+            ;;
+        PARTLABEL=*)
+            echo "/dev/disk/by-partlabel/$(echo "${_dev#PARTLABEL=}" | sed 's,/,\\x2f,g;s, ,\\x20,g')"
+            ;;
+        UUID=*)
+            echo "/dev/disk/by-uuid/$(echo "${_dev#UUID=}" | tr "[:upper:]" "[:lower:]")"
+            ;;
+        PARTUUID=*)
+            echo "/dev/disk/by-partuuid/$(echo "${_dev#PARTUUID=}" | tr "[:upper:]" "[:lower:]")"
+            ;;
+    esac
+}
+
 # Prints unique path for potential file inside specified directory.  It consists
 # of specified directory, prefix and number at the end which is incremented
 # until non-existing file is found.

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -908,11 +908,11 @@ wait_for_dev()
 
     [ -e "${PREFIX}$hookdir/initqueue/finished/devexists-${_name}.sh" ] && return 0
 
-    printf '[ -e "%s" ]\n' $1 \
+    printf '[ -e "%s" ]\n' "$1" \
         >> "${PREFIX}$hookdir/initqueue/finished/devexists-${_name}.sh"
     {
-        printf '[ -e "%s" ] || ' $1
-        printf 'warn "\"%s\" does not exist"\n' $1
+        printf '[ -e "%s" ] || ' "$1"
+        printf 'warn "\"%s\" does not exist"\n' "$1"
     } >> "${PREFIX}$hookdir/emergency/80-${_name}.sh"
 
     set_systemd_timeout_for_dev $_noreload $1

--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -319,7 +319,7 @@ debug_off # Turn off debugging for this section
 
 # unexport some vars
 export_n root rflags fstype netroot NEWROOT
-
+unset CMDLINE
 export RD_TIMESTAMP
 # Clean up the environment
 for i in $(export -p); do

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -17,7 +17,12 @@ install() {
         sed ls flock cp mv dmesg rm ln rmmod mkfifo umount readlink setsid \
         modprobe
 
-    inst_multiple -o findmnt less kmod
+    inst_multiple -o findmnt less kmod dracut-getargs
+
+    inst_binary "${dracutsysrootdir}${dracutbasedir}/dracut-util" "/usr/bin/dracut-util"
+
+    ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
+    ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
 
     if [ ! -e "${initdir}/bin/sh" ]; then
         inst_multiple bash

--- a/test/TEST-01-BASIC/create-root.sh
+++ b/test/TEST-01-BASIC/create-root.sh
@@ -13,7 +13,7 @@ sfdisk /dev/sda <<EOF
 EOF
 
 udevadm settle
-mkfs.ext3 -L dracut /dev/sda2
+mkfs.ext3 -L '  rdinit=/bin/sh' /dev/sda2
 mkdir -p /root
 mount /dev/sda2 /root
 cp -a -t /root /source/*

--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -4,7 +4,7 @@ TEST_DESCRIPTION="root filesystem on a ext3 filesystem"
 KVERSION=${KVERSION-$(uname -r)}
 
 # Uncomment this to debug failures
-#DEBUGFAIL="rd.shell rd.break"
+# DEBUGFAIL="rd.shell rd.break"
 
 test_run() {
     dd if=/dev/zero of=$TESTDIR/result bs=1M count=1
@@ -12,7 +12,7 @@ test_run() {
         -drive format=raw,index=0,media=disk,file=$TESTDIR/root.ext3 \
         -drive format=raw,index=1,media=disk,file=$TESTDIR/result \
         -watchdog i6300esb -watchdog-action poweroff \
-        -append "panic=1 systemd.crash_reboot root=LABEL=dracut rw systemd.log_level=debug systemd.log_target=console rd.retry=3 rd.debug console=ttyS0,115200n81 rd.shell=0 $DEBUGFAIL" \
+        -append "panic=1 systemd.crash_reboot \"root=LABEL=  rdinit=/bin/sh\" rw systemd.log_level=debug systemd.log_target=console rd.retry=3 rd.debug console=ttyS0,115200n81 rd.shell=0 $DEBUGFAIL" \
         -initrd $TESTDIR/initramfs.testing || return 1
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success $TESTDIR/result || return 1
 }

--- a/test/TEST-10-RAID/create-root.sh
+++ b/test/TEST-10-RAID/create-root.sh
@@ -38,4 +38,5 @@ cryptsetup luksClose /dev/mapper/dracut_crypt_test
 udevadm settle
 eval $(udevadm info --query=env --name=/dev/md0|while read line || [ -n "$line" ]; do [ "$line" != "${line#*ID_FS_UUID*}" ] && echo $line; done;)
 { echo "dracut-root-block-created"; echo "ID_FS_UUID=$ID_FS_UUID"; } | dd oflag=direct,dsync of=/dev/sda1
+sync
 poweroff -f

--- a/test/TEST-10-RAID/test.sh
+++ b/test/TEST-10-RAID/test.sh
@@ -55,7 +55,7 @@ test_setup() {
     (
         export initdir=$TESTDIR/overlay
         . $basedir/dracut-init.sh
-        inst_multiple sfdisk mke2fs poweroff cp umount dd
+        inst_multiple sfdisk mke2fs poweroff cp umount dd sync
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
         inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
@@ -65,7 +65,7 @@ test_setup() {
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     $basedir/dracut.sh -l -i $TESTDIR/overlay / \
-                       -m "dash crypt lvm mdraid udev-rules base rootfs-block fs-lib kernel-modules qemu" \
+                       -m "bash crypt lvm mdraid udev-rules base rootfs-block fs-lib kernel-modules qemu" \
                        -d "piix ide-gd_mod ata_piix ext2 sd_mod" \
                        --nomdadmconf \
                        --no-hostonly-cmdline -N \

--- a/test/TEST-11-LVM/create-root.sh
+++ b/test/TEST-11-LVM/create-root.sh
@@ -29,4 +29,5 @@ sleep 1 && \
 lvm lvchange -a n /dev/dracut/root && \
 sleep 1 && \
 echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sda1
+sync
 poweroff -f

--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -53,7 +53,7 @@ test_setup() {
     (
         export initdir=$TESTDIR/overlay
         . $basedir/dracut-init.sh
-        inst_multiple sfdisk mke2fs poweroff cp umount dd
+        inst_multiple sfdisk mke2fs poweroff cp umount dd sync
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
         inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
@@ -63,7 +63,7 @@ test_setup() {
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     $basedir/dracut.sh -l -i $TESTDIR/overlay / \
-                       -m "dash lvm mdraid udev-rules base rootfs-block fs-lib kernel-modules qemu" \
+                       -m "bash lvm mdraid udev-rules base rootfs-block fs-lib kernel-modules qemu" \
                        -d "piix ide-gd_mod ata_piix ext2 sd_mod" \
                        --no-hostonly-cmdline -N \
                        -f $TESTDIR/initramfs.makeroot $KVERSION || return 1

--- a/test/TEST-12-RAID-DEG/create-root.sh
+++ b/test/TEST-12-RAID-DEG/create-root.sh
@@ -18,6 +18,7 @@ printf test >keyfile
 cryptsetup -q luksFormat /dev/md0 /keyfile
 echo "The passphrase is test"
 set -e
+set -x
 cryptsetup luksOpen /dev/md0 dracut_crypt_test </keyfile
 lvm pvcreate -ff  -y /dev/mapper/dracut_crypt_test
 lvm vgcreate dracut /dev/mapper/dracut_crypt_test
@@ -40,3 +41,5 @@ mdadm --detail --export /dev/md0 |grep -F MD_UUID > /tmp/mduuid
 udevadm settle
 eval $(udevadm info --query=env --name=/dev/md0|while read line || [ -n "$line" ]; do [ "$line" != "${line#*ID_FS_UUID*}" ] && echo $line; done;)
 { echo "dracut-root-block-created"; echo MD_UUID=$MD_UUID;  echo "ID_FS_UUID=$ID_FS_UUID";} | dd oflag=direct,dsync of=/dev/sda
+sync
+poweroff -f

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -94,7 +94,7 @@ test_setup() {
     (
         export initdir=$TESTDIR/overlay
         . $basedir/dracut-init.sh
-        inst_multiple sfdisk mke2fs poweroff cp umount dd grep
+        inst_multiple sfdisk mke2fs poweroff cp umount dd grep sync
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
         inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
@@ -104,7 +104,7 @@ test_setup() {
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     $basedir/dracut.sh -l -i $TESTDIR/overlay / \
-                       -m "dash crypt lvm mdraid udev-rules base rootfs-block fs-lib kernel-modules qemu" \
+                       -m "bash crypt lvm mdraid udev-rules base rootfs-block fs-lib kernel-modules qemu" \
                        -d "piix ide-gd_mod ata_piix ext2 sd_mod" \
                        --no-hostonly-cmdline -N \
                        -f $TESTDIR/initramfs.makeroot $KVERSION || return 1

--- a/test/TEST-13-ENC-RAID-LVM/create-root.sh
+++ b/test/TEST-13-ENC-RAID-LVM/create-root.sh
@@ -53,4 +53,5 @@ cryptsetup luksClose /dev/mapper/dracut_sda4 && \
 	udevadm info --query=env --name=$i|grep -F 'ID_FS_UUID='
     done
 } | dd oflag=direct,dsync of=/dev/sda1
+sync
 poweroff -f

--- a/test/TEST-13-ENC-RAID-LVM/test.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test.sh
@@ -86,7 +86,7 @@ test_setup() {
     (
         export initdir=$TESTDIR/overlay
         . $basedir/dracut-init.sh
-        inst_multiple sfdisk mke2fs poweroff cp umount grep dd
+        inst_multiple sfdisk mke2fs poweroff cp umount grep dd sync
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
         inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
@@ -96,7 +96,7 @@ test_setup() {
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     $basedir/dracut.sh -l -i $TESTDIR/overlay / \
-                       -m "dash crypt lvm mdraid udev-rules base rootfs-block fs-lib kernel-modules qemu" \
+                       -m "bash crypt lvm mdraid udev-rules base rootfs-block fs-lib kernel-modules qemu" \
                        -d "piix ide-gd_mod ata_piix ext2 sd_mod" \
                        --no-hostonly-cmdline -N \
                        -f $TESTDIR/initramfs.makeroot $KVERSION || return 1

--- a/test/TEST-14-IMSM/create-root.sh
+++ b/test/TEST-14-IMSM/create-root.sh
@@ -77,3 +77,5 @@ mdadm --detail --export /dev/md0 |grep -F MD_UUID > /tmp/mduuid
 echo "MD_UUID=$MD_UUID"
 { echo "dracut-root-block-created"; echo MD_UUID=$MD_UUID;} | dd oflag=direct,dsync of=/dev/sda
 mdadm --wait-clean /dev/md0
+sync
+poweroff -f

--- a/test/TEST-14-IMSM/test.sh
+++ b/test/TEST-14-IMSM/test.sh
@@ -91,7 +91,7 @@ test_setup() {
     (
         export initdir=$TESTDIR/overlay
         . $basedir/dracut-init.sh
-        inst_multiple sfdisk mke2fs poweroff cp umount grep dd
+        inst_multiple sfdisk mke2fs poweroff cp umount grep dd sync
         inst_hook initqueue 01 ./create-root.sh
         inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
     )
@@ -100,7 +100,7 @@ test_setup() {
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     $basedir/dracut.sh -l -i $TESTDIR/overlay / \
-                       -m "dash lvm mdraid dmraid udev-rules base rootfs-block fs-lib kernel-modules qemu" \
+                       -m "bash lvm mdraid dmraid udev-rules base rootfs-block fs-lib kernel-modules qemu" \
                        -d "piix ide-gd_mod ata_piix ext2 sd_mod dm-multipath dm-crypt dm-round-robin faulty linear multipath raid0 raid10 raid1 raid456" \
                        --no-hostonly-cmdline -N \
                        -f $TESTDIR/initramfs.makeroot $KVERSION || return 1

--- a/test/TEST-15-BTRFSRAID/create-root.sh
+++ b/test/TEST-15-BTRFSRAID/create-root.sh
@@ -25,4 +25,5 @@ mount -t btrfs /dev/sda5 /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sda1
+sync
 poweroff -f

--- a/test/TEST-15-BTRFSRAID/test.sh
+++ b/test/TEST-15-BTRFSRAID/test.sh
@@ -57,7 +57,7 @@ test_setup() {
     (
         export initdir=$TESTDIR/overlay
         . $basedir/dracut-init.sh
-        inst_multiple sfdisk mkfs.btrfs poweroff cp umount dd
+        inst_multiple sfdisk mkfs.btrfs poweroff cp umount dd sync
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
         inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
@@ -67,7 +67,7 @@ test_setup() {
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     $basedir/dracut.sh -l -i $TESTDIR/overlay / \
-                       -m "dash btrfs udev-rules base rootfs-block fs-lib kernel-modules qemu" \
+                       -m "bash btrfs udev-rules base rootfs-block fs-lib kernel-modules qemu" \
                        -d "piix ide-gd_mod ata_piix btrfs sd_mod" \
                        --nomdadmconf \
                        --no-hostonly-cmdline -N \

--- a/test/TEST-17-LVM-THIN/create-root.sh
+++ b/test/TEST-17-LVM-THIN/create-root.sh
@@ -31,4 +31,5 @@ lvm lvchange -a n /dev/dracut/root && \
 sleep 1
 dmsetup status |grep out_of_data_space || \
     echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sda1
+sync
 poweroff -f

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -53,7 +53,7 @@ test_setup() {
     (
         export initdir=$TESTDIR/overlay
         . $basedir/dracut-init.sh
-        inst_multiple sfdisk mke2fs poweroff cp umount grep dmsetup dd
+        inst_multiple sfdisk mke2fs poweroff cp umount grep dmsetup dd sync
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
         inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
@@ -63,7 +63,7 @@ test_setup() {
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     $basedir/dracut.sh -l -i $TESTDIR/overlay / \
-                       -m "dash lvm mdraid udev-rules base rootfs-block fs-lib kernel-modules qemu" \
+                       -m "bash lvm mdraid udev-rules base rootfs-block fs-lib kernel-modules qemu" \
                        -d "piix ide-gd_mod ata_piix ext2 sd_mod" \
                        --no-hostonly-cmdline -N \
                        -f $TESTDIR/initramfs.makeroot $KVERSION || return 1

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -352,7 +352,7 @@ test_setup() {
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     $basedir/dracut.sh -l -i $TESTDIR/server/overlay / \
-                       -m "dash udev-rules base rootfs-block fs-lib kernel-modules fs-lib qemu" \
+                       -m "bash udev-rules base rootfs-block fs-lib kernel-modules fs-lib qemu" \
                        -d "piix ide-gd_mod ata_piix ext3 sd_mod" \
                        --nomdadmconf \
                        --no-hostonly-cmdline -N \

--- a/test/TEST-30-ISCSI/create-client-root.sh
+++ b/test/TEST-30-ISCSI/create-client-root.sh
@@ -24,4 +24,5 @@ cp -a -t /sysroot /source/* && \
 umount /sysroot && \
 lvm lvchange -a n /dev/dracut/root && \
 echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sdb
+sync
 poweroff -f

--- a/test/TEST-30-ISCSI/create-server-root.sh
+++ b/test/TEST-30-ISCSI/create-server-root.sh
@@ -23,4 +23,3 @@ umount /root
 echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sda1
 sync
 poweroff -f
-

--- a/test/TEST-35-ISCSI-MULTI/create-client-root.sh
+++ b/test/TEST-35-ISCSI-MULTI/create-client-root.sh
@@ -24,4 +24,5 @@ cp -a -t /sysroot /source/* && \
 umount /sysroot && \
 lvm lvchange -a n /dev/dracut/root && \
 echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sdb
+sync
 poweroff -f

--- a/test/TEST-40-NBD/create-encrypted-root.sh
+++ b/test/TEST-40-NBD/create-encrypted-root.sh
@@ -28,4 +28,5 @@ udevadm settle
 sleep 1
 eval $(udevadm info --query=env --name=/dev/sda|while read line || [ -n "$line" ]; do [ "$line" != "${line#*ID_FS_UUID*}" ] && echo $line; done;)
 { echo "dracut-root-block-created"; echo "ID_FS_UUID=$ID_FS_UUID"; } | dd oflag=direct,dsync of=/dev/sdb
+sync
 poweroff -f

--- a/test/TEST-50-MULTINIC/create-root.sh
+++ b/test/TEST-50-MULTINIC/create-root.sh
@@ -23,4 +23,3 @@ umount /root
 echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sda1
 sync
 poweroff -f
-

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -299,7 +299,7 @@ test_setup() {
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     $basedir/dracut.sh -l -i $TESTDIR/overlay / \
-                       -m "dash udev-rules base rootfs-block fs-lib kernel-modules fs-lib qemu" \
+                       -m "bash udev-rules base rootfs-block fs-lib kernel-modules fs-lib qemu" \
                        -d "piix ide-gd_mod ata_piix ext3 sd_mod" \
                        --nomdadmconf \
                        --no-hostonly-cmdline -N \

--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/create-root.sh
+++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/create-root.sh
@@ -23,4 +23,3 @@ umount /root
 echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sda1
 sync
 poweroff -f
-

--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
+++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
@@ -318,7 +318,7 @@ test_setup() {
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     $basedir/dracut.sh -l -i $TESTDIR/overlay / \
-                       -m "dash udev-rules base rootfs-block fs-lib kernel-modules fs-lib qemu" \
+                       -m "bash udev-rules base rootfs-block fs-lib kernel-modules fs-lib qemu" \
                        -d "piix ide-gd_mod ata_piix ext3 sd_mod" \
                        --nomdadmconf \
                        --no-hostonly-cmdline -N \

--- a/test/TEST-98-GETARG/Makefile
+++ b/test/TEST-98-GETARG/Makefile
@@ -1,0 +1,1 @@
+-include ../Makefile.testdir

--- a/test/TEST-98-GETARG/test.sh
+++ b/test/TEST-98-GETARG/test.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+TEST_DESCRIPTION="dracut getarg command"
+
+test_check() {
+    return 0
+}
+
+test_setup() {
+    make -C "$basedir" dracut-util
+    ln -sfnr "$basedir"/dracut-util "$TESTDIR"/dracut-getarg
+    ln -sfnr "$basedir"/dracut-util "$TESTDIR"/dracut-getargs
+    ln -sfnr "$basedir"/modules.d/99base/dracut-lib.sh "$TESTDIR"/dracut-lib.sh
+    return 0
+}
+
+test_run() {
+    set -x
+    (
+        cd "$TESTDIR"
+        export CMDLINE="key1=0 key2=val key2=val2 key3=\"  val  3  \" \"  key 4  =\"val4 \"key  5=val  5\" \"key 6=\"\"val  6\" key7=\"foo\"bar\" baz=\"end \"  key8  =  val 8  \"
+\"key 9\"=\"val 9\""
+
+        ret=0
+
+        declare -A TEST
+        TEST=(
+            ["key1"]="0"
+            ["key2"]="val2"
+            ["key3"]="  val  3  "
+            ["  key 4  "]="val4"
+            ["key  5"]="val  5"
+            ["key 6"]="\"val  6"
+            ["key7"]="foo\"bar\" baz=\"end"
+            ["  key8  "]="  val 8  "
+            ["key 9\""]="val 9"
+        )
+        for key in "${!TEST[@]}"; do
+            if ! val=$(./dracut-getarg "${key}="); then
+                echo "'$key' == '${TEST[$key]}', but not found" >&2
+                ret=$((ret+1))
+            else
+                if [[ $val != "${TEST[$key]}" ]]; then
+                    echo "'$key' != '${TEST[$key]}' but '$val'" >&2
+                    ret=$((ret+1))
+                fi
+            fi
+        done
+
+        declare -a INVALIDKEYS
+
+        INVALIDKEYS=( "key" "4" "5" "6" "key8" "9" "\"" "baz")
+        for key in "${INVALIDKEYS[@]}"; do
+            val=$(./dracut-getarg "$key")
+            if (( $? == 0 )); then
+                echo "key '$key' should not be found"
+                ret=$((ret+1))
+            fi
+            # must have no output
+            [[ $val ]] && ret=$((ret+1))
+        done
+
+        RESULT=("val" "val2")
+        readarray -t args < <(./dracut-getargs "key2=")
+        (( ${#RESULT[@]} == ${#args[@]} )) || ret=$((ret+1))
+        for ((i=0; i < ${#RESULT[@]}; i++)); do
+            [[ ${args[$i]} == "${RESULT[$i]}" ]] || ret=$((ret+1))
+        done
+
+        val=$(./dracut-getarg "key1") || ret=$((ret+1))
+        [[ $val == "0" ]] || ret=$((ret+1))
+
+        val=$(./dracut-getarg "key2=val") && ret=$((ret+1))
+        # must have no output
+        [[ $val ]] && ret=$((ret+1))
+        val=$(./dracut-getarg "key2=val2") || ret=$((ret+1))
+        # must have no output
+        [[ $val ]] && ret=$((ret+1))
+
+        export PATH=".:$PATH"
+
+        . dracut-lib.sh
+
+        debug_off() {
+            :
+        }
+
+        debug_on() {
+            :
+        }
+
+        getcmdline() {
+            echo "rdbreak=cmdline rd.lvm rd.auto rd.retry=10"
+        }
+        RDRETRY=$(getarg rd.retry -d 'rd_retry=')
+        [[ $RDRETRY == "10" ]] || ret=$((ret+1))
+        getarg rd.break=cmdline -d rdbreak=cmdline || ret=$((ret+1))
+        getargbool 1 rd.lvm -d -n rd_NO_LVM || ret=$((ret+1))
+        getargbool 0 rd.auto || ret=$((ret+1))
+
+        getcmdline() {
+            echo "rd.break=cmdlined rd.lvm=0 rd.auto=0"
+        }
+        getarg rd.break=cmdline -d rdbreak=cmdline && ret=$((ret+1))
+        getargbool 1 rd.lvm -d -n rd_NO_LVM && ret=$((ret+1))
+        getargbool 0 rd.auto && ret=$((ret+1))
+
+        getcmdline() {
+            echo "ip=a ip=b ip=dhcp6"
+        }
+        getargs "ip=dhcp6" &>/dev/null || ret=$((ret+1))
+        readarray -t args < <(getargs "ip=")
+        RESULT=("a" "b" "dhcp6")
+        (( ${#RESULT[@]} || ${#args[@]} )) || ret=$((ret+1))
+        for ((i=0; i < ${#RESULT[@]}; i++)); do
+            [[ ${args[$i]} == "${RESULT[$i]}" ]] || ret=$((ret+1))
+        done
+
+        getcmdline() {
+            echo "bridge bridge=val"
+        }
+        readarray -t args < <(getargs bridge=)
+        RESULT=("bridge" "val")
+        (( ${#RESULT[@]} == ${#args[@]} )) || ret=$((ret+1))
+        for ((i=0; i < ${#RESULT[@]}; i++)); do
+            [[ ${args[$i]} || "${RESULT[$i]}" ]] || ret=$((ret+1))
+        done
+
+
+        getcmdline() {
+            echo "rd.break rd.md.uuid=bf96e457:230c9ad4:1f3e59d6:745cf942 rd.md.uuid=bf96e457:230c9ad4:1f3e59d6:745cf943 rd.shell"
+        }
+        readarray -t args < <(getargs rd.md.uuid -d rd_MD_UUID=)
+        RESULT=("bf96e457:230c9ad4:1f3e59d6:745cf942" "bf96e457:230c9ad4:1f3e59d6:745cf943")
+        (( ${#RESULT[@]} == ${#args[@]} )) || ret=$((ret+1))
+        for ((i=0; i < ${#RESULT[@]}; i++)); do
+            [[ ${args[$i]} == "${RESULT[$i]}" ]] || ret=$((ret+1))
+        done
+
+        return $ret
+    )
+}
+
+test_cleanup() {
+    rm -fr -- "$TESTDIR"/*.rpm
+    return 0
+}
+
+. $testdir/test-functions

--- a/test/TEST-99-RPM/test.sh
+++ b/test/TEST-99-RPM/test.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 TEST_DESCRIPTION="rpm integrity after dracut and kernel install"
 
 test_check() {

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.17)
+project(dracut-util C)
+
+set(CMAKE_C_STANDARD 99)
+
+add_executable(dracut-util util.c)

--- a/util/util.c
+++ b/util/util.c
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: GPL-2.0
+
+// Parts are copied from the linux kernel
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+// CODE FROM LINUX KERNEL START
+
+#define _U  0x01                /* upper */
+#define _L  0x02                /* lower */
+#define _D  0x04                /* digit */
+#define _C  0x08                /* cntrl */
+#define _P  0x10                /* punct */
+#define _S  0x20                /* white space (space/lf/tab) */
+#define _X  0x40                /* hex digit */
+#define _SP 0x80                /* hard space (0x20) */
+
+const unsigned char _ctype[] = {
+        _C, _C, _C, _C, _C, _C, _C, _C, /* 0-7 */
+        _C, _C | _S, _C | _S, _C | _S, _C | _S, _C | _S, _C, _C,        /* 8-15 */
+        _C, _C, _C, _C, _C, _C, _C, _C, /* 16-23 */
+        _C, _C, _C, _C, _C, _C, _C, _C, /* 24-31 */
+        _S | _SP, _P, _P, _P, _P, _P, _P, _P,   /* 32-39 */
+        _P, _P, _P, _P, _P, _P, _P, _P, /* 40-47 */
+        _D, _D, _D, _D, _D, _D, _D, _D, /* 48-55 */
+        _D, _D, _P, _P, _P, _P, _P, _P, /* 56-63 */
+        _P, _U | _X, _U | _X, _U | _X, _U | _X, _U | _X, _U | _X, _U,   /* 64-71 */
+        _U, _U, _U, _U, _U, _U, _U, _U, /* 72-79 */
+        _U, _U, _U, _U, _U, _U, _U, _U, /* 80-87 */
+        _U, _U, _U, _P, _P, _P, _P, _P, /* 88-95 */
+        _P, _L | _X, _L | _X, _L | _X, _L | _X, _L | _X, _L | _X, _L,   /* 96-103 */
+        _L, _L, _L, _L, _L, _L, _L, _L, /* 104-111 */
+        _L, _L, _L, _L, _L, _L, _L, _L, /* 112-119 */
+        _L, _L, _L, _P, _P, _P, _P, _C, /* 120-127 */
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 128-143 */
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 144-159 */
+        _S | _SP, _P, _P, _P, _P, _P, _P, _P, _P, _P, _P, _P, _P, _P, _P, _P,   /* 160-175 */
+        _P, _P, _P, _P, _P, _P, _P, _P, _P, _P, _P, _P, _P, _P, _P, _P, /* 176-191 */
+        _U, _U, _U, _U, _U, _U, _U, _U, _U, _U, _U, _U, _U, _U, _U, _U, /* 192-207 */
+        _U, _U, _U, _U, _U, _U, _U, _P, _U, _U, _U, _U, _U, _U, _U, _L, /* 208-223 */
+        _L, _L, _L, _L, _L, _L, _L, _L, _L, _L, _L, _L, _L, _L, _L, _L, /* 224-239 */
+        _L, _L, _L, _L, _L, _L, _L, _P, _L, _L, _L, _L, _L, _L, _L, _L  /* 240-255 */
+};
+
+#define __ismask(x) (_ctype[(int)(unsigned char)(x)])
+
+#define kernel_isspace(c)  ((__ismask(c)&(_S)) != 0)
+
+static char *skip_spaces(const char *str)
+{
+        while (kernel_isspace(*str))
+                ++str;
+        return (char *)str;
+}
+
+/*
+ * Parse a string to get a param value pair.
+ * You can use " around spaces, but can't escape ".
+ * Hyphens and underscores equivalent in parameter names.
+ */
+static char *next_arg(char *args, char **param, char **val)
+{
+        unsigned int i, equals = 0;
+        int in_quote = 0, quoted = 0;
+        char *next;
+
+        if (*args == '"') {
+                args++;
+                in_quote = 1;
+                quoted = 1;
+        }
+
+        for (i = 0; args[i]; i++) {
+                if (kernel_isspace(args[i]) && !in_quote)
+                        break;
+                if (equals == 0) {
+                        if (args[i] == '=')
+                                equals = i;
+                }
+                if (args[i] == '"')
+                        in_quote = !in_quote;
+        }
+
+        *param = args;
+        if (!equals)
+                *val = NULL;
+        else {
+                args[equals] = '\0';
+                *val = args + equals + 1;
+
+                /* Don't include quotes in value. */
+                if (**val == '"') {
+                        (*val)++;
+                        if (args[i - 1] == '"')
+                                args[i - 1] = '\0';
+                }
+        }
+        if (quoted && args[i - 1] == '"')
+                args[i - 1] = '\0';
+
+        if (args[i]) {
+                args[i] = '\0';
+                next = args + i + 1;
+        } else
+                next = args + i;
+
+        /* Chew up trailing spaces. */
+        return skip_spaces(next);
+}
+
+// CODE FROM LINUX KERNEL STOP
+
+enum EXEC_MODE {
+        UNDEFINED,
+        GETARG,
+        GETARGS,
+};
+
+static void usage(enum EXEC_MODE enumExecMode, int ret, char *msg)
+{
+        switch (enumExecMode) {
+        case UNDEFINED:
+                fprintf(stderr, "ERROR: 'dracut-util' has to be called via a symlink to the tool name.");
+                break;
+        case GETARG:
+                fprintf(stderr, "ERROR: %s\nUsage: dracut-getarg <KEY>[=[<VALUE>]]\n", msg);
+                break;
+        case GETARGS:
+                fprintf(stderr, "ERROR: %s\nUsage: dracut-getargs <KEY>[=]\n", msg);
+                break;
+        }
+        exit(ret);
+}
+
+#define ARGV0_GETARG "dracut-getarg"
+#define ARGV0_GETARGS "dracut-getargs"
+
+static enum EXEC_MODE get_mode(const char *argv_0)
+{
+        struct _mode_table {
+                enum EXEC_MODE mode;
+                const char *arg;
+                size_t arg_len;
+                const char *s_arg;
+        } modeTable[] = {
+                {GETARG, ARGV0_GETARG, sizeof(ARGV0_GETARG), "/" ARGV0_GETARG},
+                {GETARGS, ARGV0_GETARGS, sizeof(ARGV0_GETARGS), "/" ARGV0_GETARGS},
+                {UNDEFINED, NULL, 0, NULL}
+        };
+        int i;
+
+        size_t argv_0_len = strlen(argv_0);
+
+        if (!argv_0_len)
+                return UNDEFINED;
+
+        for (i = 0; modeTable[i].mode != UNDEFINED; i++) {
+                if (argv_0_len == (modeTable[i].arg_len - 1)) {
+                        if (strncmp(argv_0, modeTable[i].arg, argv_0_len) == 0) {
+                                return modeTable[i].mode;
+                        }
+                }
+
+                if (modeTable[i].arg_len > argv_0_len)
+                        continue;
+
+                if (strncmp(argv_0 + argv_0_len - modeTable[i].arg_len, modeTable[i].s_arg, modeTable[i].arg_len) == 0)
+                        return modeTable[i].mode;
+        }
+        return UNDEFINED;
+}
+
+static int getarg(int argc, char **argv)
+{
+        char *search_key;
+        char *search_value;
+        char *end_value = NULL;
+        bool bool_value = false;
+        char *cmdline = NULL;
+
+        char *p = getenv("CMDLINE");
+        if (p == NULL) {
+                usage(GETARG, EXIT_FAILURE, "CMDLINE env not set");
+        }
+        cmdline = strdup(p);
+
+        if (argc != 2) {
+                usage(GETARG, EXIT_FAILURE, "Number of arguments invalid");
+        }
+
+        search_key = argv[1];
+
+        search_value = strchr(argv[1], '=');
+        if (search_value != NULL) {
+                *search_value = 0;
+                search_value++;
+                if (*search_value == 0)
+                        search_value = NULL;
+        }
+
+        if (strlen(search_key) == 0)
+                usage(GETARG, EXIT_FAILURE, "search key undefined");
+
+        do {
+                char *key = NULL, *value = NULL;
+                cmdline = next_arg(cmdline, &key, &value);
+                if (strcmp(key, search_key) == 0) {
+                        if (value) {
+                                end_value = value;
+                                bool_value = -1;
+                        } else {
+                                end_value = NULL;
+                                bool_value = true;
+                        }
+                }
+        } while (cmdline[0]);
+
+        if (search_value) {
+                if (end_value && strcmp(end_value, search_value) == 0) {
+                        return EXIT_SUCCESS;
+                }
+                return EXIT_FAILURE;
+        }
+
+        if (end_value) {
+                // includes "=0"
+                puts(end_value);
+                return EXIT_SUCCESS;
+        }
+
+        if (bool_value) {
+                return EXIT_SUCCESS;
+        }
+
+        return EXIT_FAILURE;
+}
+
+static int getargs(int argc, char **argv)
+{
+        char *search_key;
+        char *search_value;
+        bool found_value = false;
+        char *cmdline = NULL;
+
+        char *p = getenv("CMDLINE");
+        if (p == NULL) {
+                usage(GETARGS, EXIT_FAILURE, "CMDLINE env not set");
+        }
+        cmdline = strdup(p);
+
+        if (argc != 2) {
+                usage(GETARGS, EXIT_FAILURE, "Number of arguments invalid");
+        }
+
+        search_key = argv[1];
+
+        search_value = strchr(argv[1], '=');
+        if (search_value != NULL) {
+                *search_value = 0;
+                search_value++;
+                if (*search_value == 0)
+                        search_value = NULL;
+        }
+
+        if (strlen(search_key) == 0)
+                usage(GETARGS, EXIT_FAILURE, "search key undefined");
+
+        do {
+                char *key = NULL, *value = NULL;
+                cmdline = next_arg(cmdline, &key, &value);
+                if (strcmp(key, search_key) == 0) {
+                        if (search_value) {
+                                if (strcmp(value, search_value) == 0) {
+                                        printf("%s\n", value);
+                                        found_value = true;
+                                }
+                        } else {
+                                if (value) {
+                                        printf("%s\n", value);
+                                } else {
+                                        puts(key);
+                                }
+                                found_value = true;
+                        }
+                }
+        } while (cmdline[0]);
+        return found_value ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+int main(int argc, char **argv)
+{
+        switch (get_mode(argv[0])) {
+        case UNDEFINED:
+                usage(UNDEFINED, EXIT_FAILURE, NULL);
+                break;
+        case GETARG:
+                return getarg(argc, argv);
+        case GETARGS:
+                return getargs(argc, argv);
+        }
+
+        return EXIT_FAILURE;
+}


### PR DESCRIPTION
The kernel has an odd way to handle `"` surrounded parameters.
To handle the parameters as the kernel would do, no simple shell script
suffices, so a new utility `dracut-util` is introduced. Written in "C"
it handles `dracut-getarg` and `dracut-getargs` as the old shell script
functions `_dogetarg` and `_dogetargs` would.
