### PR TITLE
fix(zipl): don't depend on grub2

### DIFF
--- a/modules.d/91zipl/module-setup.sh
+++ b/modules.d/91zipl/module-setup.sh
@@ -14,7 +14,6 @@ check() {
 
 # called by dracut
 depends() {
-    echo grub2
     return 0
 }
 


### PR DESCRIPTION
There is no grub2 dracut module.
