### PR TITLE
fix(TEST ISCSI): try to debug md error 524

### DIFF
--- a/test/TEST-30-ISCSI/create-client-root.sh
+++ b/test/TEST-30-ISCSI/create-client-root.sh
@@ -7,6 +7,9 @@ rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
 
+echo "Size of /dev/sdc and /dev/sdd"
+blockdev --getsize64 /dev/sdc /dev/sdd
+
 mkfs.ext3 -j -L singleroot -F /dev/sda \
     && mkdir -p /sysroot \
     && mount /dev/sda /sysroot \

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -129,9 +129,12 @@ test_setup() {
     fi
 
     # Create the blank file to use as a root filesystem
-    dd if=/dev/zero of="$TESTDIR"/root.ext3 bs=1M count=100
-    dd if=/dev/zero of="$TESTDIR"/iscsidisk2.img bs=1M count=50
-    dd if=/dev/zero of="$TESTDIR"/iscsidisk3.img bs=1M count=50
+    rm -f "$TESTDIR"/root.ext3
+    dd if=/dev/zero of="$TESTDIR"/root.ext3 bs=4096 count=$((200 * 256))
+    rm -f "$TESTDIR"/iscsidisk2.img
+    dd if=/dev/zero of="$TESTDIR"/iscsidisk2.img bs=4096 count=$((100 * 256))
+    rm -f "$TESTDIR"/iscsidisk3.img
+    dd if=/dev/zero of="$TESTDIR"/iscsidisk3.img bs=4096 count=$((100 * 256))
 
     kernel=$KVERSION
     # Create what will eventually be our root filesystem onto an overlay
@@ -175,7 +178,7 @@ test_setup() {
         export initdir=$TESTDIR/overlay
         # shellcheck disable=SC1090
         . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext3 poweroff cp umount setsid dd sync
+        inst_multiple sfdisk mkfs.ext3 poweroff cp umount setsid dd sync blockdev
         inst_hook initqueue 01 ./create-client-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
         inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules

--- a/test/TEST-35-ISCSI-MULTI/create-client-root.sh
+++ b/test/TEST-35-ISCSI-MULTI/create-client-root.sh
@@ -7,6 +7,9 @@ rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
 
+echo "Size of /dev/sdc and /dev/sdd"
+blockdev --getsize64 /dev/sdc /dev/sdd
+
 mkfs.ext3 -j -L singleroot -F /dev/sda \
     && mkdir -p /sysroot \
     && mount /dev/sda /sysroot \

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -145,9 +145,12 @@ test_setup() {
     fi
 
     # Create the blank file to use as a root filesystem
-    dd if=/dev/zero of="$TESTDIR"/root.ext3 bs=1M count=180
-    dd if=/dev/zero of="$TESTDIR"/iscsidisk2.img bs=1M count=90
-    dd if=/dev/zero of="$TESTDIR"/iscsidisk3.img bs=1M count=90
+    rm -f "$TESTDIR"/root.ext3
+    dd if=/dev/zero of="$TESTDIR"/root.ext3 bs=4096 count=$((200 * 256))
+    rm -f "$TESTDIR"/iscsidisk2.img
+    dd if=/dev/zero of="$TESTDIR"/iscsidisk2.img bs=4096 count=$((100 * 256))
+    rm -f "$TESTDIR"/iscsidisk3.img
+    dd if=/dev/zero of="$TESTDIR"/iscsidisk3.img bs=4096 count=$((100 * 256))
 
     kernel=$KVERSION
     # Create what will eventually be our root filesystem onto an overlay
@@ -191,7 +194,7 @@ test_setup() {
         export initdir=$TESTDIR/overlay
         # shellcheck disable=SC1090
         . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext3 poweroff cp umount setsid dd
+        inst_multiple sfdisk mkfs.ext3 poweroff cp umount setsid dd sync blockdev
         inst_hook initqueue 01 ./create-client-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
         inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules


### PR DESCRIPTION
While creating the striped md raid0 sometimes this error occures:

```
mdadm: Defaulting to version 1.2 metadata
mdadm: RUN_ARRAY failed: Unknown error 524
  Failed to clear hint file.
  Device /dev/md0 not found.
Powering off.
```

Add debug output with the size of the disks.

