### PR TITLE
feat(network): install hosts and nss file in hostonly mode

### DIFF
--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -41,5 +41,10 @@ install() {
     inst_hook pre-udev 50 "$moddir/ifname-genrules.sh"
     inst_hook cmdline 91 "$moddir/dhcp-root.sh"
 
+    if [[ $hostonly ]]; then
+        inst "/etc/hosts"
+        inst "/etc/nsswitch.conf"
+    fi
+
     dracut_need_initqueue
 }


### PR DESCRIPTION
## Changes
Install hosts and nss file in hostonly initramfs can make it easier to
maintain the config and allow using hostname in initramfs stage.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
