### PR TITLE
ci: disable fedora-eln for now

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -4,7 +4,7 @@
 # The name of the upstream package
 upstream_package_name: dracut
 
-# The upstream tag versioning scheme 
+# The upstream tag versioning scheme
 upstream_tag_template: "{version}"
 
 # The URL of the upstream project
@@ -46,7 +46,6 @@ jobs:
   metadata:
     targets:
       - fedora-development
-      - fedora-eln
 
 - job: copr_build
   trigger: commit
@@ -54,7 +53,6 @@ jobs:
     targets:
       - fedora-all
       - fedora-development
-      - fedora-eln
     branch: master
     owner: "@dracut"
     project: Dracut


### PR DESCRIPTION
Seems like there is a missing glib2 build in the pipeline, so
fedora-eln only fails, and therefore is of no use for us.
