### PR TITLE
fix(i18n): skip if data is missing

### DIFF
--- a/modules.d/10i18n/module-setup.sh
+++ b/modules.d/10i18n/module-setup.sh
@@ -265,6 +265,8 @@ install() {
             kbddir=''
         done
 
+        [[ "$kbddir" ]] || return 1
+
         [[ -f $dracutsysrootdir$I18N_CONF && -f $dracutsysrootdir$VCONFIG_CONF ]] \
             || [[ ! ${hostonly} || ${i18n_vars} ]] || {
             derror 'i18n_vars not set!  Please set up i18n_vars in ' \


### PR DESCRIPTION
On system that doesn't have either consolefonts, consoletrans, keymaps,
or unimaps, "kbddir" is empty, thus the followed installation will
broken with errors like:

	cp: cannot stat '/consolefonts/*': No such file or directory

Let's report the checks as failure if "kbddir" is empty.

Signed-off-by: Đoàn Trần Công Danh <congdanhqx@gmail.com>

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
