### PR TITLE
fix(multipath): revise multipathd-stop

### DIFF
--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -75,14 +75,18 @@ install() {
         }
     }
 
-    inst_multiple -o \
-        dmsetup \
+    inst_multiple \
+        pkill \
+        pidof \
         kpartx \
+        dmsetup \
+        multipath \
+        multipathd
+
+    inst_multiple -o \
         mpath_wait \
         mpathconf \
         mpathpersist \
-        multipath \
-        multipathd \
         xdrgetprio \
         xdrgetuid \
         /etc/xdrdevices.conf \

--- a/modules.d/90multipath/multipathd-stop.sh
+++ b/modules.d/90multipath/multipathd-stop.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
 
 if [ -e /etc/multipath.conf ]; then
-    HARD=""
-    while pidof multipathd > /dev/null 2>&1; do
-        for pid in $(pidof multipathd); do
-            kill "$HARD" "$pid" > /dev/null 2>&1
-        done
-        HARD="-9"
-    done
+    pkill multipathd > /dev/null 2>&1
+
+    if pidof multipathd > /dev/null 2>&1; then
+        sleep 0.2
+    fi
+
+    if pidof multipathd > /dev/null 2>&1; then
+        pkill -9 multipathd > /dev/null 2>&1
+    fi
 fi


### PR DESCRIPTION
A shellcheck regression quoted `HARD` in
```shell
    kill "$HARD" "$pid" > /dev/null 2>&1
```

which would error on an empty "HARD".

Instead of fixing this, use `pkill` instead and also add it to the
non-optional list of binaries to install, which was revised also.

Fixes: https://github.com/dracutdevs/dracut/issues/1275
