### PR TITLE
fix(systemd-networkd): make systemd-networkd a proper network provider 

### DIFF
--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -9,7 +9,7 @@ check() {
 depends() {
     is_qemu_virtualized && echo -n "qemu-net "
 
-    for module in network-wicked network-manager network-legacy; do
+    for module in network-wicked network-manager network-legacy systemd-networkd; do
         if dracut_module_included "$module"; then
             network_handler="$module"
             break
@@ -21,6 +21,8 @@ depends() {
             network_handler="network-wicked"
         elif [[ -x $dracutsysrootdir/usr/libexec/nm-initrd-generator ]]; then
             network_handler="network-manager"
+        elif [[ -x $dracutsysrootdir/usr/lib/systemd/systemd-networkd ]]; then
+            network_handler="systemd-networkd"
         else
             network_handler="network-legacy"
         fi


### PR DESCRIPTION
Let's make systemd-networkd a proper network provider which should fix #737
Node that this PR adds dependencies on the dbus module ( since it provides networkd dbus files ) as well as sysusers ( which replaces the grep passwd section from the existing module ) and should not be merged until I have provided the rest of the modules hostnamed, timesyncd,resolved etc. ( read as do not enable automerge  ) which will provide the libraries in the existing module.  


## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
