### PR TITLE
dbus-broker: enable the service

### DIFF
--- a/modules.d/06dbus-broker/module-setup.sh
+++ b/modules.d/06dbus-broker/module-setup.sh
@@ -66,6 +66,8 @@ install() {
         /^\[Socket\]/aRemoveOnStop=yes' \
         "$initdir$systemdsystemunitdir/dbus.socket"
 
+    $SYSTEMCTL -q --root "$initdir" enable dbus-broker.service
+
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \


### PR DESCRIPTION
dbus-broker.service has a 'dbus.service' alias which is installed when the service gets enabled.

If the alias is not present in the initrd image, services requiring D-Bus in the initrd fail to start because they depend on dbus.service, which doesn't exist.

Therefore, enable the service to create the alias.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant

