### PR TITLE
feat(systemd-ac-power): introducing the systemd-ac-power module

### DIFF
--- a/dracut.spec
+++ b/dracut.spec
@@ -322,6 +322,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version}
 %{dracutlibdir}/modules.d/01fips
 %endif
+%{dracutlibdir}/modules.d/01systemd-ac-power
 %{dracutlibdir}/modules.d/01systemd-ask-password
 %{dracutlibdir}/modules.d/01systemd-coredump
 %{dracutlibdir}/modules.d/01systemd-initrd

--- a/modules.d/01systemd-ac-power/99-initrd-power-targets.rules
+++ b/modules.d/01systemd-ac-power/99-initrd-power-targets.rules
@@ -1,0 +1,3 @@
+# This file is part of dracut systemd ac power module
+SUBSYSTEM=="power_supply", KERNEL=="AC", ATTR{online}=="0", RUN+="/usr/sbin/systemctl start initrd-on-battery-power.target"
+SUBSYSTEM=="power_supply", KERNEL=="AC", ATTR{online}=="1", RUN+="/usr/sbin/systemctl start initrd-on-ac-power.target"

--- a/modules.d/01systemd-ac-power/initrd-on-ac-power.target
+++ b/modules.d/01systemd-ac-power/initrd-on-ac-power.target
@@ -1,0 +1,8 @@
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+[Unit]
+Description=Initial RAM Disk On AC Power
+ConditionPathExists=/usr/lib/initrd-release
+DefaultDependencies=no
+StopWhenUnneeded=yes

--- a/modules.d/01systemd-ac-power/initrd-on-battery-power.target
+++ b/modules.d/01systemd-ac-power/initrd-on-battery-power.target
@@ -1,0 +1,8 @@
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+[Unit]
+Description=Initial RAM Disk On Battery Power
+ConditionPathExists=/usr/lib/initrd-release
+DefaultDependencies=no
+StopWhenUnneeded=yes

--- a/modules.d/01systemd-ac-power/module-setup.sh
+++ b/modules.d/01systemd-ac-power/module-setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Prerequisite check(s) for module.
+check() {
+
+    # Return 255 to only include the module, if another module requires it.
+    return 255
+
+}
+
+# Module dependency requirements.
+depends() {
+
+    # Return 0 to include the dependent module(s) in the initramfs.
+    return 0
+
+}
+
+# Install the required file(s) and directories for the module in the initramfs.
+install() {
+
+    inst_rules "$moddir/99-initrd-power-targets.rules"
+    inst_simple "$systemdutildir"/systemd-ac-power
+    inst_simple "$moddir/initrd-on-ac-power.target" "$systemdsystemunitdir/initrd-on-ac-power.target"
+    inst_simple "$moddir/initrd-on-battery-power.target" "$systemdsystemunitdir/initrd-on-battery-power.target"
+
+}


### PR DESCRIPTION
Introducing the systemd-ac-power module

This module introduces two new targets which are run based on the power state in initrd which users/projects/products can then use when running on ac or battery power.

A typical service type unit to be used with this would look like this when on AC

```
# AC
[Unit]
Description=Run When I'm On AC Power In Initrd 

[Service]
...

[Install]
WantedBy=initrd-on-ac-power.target
```

And this when on battery

```
# Battery
[Unit]
Description=Run When I'm On Battery Power In Initrd 

[Service]
...

[Install
WantedBy=initrd-on-battery-power.target
```

If the situation requires it, a belt and suspenders approach for the type units can be achieved by adding the `ConditionACPower=` with true or false depending on the target. 