### PR TITLE
network-manager: run as daemon with D-Bus

### DIFF
--- a/modules.d/35network-manager/initrd-no-auto-default.conf
+++ b/modules.d/35network-manager/initrd-no-auto-default.conf
@@ -1,0 +1,5 @@
+[.config]
+enable=env:initrd
+
+[main]
+no-auto-default=*

--- a/modules.d/35network-manager/nm-config.sh
+++ b/modules.d/35network-manager/nm-config.sh
@@ -10,6 +10,9 @@ if getargbool 0 rd.debug -d -y rdinitdebug -d -y rdnetdebug; then
     # shellcheck disable=SC2174
     mkdir -m 0755 -p /run/NetworkManager/conf.d
     (
+        echo '[.config]'
+        echo 'enable=env:initrd'
+        echo
         echo '[logging]'
         echo 'level=TRACE'
     ) > /run/NetworkManager/conf.d/initrd-logging.conf

--- a/modules.d/35network-manager/nm-initrd.service
+++ b/modules.d/35network-manager/nm-initrd.service
@@ -1,0 +1,26 @@
+[Unit]
+DefaultDependencies=no
+Wants=systemd-udev-settle.service
+After=systemd-udev-settle.service
+Before=network.target
+ConditionPathExists=/run/NetworkManager/initrd/neednet
+ConditionPathExistsGlob=|/usr/lib/NetworkManager/system-connections/*
+ConditionPathExistsGlob=|/run/NetworkManager/system-connections/*
+ConditionPathExistsGlob=|/etc/NetworkManager/system-connections/*
+ConditionPathExistsGlob=|/etc/sysconfig/network-scripts/ifcfg-*
+
+[Service]
+Type=dbus
+BusName=org.freedesktop.NetworkManager
+ExecReload=/usr/bin/busctl call org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Reload u 0
+ExecStart=/usr/sbin/NetworkManager --debug
+KillMode=process
+StandardOutput=tty
+Environment=NM_CONFIG_ENABLE_TAG=initrd
+Restart=on-failure
+ProtectSystem=true
+ProtectHome=read-only
+
+[Install]
+WantedBy=initrd.target
+Also=nm-wait-online-initrd.service

--- a/modules.d/35network-manager/nm-lib.sh
+++ b/modules.d/35network-manager/nm-lib.sh
@@ -14,7 +14,7 @@ nm_generate_connections() {
             /etc/sysconfig/network-scripts/ifcfg-*; do
             [ -f "$i" ] || continue
             echo '[ -f /tmp/nm.done ]' > "$hookdir"/initqueue/finished/nm.sh
-            : > /run/NetworkManager/initrd/neednet # activate nm-run.service
+            : > /run/NetworkManager/initrd/neednet # activate NM services
             break
         done
     fi

--- a/modules.d/35network-manager/nm-wait-online-initrd.service
+++ b/modules.d/35network-manager/nm-wait-online-initrd.service
@@ -1,0 +1,17 @@
+[Unit]
+DefaultDependencies=no
+Requires=nm-initrd.service
+After=nm-initrd.service
+Before=network-online.target
+Before=dracut-initqueue.service
+ConditionPathExists=/run/NetworkManager/initrd/neednet
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/nm-online -s -q
+RemainAfterExit=yes
+Environment=NM_ONLINE_TIMEOUT=3600
+
+[Install]
+WantedBy=initrd.target
+WantedBy=network-online.target


### PR DESCRIPTION
This is version 2 of #927. I did only some basic testing on it; I plan to do more tests in the next days. In the meantime, comments are welcome.

This commit changes how NM is started inside the initrd. Instead of running NM in the special `--configure-and-quit=initrd` mode, which sets up network and quits, start it as a daemon.

This has multiple advantages. First, we no longer need to run NM in a special mode that requires additional code and maintenance. NetworkManager works exactly as in the real root.

One problem of the current configure-and-quit approach is that once NM has quit, dynamic addresses can expire if the initrd setup takes longer than the DHCP lease interval or than the IPv6 address lifetime. Running NM as a service
solves this problem.

Now NM runs with D-Bus support and therefore its API can be used by other modules. This open the possibility, for example, to integrate nm-cloud-setup to automatically configure networking based on cloud metadata.

Use the NetworkManager-wait-online.service, ordered before dracut-initqueue.service, to delay the initqueue until NM has terminated its configuration.