### PR TITLE
fix(network-manager): no default deps for nm-run.service

### DIFF
--- a/modules.d/35network-manager/nm-run.service
+++ b/modules.d/35network-manager/nm-run.service
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 [Unit]
+DefaultDependencies=no
+
 #make sure all devices showed up
 Wants=systemd-udev-settle.service
 After=systemd-udev-settle.service


### PR DESCRIPTION
Otherwise nm-run.service will run only in basic.target, which is too
late in the initramfs.
