### PR TITLE
fix(memstrack): correct dependencies

### DIFF
--- a/modules.d/99memstrack/memstrack-report.sh
+++ b/modules.d/99memstrack/memstrack-report.sh
@@ -1,15 +1,15 @@
-#!/bin/bash
+#!/bin/sh
 . /lib/dracut-lib.sh
 
 if ! [ "$DEBUG_MEM_LEVEL" -ge 4 ]; then
     return 0
 fi
 
-if type -P systemctl > /dev/null; then
+if command -v systemctl > /dev/null; then
     systemctl stop memstrack.service
 else
     pkill --signal INT '[m]emstrack'
-    while [[ $(pgrep '[m]emstrack') ]]; do
+    while pgrep -c '[m]emstrack' > /dev/null; do
         sleep 1
     done
 fi

--- a/modules.d/99memstrack/module-setup.sh
+++ b/modules.d/99memstrack/module-setup.sh
@@ -11,6 +11,7 @@ check() {
 }
 
 depends() {
+    echo systemd
     return 0
 }
 


### PR DESCRIPTION
memstrack does not need to depend on `bash` but does on `systemd`.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
