### PR TITLE
fix(dracut-logger.sh): double dash trigger unknown logger warnings during run

### DIFF
--- a/dracut-logger.sh
+++ b/dracut-logger.sh
@@ -239,7 +239,7 @@ _lvl2char() {
 # @retval 0 if @a lvl is correct.
 # @result Echoes logger priority.
 _lvl2syspri() {
-    printf "%s" -- "$syslogfacility."
+    printf -- "%s" "$syslogfacility."
     case "$1" in
         1) echo crit ;;
         2) echo error ;;


### PR DESCRIPTION
There are a bunch of `logger: unknown facility name: --user` errors
during a run. This is because logger is getting passed something like:

```
logger -p --user.info
```

Where it should be something like:

```
logger -p user.info
```
