### PR TITLE
fix(network-manager): only run NetworkManager if rd.neednet=1 

### DIFF
--- a/modules.d/35network-manager/nm-lib.sh
+++ b/modules.d/35network-manager/nm-lib.sh
@@ -14,6 +14,7 @@ nm_generate_connections() {
             /etc/sysconfig/network-scripts/ifcfg-*; do
             [ -f "$i" ] || continue
             echo '[ -f /tmp/nm.done ]' > "$hookdir"/initqueue/finished/nm.sh
+            : > /run/NetworkManager/initrd/neednet # activate nm-run.service
             break
         done
     fi

--- a/modules.d/35network-manager/nm-run.service
+++ b/modules.d/35network-manager/nm-run.service
@@ -15,6 +15,9 @@ Before=network.target network-online.target
 #run before we try to mount anything from the dracut hooks
 Before=dracut-initqueue.service
 
+#do not run if networking not needed
+ConditionPathExists=/run/NetworkManager/initrd/neednet
+
 #do not run, if there is no configuration
 ConditionPathExistsGlob=|/usr/lib/NetworkManager/system-connections/*
 ConditionPathExistsGlob=|/run/NetworkManager/system-connections/*

--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -6,15 +6,19 @@ if [ -e /tmp/nm.done ]; then
     return
 fi
 
-[ -z "$DRACUT_SYSTEMD" ] \
-    && for i in /usr/lib/NetworkManager/system-connections/* \
-        /run/NetworkManager/system-connections/* \
-        /etc/NetworkManager/system-connections/* \
-        /etc/sysconfig/network-scripts/ifcfg-*; do
-        [ -f "$i" ] || continue
-        /usr/sbin/NetworkManager --configure-and-quit=initrd --no-daemon
-        break
-    done
+if [ -z "$DRACUT_SYSTEMD" ]; then
+    # Only start NM if networking is needed
+    if [ -e /run/NetworkManager/initrd/neednet ]; then
+        for i in /usr/lib/NetworkManager/system-connections/* \
+            /run/NetworkManager/system-connections/* \
+            /etc/NetworkManager/system-connections/* \
+            /etc/sysconfig/network-scripts/ifcfg-*; do
+            [ -f "$i" ] || continue
+            /usr/sbin/NetworkManager --configure-and-quit=initrd --no-daemon
+            break
+        done
+    fi
+fi
 
 if [ -s /run/NetworkManager/initrd/hostname ]; then
     cat /run/NetworkManager/initrd/hostname > /proc/sys/kernel/hostname


### PR DESCRIPTION
```
commit 0152fa88c9a155ac3e34c575da6c7ed2134b32f0
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Apr 13 11:45:35 2021 -0400

    network-manager: use /run/NetworkManager/initrd/neednet in initqueue
    
    We don't want to start NetworkManager if networking is not needed.
    Right now nm-config.sh lays down /usr/lib/dracut/hooks/initqueue/finished/nm.sh
    which will cause the initqueue to run. If nothing exists in
    /usr/lib/dracut/hooks/initqueue/finished/ then it will short circuit and
    the initqueue won't run anything. But what if something else needed
    something to run in the initqueue? nm-run.sh would still get started,
    even though /usr/lib/dracut/hooks/initqueue/finished/nm.sh didn't exist.
    In this case let's just trigger off of /run/NetworkManager/initrd/neednet
    like we are doing in the systemd unit (nm-run.service).

commit 127fc8028a47a44c3a73c09b00bea269fa1d70b3
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Apr 13 11:36:21 2021 -0400

    network-manager: only run NetworkManager if rd.neednet=1
    
    Don't run the new systemd unit (nm-run.service) if rd.neednet=1
    isn't set. nm-initrd-generator will generate configuration even
    without rd.neednet=1 so determining if we should start based on
    just if connection profiles exist isn't enough. We need some other
    indicator. In this case we lay down a /run/NetworkManager/initrd/neednet
    if rd.neednet=1, which is used by nm-run.service to determine the
    need to run.
```