### PR TITLE
fix(nbd): make nbd work again with systemd

### DIFF
--- a/modules.d/95nbd/nbdroot.sh
+++ b/modules.d/95nbd/nbdroot.sh
@@ -113,6 +113,16 @@ if [ "$root" = "block:/dev/root" -o "$root" = "dhcp" ]; then
         printf '/bin/mount %s\n' \
             "$NEWROOT" \
             > "$hookdir"/mount/01-$$-nbd.sh
+    else
+        mkdir -p /run/systemd/system/sysroot.mount.d
+        cat << EOF > /run/systemd/system/sysroot.mount.d/dhcp.conf
+[Mount]
+Where=/sysroot
+What=/dev/root
+Type=$nbdfstype
+Options=$fsopts
+EOF
+        systemctl --no-block daemon-reload
     fi
     # if we're on systemd, use the nbd-generator script
     # to create the /sysroot mount.

--- a/modules.d/95nbd/parse-nbdroot.sh
+++ b/modules.d/95nbd/parse-nbdroot.sh
@@ -60,3 +60,5 @@ if [ -z "$root" ]; then
     root=block:/dev/root
     # the device is created and waited for in ./nbdroot.sh
 fi
+
+echo 'nbd-client -check /dev/nbd0 > /dev/null 2>&1' > "$hookdir"/initqueue/finished/nbdroot.sh


### PR DESCRIPTION
This pull request changes...

## Changes

* Correct the systemd generated sysroot.mount unit with the options
received by the DHCP request and do a `daemon-reload`.

* Inject the `nbd-client -check /dev/nbd0` in the finished initqueue.

* Reactivate the NBD tests and prepare them for NetworkManager tests.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it

Fixes #
