### PR TITLE
fix(dracut-systemd): regression on root=block:

### DIFF
--- a/modules.d/98dracut-systemd/dracut-cmdline.sh
+++ b/modules.d/98dracut-systemd/dracut-cmdline.sh
@@ -51,11 +51,11 @@ source_hook cmdline
 
 case "${root#block:}${root_unset}" in
     LABEL=* | UUID=* | PARTUUID=* | PARTLABEL=*)
-        root="block:$(label_uuid_to_dev "$root")"
+        root="block:$(label_uuid_to_dev "${root#block:}")"
         rootok=1
         ;;
     /dev/*)
-        root="block:${root}"
+        root="block:${root#block:}"
         rootok=1
         ;;
     UNSET | gpt-auto | tmpfs)


### PR DESCRIPTION
Commit 3532978de04c7 introduced a regression, where the `root` could be
`root=block:block:/dev/foo`.
