### PR TITLE
fix: Added _libexec_prefix variable to NM module-setup.sh for distros w/o libexec

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1736,6 +1736,11 @@ if ! [[ -d $dracutsysrootdir$tmpfilesdir ]]; then
     [[ -d $dracutsysrootdir/usr/lib/tmpfiles.d ]] && tmpfilesdir=/usr/lib/tmpfiles.d
 fi
 
+[[ -d $dracutsysrootdir$libexecdir ]] \
+    || libexecdir=$(pkg-config libexecdir --variable=libexecdir 2> /dev/null)
+
+[[ -d $dracutsysrootdir$libexecdir ]] || libexecdir=/usr/libexec
+
 export initdir dracutbasedir \
     dracutmodules force_add_dracutmodules add_dracutmodules omit_dracutmodules \
     mods_to_load \
@@ -1752,7 +1757,7 @@ export initdir dracutbasedir \
     systemdutildir systemdutilconfdir systemdcatalog systemdntpunits \
     systemdntpunitsconfdir systemdsystemunitdir systemdsystemconfdir \
     hostonly_cmdline loginstall \
-    tmpfilesdir
+    tmpfilesdir libexecdir
 
 mods_to_load=""
 # check all our modules to see if they should be sourced.

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -31,7 +31,7 @@ install() {
     inst_multiple ip sed grep
 
     inst NetworkManager
-    inst /usr/libexec/nm-initrd-generator
+    inst $libexecdir/nm-initrd-generator
     inst_multiple -o teamd dhclient
     inst_hook cmdline 99 "$moddir/nm-config.sh"
     if dracut_module_included "systemd"; then
@@ -46,7 +46,7 @@ install() {
     inst_simple "$moddir/nm-lib.sh" "/lib/nm-lib.sh"
 
     if [[ -x "$initdir/usr/sbin/dhclient" ]]; then
-        inst /usr/libexec/nm-dhcp-helper
+        inst $libexecdir/nm-dhcp-helper
     elif ! [[ -e "$initdir/etc/machine-id" ]]; then
         # The internal DHCP client silently fails if we
         # have no machine-id

--- a/modules.d/35network-manager/nm-lib.sh
+++ b/modules.d/35network-manager/nm-lib.sh
@@ -4,7 +4,7 @@ type getcmdline > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 nm_generate_connections() {
     rm -f /run/NetworkManager/system-connections/*
-    /usr/libexec/nm-initrd-generator -- $(getcmdline)
+    $libexecdir/nm-initrd-generator -- $(getcmdline)
 
     if getargbool 0 rd.neednet; then
         for i in /usr/lib/NetworkManager/system-connections/* \

--- a/modules.d/35network-wicked/module-setup.sh
+++ b/modules.d/35network-wicked/module-setup.sh
@@ -41,7 +41,7 @@ install() {
     inst_multiple "/etc/dbus-1/system.d/org.opensuse.Network*"
     inst_multiple "/usr/share/wicked/schema/*"
     inst_multiple "/usr/lib/wicked/bin/*"
-    inst_multiple "/usr/libexec/wicked/bin/*"
+    inst_multiple "$libexecdir/wicked/bin/*"
     inst_multiple "/usr/sbin/wicked*"
 
     wicked_units="

--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -19,7 +19,7 @@ depends() {
     if [ -z "$network_handler" ]; then
         if find_binary wicked &> /dev/null; then
             network_handler="network-wicked"
-        elif [[ -x $dracutsysrootdir/usr/libexec/nm-initrd-generator ]]; then
+        elif [[ -x $dracutsysrootdir$libexecdir/nm-initrd-generator ]]; then
             network_handler="network-manager"
         else
             network_handler="network-legacy"

--- a/modules.d/50plymouth/module-setup.sh
+++ b/modules.d/50plymouth/module-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 pkglib_dir() {
-    local _dirs="/usr/lib/plymouth /usr/libexec/plymouth/"
+    local _dirs="/usr/lib/plymouth $libexecdir/plymouth/"
     if find_binary dpkg-architecture &> /dev/null; then
         _dirs+=" /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/plymouth"
     fi

--- a/modules.d/80cms/cmsifup.sh
+++ b/modules.d/80cms/cmsifup.sh
@@ -47,7 +47,7 @@ fi
 IFACES="$IFACES $DEVICE"
 echo "$IFACES" >> /tmp/net.ifaces
 
-if [ -x /usr/libexec/nm-initrd-generator ]; then
+if [ -x $libexecdir/nm-initrd-generator ]; then
     type nm_generate_connections > /dev/null 2>&1 || . /lib/nm-lib.sh
     nm_generate_connections
 else

--- a/modules.d/91crypt-gpg/module-setup.sh
+++ b/modules.d/91crypt-gpg/module-setup.sh
@@ -29,7 +29,7 @@ install() {
     if sc_requested; then
         inst_multiple gpg-agent
         inst_multiple gpg-connect-agent
-        inst_multiple /usr/libexec/scdaemon
+        inst_multiple $libexecdir/scdaemon
         cp "$dracutsysrootdir$(sc_public_key)" "${initdir}/root/"
     fi
 }
@@ -45,8 +45,8 @@ sc_supported() {
     if [[ ${gpgMajor} -gt 2 || ${gpgMajor} -eq 2 && ${gpgMinor} -ge 1 ]] \
         && require_binaries gpg-agent \
         && require_binaries gpg-connect-agent \
-        && require_binaries /usr/libexec/scdaemon \
-        && ($DRACUT_LDD "$dracutsysrootdir"/usr/libexec/scdaemon | grep libusb > /dev/null); then
+        && require_binaries $libexecdir/scdaemon \
+        && ($DRACUT_LDD "$dracutsysrootdir$libexecdir"/scdaemon | grep libusb > /dev/null); then
         return 0
     else
         return 1


### PR DESCRIPTION
Added _libexec_prefix variable to NM module-setup.sh for distros (e.g. Arch Linux) that don't use /usr/libexec

This pull request changes...

## Changes

When added to the initramfs, the network-manager module will miss the nm-dhcp-helper and nm-initrd-generator files on distros such as Arch Linux that install files which would otherwise go into /usr/libexec, to /usr/lib.

This changes module-setup.sh to use /usr/lib if /usr/libexec doesn't exist.

This assumes that if the two NM files can't be found under /usr/libexec, that they'll be under /usr/lib instead, which I think is fair - it works for Arch Linux, at least.

I'm definitely welcome to hear better variable names than "_libexec_prefix".

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1161 