### PR TITLE
fix: remove old systemd/udev version checks

### DIFF
--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -31,14 +31,10 @@ mount_boot() {
 
         if ! [ -e "$boot" ]; then
             udevadm trigger --action=add > /dev/null 2>&1
-            [ -z "$UDEVVERSION" ] && UDEVVERSION=$(udevadm --version)
+
             i=0
             while ! [ -e "$boot" ]; do
-                if [ "$UDEVVERSION" -ge 143 ]; then
-                    udevadm settle --exit-if-exists="$boot"
-                else
-                    udevadm settle --timeout=30
-                fi
+                udevadm settle --exit-if-exists="$boot"
                 [ -e "$boot" ] && break
                 sleep 0.5
                 i=$((i + 1))

--- a/modules.d/95nbd/nbdroot.sh
+++ b/modules.d/95nbd/nbdroot.sh
@@ -90,11 +90,7 @@ fsopts=${fsopts:+$fsopts,}${nbdrw}
 i=0
 while [ ! -b /dev/nbd0 ]; do
     [ $i -ge 20 ] && exit 1
-    if [ "$UDEVVERSION" -ge 143 ]; then
-        udevadm settle --exit-if-exists=/dev/nbd0
-    else
-        sleep 0.1
-    fi
+    udevadm settle --exit-if-exists=/dev/nbd0
     i=$((i + 1))
 done
 


### PR DESCRIPTION
Came across some old systemd/udev version checks in modules so I removed those and what followed since it should not be needed anymore + it's somewhat weird if vendors/distributions are shipping old systemd versions with newer dracut....

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
