### PR TITLE
fix(network-manager): nm-run.service: don't kill forked processes

### DIFF
--- a/modules.d/35network-manager/nm-run.service
+++ b/modules.d/35network-manager/nm-run.service
@@ -25,6 +25,8 @@ ConditionPathExistsGlob=|/etc/sysconfig/network-scripts/ifcfg-*
 #run the script and wait before it finishes
 Type=oneshot
 ExecStart=/usr/sbin/NetworkManager --configure-and-quit=initrd --no-daemon
+#don't kill forked off processes (for example: teamd for teaming)
+KillMode=process
 
 [Install]
 WantedBy=initrd.target


### PR DESCRIPTION
If teaming is set up via NetworkManager we don't want systemd to take
down the userspace teamd process when NetworkManager quits. `KillMode=process`
will allow it to leave those processes behind.

This is fallout from the change to run NetworkManager via systemd (c17c5b7).

With `KillMode=process` we get something like:

```
sh-5.1# journalctl -u nm-run -o cat | tail
<info>  [1618411262.7030] quitting now that startup is complete
<info>  [1618411262.7030] device (team0): carrier: link connected
<info>  [1618411262.7033] device (team0): team port ens2 was released
<info>  [1618411262.7033] device (team0): team port ens3 was released
<info>  [1618411262.7033] manager: NetworkManager state is now CONNECTED_SITE
<info>  [1618411262.7034] exiting (success)
nm-run.service: Deactivated successfully.
nm-run.service: Unit process 476 (teamd) remains running after unit stopped.
Finished nm-run.service.
```

