### PR TITLE
ci: add shellcheck

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,12 +28,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run the sh-checker
+      - name: install tools
+        run: |
+          sudo apt-get install shellcheck
+          sudo wget "https://github.com/mvdan/sh/releases/download/v3.2.4/shfmt_v3.2.4_linux_amd64" \
+                    -O /usr/local/bin/shfmt
+          sudo chmod +x /usr/local/bin/shfmt
+
+      - name: shfmt
         uses: luizm/action-sh-checker@v0.1.13
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SHELLCHECK_OPTS: -e SC1004 # exclude some shellcheck warnings.
           SHFMT_OPTS: -s # arguments to shfmt.
         with:
           sh_checker_shellcheck_disable: true
           sh_checker_comment: true
+
+      - name: shellcheck on all marked directories
+        run: while read -r -d '' dir; do shellcheck $(shfmt -f $dir); done < <(find . -name .shchkdir -printf '%h\0')

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,5 +1,19 @@
 # SC2039: In POSIX sh, 'local' is undefined.
+# https://github.com/koalaman/shellcheck/wiki/SC2039
 disable=SC2039
 
 # SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
+# https://github.com/koalaman/shellcheck/wiki/SC2166
 disable=SC2166
+
+# SC2154: Variable is referenced but not assigned
+# https://github.com/koalaman/shellcheck/wiki/SC2154
+disable=SC2154
+
+# SC1091: Not following <file>
+# https://github.com/koalaman/shellcheck/wiki/SC1091
+disable=SC1091
+
+# SC2174: When used with -p, -m only applies to the deepest directory.
+# https://github.com/koalaman/shellcheck/wiki/SC2174
+disable=SC2174


### PR DESCRIPTION
This pull request `shellcheck` to the ci and checks every directory (and subdirs), which contains a `.shchkdir` file.

The `.shchkdir` file solution is temporary, until all of dracut is shellcheck error free and all  `.shchkdir` files will be removed at the end and the `luizm/action-sh-checker` shellcheck and shfmt github action will be used exclusively.