### PR TITLE
fix(nvdimm): shellcheck regression

### DIFF
--- a/modules.d/90nvdimm/module-setup.sh
+++ b/modules.d/90nvdimm/module-setup.sh
@@ -19,10 +19,11 @@ depends() {
 installkernel() {
     # Directories to search for NVDIMM "providers" (firmware drivers)
     # These modules call "nvdimm_bus_register()".
-    local _provider_dirs='=drivers/nvdimm =drivers/acpi =arch/powerpc'
-
     #instmods() will take care of hostonly
-    dracut_instmods -o -s nvdimm_bus_register "$_provider_dirs"
+    dracut_instmods -o -s nvdimm_bus_register \
+        '=drivers/nvdimm' \
+        '=drivers/acpi' \
+        '=arch/powerpc'
 }
 
 # called by dracut


### PR DESCRIPTION
`_provider_dirs` should not have been quoted, because it should expand
to multiple arguments.

Just remove the whole variable and add those arguments.

Fixes: https://github.com/dracutdevs/dracut/issues/1273
