### PR TITLE
docs: clarify `netroot=dhcp`

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -576,7 +576,7 @@ USB Android phone::
 =====================
 
 **ip=**__{dhcp|on|any|dhcp6|auto6|either6|link6|single-dhcp}__::
-    dhcp|on|any::: get ip from dhcp server from all interfaces. If root=dhcp,
+    dhcp|on|any::: get ip from dhcp server from all interfaces. If netroot=dhcp,
     loop sequentially through all interfaces (eth0, eth1, ...) and use the first
     with a valid DHCP root-path.
 
@@ -707,7 +707,7 @@ NFS
     ":" or "," and are separated by ",".
 
 **root=**nfs:\[_<server-ip>_:]__<root-dir>__[:__<nfs-options>__], **root=**nfs4:\[_<server-ip>_:]__<root-dir>__[:__<nfs-options>__], **root=**__{dhcp|dhcp6}__::
-    root=dhcp alone directs initrd to look at the DHCP root-path where NFS
+    netroot=dhcp alone directs initrd to look at the DHCP root-path where NFS
     options can be specified.
 +
 [listing]
@@ -909,8 +909,8 @@ NOTE:
     If "exportname" instead of "port" is given the standard port is used.
     Newer versions of nbd are only supported with "exportname".
 
-**root=dhcp** with **dhcp** **root-path=**nbd:__<server>__:__<port/exportname>__[:__<fstype>__[:__<mountopts>__[:__<nbdopts>__]]]::
-    root=dhcp alone directs initrd to look at the DHCP root-path where NBD
+**root=/dev/root netroot=dhcp** with **dhcp** **root-path=**nbd:__<server>__:__<port/exportname>__[:__<fstype>__[:__<mountopts>__[:__<nbdopts>__]]]::
+    netroot=dhcp alone directs initrd to look at the DHCP root-path where NBD
     options can be specified. This syntax is only usable in cases where you are
     directly mounting the volume as the rootfs.
 +


### PR DESCRIPTION
`root=dhcp` does not work with systemd, so `netroot=dhcp` should be
used.
