### PR TITLE
[RFC] Add kdump tests to keep dracut change from breaking kexec-tools

### DIFF
--- a/.github/workflows/fedora-33.yml
+++ b/.github/workflows/fedora-33.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: quay.io/haraldh/dracut-fedora:33
-      options: "-v /dev/kvm:/dev/kvm"
+      options: "-v /dev/kvm:/dev/kvm -v/dev:/dev --privileged -v/lib/modules:/lib/modules:ro"
     timeout-minutes: 45
     strategy:
       matrix:
@@ -37,6 +37,7 @@ jobs:
           "36",
           "40",
           "41",
+          "96",
           "98",
         ]
       fail-fast: false

--- a/fedora-test-github.sh
+++ b/fedora-test-github.sh
@@ -23,7 +23,7 @@ if ! [[ $TESTS ]]; then
     [[ -d .git ]] && git fetch --tags && git describe --tags
     make -j "$NCPU" all syncheck rpm logtee
 else
-    if [[ $TESTS == "99" ]]; then
+    if [[ $TESTS == "99" || $TESTS == "96" ]]; then
         [[ -d .git ]] && git fetch --tags && git describe --tags
         make_docs=yes
     else

--- a/fedora-test.sh
+++ b/fedora-test.sh
@@ -14,7 +14,7 @@ NCPU=$(getconf _NPROCESSORS_ONLN)
 if ! [[ $TESTS ]]; then
     make -j$NCPU all syncheck rpm logtee
 else
-    [[ $TESTS == "99" ]] && make_docs=yes || make_docs=no
+    [[ $TESTS == "99" || $TESTS == "96" ]] && make_docs=yes || make_docs=no
     make -j$NCPU enable_documentation=$make_docs all logtee
 
     cd test

--- a/test/TEST-96-KEXEC-TOOLS/Makefile
+++ b/test/TEST-96-KEXEC-TOOLS/Makefile
@@ -1,0 +1,1 @@
+-include ../Makefile.testdir

--- a/test/TEST-96-KEXEC-TOOLS/test.sh
+++ b/test/TEST-96-KEXEC-TOOLS/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+TEST_DESCRIPTION="kexec-tools test"
+
+KVERSION=${KVERSION-$(uname -r)}
+
+KEXEC_TOOLS_SRC="kexec-tools"
+test_run() {
+    # kexec-tools also use TESTDIR variable, recovert it for kexec-tools
+    KEXEC_TOOLS_TESTDIR="$TESTDIR/$KEXEC_TOOLS_SRC/tests"
+    make -C "$KEXEC_TOOLS_TESTDIR" TESTDIR="$KEXEC_TOOLS_TESTDIR" EXTRA_RPMS=$TESTDIR/*.rpm test-run V=$V || return 1
+    return 0
+}
+
+test_setup() {
+    # Buidling dracut rpm requires rpm-build
+    dnf -y rpm-build
+    make -C "$basedir" DESTDIR="$TESTDIR/" rpm V=$V || return 1
+    # dnf would bail out when asked to install a source rpm package during kexec-tools testing
+    rm -f "$TESTDIR"/*.src.rpm
+    git clone --branch rawhide https://src.fedoraproject.org/rpms/kexec-tools.git "$TESTDIR/$KEXEC_TOOLS_SRC" || return 1
+    # kexec-tools needs the following packages
+    dnf -y install qemu wget qemu-img fedpkg dnf-utils || return 1
+    yum-builddep kexec-tools || return 1
+    return 0
+}
+
+test_cleanup() {
+    rm -fr -- "$TESTDIR"/*.rpm
+    return 0
+}
+
+. $testdir/test-functions


### PR DESCRIPTION
kexec-tools heavily depends on dracut. However, the change of dracut occasionally breaks. For example, recently it's found that
 - commit 5840c466dcfe1c4322142980cac6606870bd586f  ("95nfs: /var/lib/nfs/statd/sm is /var/lib/nfs/sm on SUSE")  caused the failure of dumping vmcore to nfs (v3) target
 - commit 828feae4f1814a915b2f7f362a5920322e0d6fcc ("dracut.spec: remove unnecessary dependencies") caused the dumping failure when a NIC is configured a static IP
 - [/bin/bash is lost when calling dracut to re-generate initramfs of kdump.](https://bugzilla.redhat.com/show_bug.cgi?id=1936781)

## Changes

This new test will,
 - Build the dracut rpm package 
 - Clone kexec-tools 
 - Pass the build rpm to kexec-tools' testcases


## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it

