### PR TITLE
fix(network-manager): nm-lib.sh does not require bash

### DIFF
--- a/modules.d/35network-manager/nm-lib.sh
+++ b/modules.d/35network-manager/nm-lib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 type getcmdline > /dev/null 2>&1 || . /lib/dracut-lib.sh
 


### PR DESCRIPTION
This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
