### PR TITLE
fix: fix word splitting issue for sed in get_ucode_file

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -709,9 +709,9 @@ get_ucode_file() {
     local family
     local model
     local stepping
-    family=$(grep -E "cpu family" /proc/cpuinfo | head -1 | sed s/.*:\ //)
-    model=$(grep -E "model" /proc/cpuinfo | grep -v name | head -1 | sed s/.*:\ //)
-    stepping=$(grep -E "stepping" /proc/cpuinfo | head -1 | sed s/.*:\ //)
+    family=$(grep -E "cpu family" /proc/cpuinfo | head -1 | sed "s/.*:\ //")
+    model=$(grep -E "model" /proc/cpuinfo | grep -v name | head -1 | sed "s/.*:\ //")
+    stepping=$(grep -E "stepping" /proc/cpuinfo | head -1 | sed "s/.*:\ //")
 
     if [[ "$(get_cpu_vendor)" == "AMD" ]]; then
         if [[ $family -ge 21 ]]; then


### PR DESCRIPTION
This unquated regex could be splitted into two arguments and sed will
not work. I've see giving error of wrong arguments being used on my
desktop.

Signed-off-by: Kairui Song <kasong@redhat.com>

## Changes
Fix a word splitting issue.


## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
