### PR TITLE
fix(base): source hooks without exec

### DIFF
--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -408,15 +408,9 @@ source_all() {
     [ "$_dir" ] && [ -d "/$_dir" ] || return
     for f in "/$_dir"/*.sh; do
         if [ -e "$f" ]; then
-            # dash can't source with parameters
-            if [ -z "$BASH" ] && [ $# -gt 0 ]; then
-                [ -x "$f" ] || chmod 0755 "$f"
-                "$f" "$@"
-            else
-                # shellcheck disable=SC1090
-                # shellcheck disable=SC2240
-                . "$f" "$@"
-            fi
+            # shellcheck disable=SC1090
+            # shellcheck disable=SC2240
+            . "$f" "$@"
         fi
     done
 }


### PR DESCRIPTION
Patch 2fabaaa62dcfd31e593ca changed the behaviour for `dash`
under the assumption, that dash does not take parameters for `.` aka
`source`. Although this is true, the original positional parameters of
the `source_all` function are still in place, so everything is
fine with the old way of sourcing.
