### PR TITLE
dracut-initramfs-restore: detect Arch Linux initramfs

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -13,6 +13,7 @@ SKIP="$dracutbasedir/skipcpio"
 [[ -x $SKIP ]] || SKIP=cat
 
 [[ -f /etc/machine-id ]] && read MACHINE_ID < /etc/machine-id
+[[ -f "/lib/modules/${KERNEL_VERSION}/pkgbase" ]] && read PKGBASE < "/lib/modules/${KERNEL_VERSION}/pkgbase"
 
 mount -o ro /boot &>/dev/null || true
 
@@ -24,6 +25,8 @@ elif [[ -d /boot/loader/entries || -L /boot/loader/entries ]] \
     && [[ $MACHINE_ID ]] \
     && [[ -d /boot/${MACHINE_ID} || -L /boot/${MACHINE_ID} ]] ; then
     IMG="/boot/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
+elif [[ $PKGBASE ]] && [[ -f "/boot/initramfs-${PKGBASE}.img" ]]; then
+    IMG="/boot/initramfs-${PKGBASE}.img"
 else
     IMG="/boot/initramfs-${KERNEL_VERSION}.img"
 fi


### PR DESCRIPTION
This pull request detects the Arch Linux initramfs for restoration.

## Changes

Arch Linux creates initramfs with the names `initramfs-linux{,-lts,-hardened,-zen-whatevervariant}.img`.

The name of the variant is stored in the file `/usr/lib/modules/$KERNEL_VERSION/pkgbase`:

```
$ cat /usr/lib/modules/*/pkgbase
linux-lts
linux
```

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] ~~I am providing new code and test(s) for it~~