### PR TITLE
ci: WIP use /dev/disk/by-id

### DIFF
--- a/test/TEST-01-BASIC/99-idesymlinks.rules
+++ b/test/TEST-01-BASIC/99-idesymlinks.rules
@@ -1,8 +1,0 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hda", SYMLINK+="sda"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hda*", SYMLINK+="sda$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdb", SYMLINK+="sdb"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdb*", SYMLINK+="sdb$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdc", SYMLINK+="sdc"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdc*", SYMLINK+="sdc$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdd", SYMLINK+="sdd"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdd*", SYMLINK+="sdd$env{MINOR}"

--- a/test/TEST-01-BASIC/create-root.sh
+++ b/test/TEST-01-BASIC/create-root.sh
@@ -1,24 +1,22 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"
 done
 rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
-set -e
-# save a partition at the beginning for future flagging purposes
-sfdisk /dev/sda << EOF
-,1M
-,
-EOF
-
 udevadm settle
-mkfs.ext3 -L '  rdinit=/bin/sh' /dev/sda2
+
+set -ex
+
+mkfs.ext3 -L '  rdinit=/bin/sh' /dev/disk/by-id/ata-disk_root
 mkdir -p /root
-mount /dev/sda2 /root
+mount /dev/disk/by-id/ata-disk_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sda1
-sync
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 poweroff -f

--- a/test/TEST-01-BASIC/test-init.sh
+++ b/test/TEST-01-BASIC/test-init.sh
@@ -7,7 +7,8 @@ export PATH=/sbin:/bin:/usr/sbin:/usr/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/sdb
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+
 export TERM=linux
 export PS1='initramfs-test:\w\$ '
 [ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
@@ -20,5 +21,4 @@ if getargbool 0 rd.shell; then
 fi
 echo "Powering down."
 mount -n -o remount,ro /
-sync
 poweroff -f

--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -8,21 +8,23 @@ KVERSION=${KVERSION-$(uname -r)}
 # DEBUGFAIL="rd.shell rd.break"
 
 test_run() {
-    dd if=/dev/zero of="$TESTDIR"/result bs=1M count=1
+    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
+    declare -a disk_args=()
+    # shellcheck disable=SC2034
+    declare -i disk_index=0
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root
+
     "$testdir"/run-qemu \
-        -drive format=raw,index=0,media=disk,file="$TESTDIR"/root.ext3 \
-        -drive format=raw,index=1,media=disk,file="$TESTDIR"/result \
+        "${disk_args[@]}" \
         -watchdog i6300esb -watchdog-action poweroff \
         -append "panic=1 systemd.crash_reboot \"root=LABEL=  rdinit=/bin/sh\" rw systemd.log_level=debug systemd.log_target=console rd.retry=3 rd.debug console=ttyS0,115200n81 rd.shell=0 $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success "$TESTDIR"/result || return 1
+
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success "$TESTDIR"/marker.img
 }
 
 test_setup() {
-    rm -f -- "$TESTDIR"/root.ext3
-    # Create the blank file to use as a root filesystem
-    dd if=/dev/zero of="$TESTDIR"/root.ext3 bs=1M count=80
-
     kernel=$KVERSION
     # Create what will eventually be our root filesystem onto an overlay
     (
@@ -72,7 +74,6 @@ test_setup() {
         inst_multiple sfdisk mkfs.ext3 poweroff cp umount sync dd
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
-        inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
     )
 
     # create an initramfs that will create the target root filesystem.
@@ -85,13 +86,22 @@ test_setup() {
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
-    # Invoke KVM and/or QEMU to actually create the target filesystem.
 
+    dd if=/dev/zero of="$TESTDIR"/root.img bs=1MiB count=80
+    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
+    declare -a disk_args=()
+    # shellcheck disable=SC2034
+    declare -i disk_index=0
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root
+
+    # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
-        -drive format=raw,index=0,media=disk,file="$TESTDIR"/root.ext3 \
+        "${disk_args[@]}" \
         -append "root=/dev/dracut/root rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/root.ext3 || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
+    rm -- "$TESTDIR"/marker.img
 
     (
         # shellcheck disable=SC2031
@@ -101,7 +111,6 @@ test_setup() {
         inst_multiple poweroff shutdown dd
         inst_hook shutdown-emergency 000 ./hard-off.sh
         inst_hook emergency 000 ./hard-off.sh
-        inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
     )
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -a "debug watchdog" \

--- a/test/TEST-02-SYSTEMD/99-idesymlinks.rules
+++ b/test/TEST-02-SYSTEMD/99-idesymlinks.rules
@@ -1,8 +1,0 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hda", SYMLINK+="sda"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hda*", SYMLINK+="sda$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdb", SYMLINK+="sdb"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdb*", SYMLINK+="sdb$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdc", SYMLINK+="sdc"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdc*", SYMLINK+="sdc$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdd", SYMLINK+="sdd"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdd*", SYMLINK+="sdd$env{MINOR}"

--- a/test/TEST-02-SYSTEMD/create-root.sh
+++ b/test/TEST-02-SYSTEMD/create-root.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"
@@ -6,18 +9,13 @@ done
 rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 set -e
-# save a partition at the beginning for future flagging purposes
-sfdisk /dev/sda << EOF
-,1M
-,
-EOF
 
 udevadm settle
-mkfs.ext3 -L dracut /dev/sda2
+mkfs.ext3 -L dracut /dev/disk/by-id/ata-disk_root
 mkdir -p /root
-mount /dev/sda2 /root
+mount /dev/disk/by-id/ata-disk_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sda1
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 poweroff -f

--- a/test/TEST-02-SYSTEMD/test-init.sh
+++ b/test/TEST-02-SYSTEMD/test-init.sh
@@ -1,11 +1,14 @@
 #!/bin/sh
+: > /dev/watchdog
+
 . /lib/dracut-lib.sh
 
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/sda1
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+
 export TERM=linux
 export PS1='initramfs-test:\w\$ '
 [ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
@@ -18,5 +21,4 @@ if getargbool 0 rd.shell; then
 fi
 echo "Powering down."
 mount -n -o remount,ro /
-sync
 poweroff -f

--- a/test/TEST-03-USR-MOUNT/99-idesymlinks.rules
+++ b/test/TEST-03-USR-MOUNT/99-idesymlinks.rules
@@ -1,8 +1,0 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hda", SYMLINK+="sda"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hda*", SYMLINK+="sda$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdb", SYMLINK+="sdb"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdb*", SYMLINK+="sdb$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdc", SYMLINK+="sdc"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdc*", SYMLINK+="sdc$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdd", SYMLINK+="sdd"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdd*", SYMLINK+="sdd$env{MINOR}"

--- a/test/TEST-03-USR-MOUNT/create-root.sh
+++ b/test/TEST-03-USR-MOUNT/create-root.sh
@@ -1,44 +1,33 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
-set -x
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"
 done
 rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
-udevadm settle
 set -e
-# save a partition at the beginning for future flagging purposes
-sfdisk /dev/sda << EOF
-,1M
-,
-EOF
-
-sfdisk /dev/sdb << EOF
-,1M
-,
-EOF
 
 udevadm settle
 modprobe btrfs
-mkfs.btrfs -L dracut /dev/sda2
-mkfs.btrfs -L dracutusr /dev/sdb2
-btrfs device scan /dev/sda2
-btrfs device scan /dev/sdb2
+mkfs.btrfs -L dracut /dev/disk/by-id/ata-disk_root
+mkfs.btrfs -L dracutusr /dev/disk/by-id/ata-disk_usr
+btrfs device scan /dev/disk/by-id/ata-disk_root
+btrfs device scan /dev/disk/by-id/ata-disk_usr
 mkdir -p /root
-mount -t btrfs /dev/sda2 /root
+mount -t btrfs /dev/disk/by-id/ata-disk_root /root
 [ -d /root/usr ] || mkdir -p /root/usr
-mount -t btrfs /dev/sdb2 /root/usr
+mount -t btrfs /dev/disk/by-id/ata-disk_usr /root/usr
 btrfs subvolume create /root/usr/usr
 umount /root/usr
-mount -t btrfs -o subvol=usr /dev/sdb2 /root/usr
+mount -t btrfs -o subvol=usr /dev/disk/by-id/ata-disk_usr /root/usr
 cp -a -t /root /source/*
 mkdir -p /root/run
 btrfs filesystem sync /root/usr
 btrfs filesystem sync /root
 umount /root/usr
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sda1
-udevadm settle
-sync
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 poweroff -f

--- a/test/TEST-03-USR-MOUNT/fstab
+++ b/test/TEST-03-USR-MOUNT/fstab
@@ -1,2 +1,2 @@
-/dev/sda2	/                       btrfs   defaults         0 0
-/dev/sdb2	/usr                    btrfs   subvol=usr,ro    0 0
+/dev/disk/by-id/ata-disk_root	/                       btrfs   defaults         0 0
+/dev/disk/by-id/ata-disk_usr	/usr                    btrfs   subvol=usr,ro    0 0

--- a/test/TEST-03-USR-MOUNT/test-init.sh
+++ b/test/TEST-03-USR-MOUNT/test-init.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 : > /dev/watchdog
 
 . /lib/dracut-lib.sh
@@ -8,9 +7,8 @@ export PATH=/sbin:/bin:/usr/sbin:/usr/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-if ismounted /usr; then
-    echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/sdc
-fi
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+
 export TERM=linux
 export PS1='initramfs-test:\w\$ '
 [ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
@@ -23,5 +21,4 @@ if getargbool 0 rd.shell; then
 fi
 echo "Powering down."
 mount -n -o remount,ro /
-sync
 poweroff -f

--- a/test/TEST-04-FULL-SYSTEMD/99-idesymlinks.rules
+++ b/test/TEST-04-FULL-SYSTEMD/99-idesymlinks.rules
@@ -1,8 +1,0 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hda", SYMLINK+="sda"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hda*", SYMLINK+="sda$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdb", SYMLINK+="sdb"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdb*", SYMLINK+="sdb$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdc", SYMLINK+="sdc"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdc*", SYMLINK+="sdc$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdd", SYMLINK+="sdd"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdd*", SYMLINK+="sdd$env{MINOR}"

--- a/test/TEST-04-FULL-SYSTEMD/fstab
+++ b/test/TEST-04-FULL-SYSTEMD/fstab
@@ -1,2 +1,2 @@
-LABEL=dracut	/                       btrfs   subvol=root      0 0
-LABEL=dracutusr /usr                    btrfs   subvol=usr,ro    0 0
+/dev/disk/by-id/ata-disk_root	/                       btrfs   defaults         0 0
+/dev/disk/by-id/ata-disk_usr	/usr                    btrfs   subvol=usr,ro    0 0

--- a/test/TEST-04-FULL-SYSTEMD/test-init.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test-init.sh
@@ -21,7 +21,7 @@ else
         echo "**************************FAILED**************************"
 
     else
-        echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/sdc
+        echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
         echo "All OK"
     fi
 fi
@@ -33,11 +33,9 @@ export PS1='initramfs-test:\w\$ '
 stty sane
 echo "made it to the rootfs!"
 if getargbool 0 rd.shell; then
-    #	while sleep 1; do sleep 1;done
     strstr "$(setsid --help)" "control" && CTTY="-c"
     setsid $CTTY sh -i
 fi
-sync
-systemctl poweroff
 echo "Powering down."
+systemctl --no-block poweroff
 exit 0

--- a/test/TEST-10-RAID/99-idesymlinks.rules
+++ b/test/TEST-10-RAID/99-idesymlinks.rules
@@ -1,8 +1,0 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hda", SYMLINK+="sda"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hda*", SYMLINK+="sda$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdb", SYMLINK+="sdb"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdb*", SYMLINK+="sdb$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdc", SYMLINK+="sdc"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdc*", SYMLINK+="sdc$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdd", SYMLINK+="sdd"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdd*", SYMLINK+="sdd$env{MINOR}"

--- a/test/TEST-10-RAID/create-root.sh
+++ b/test/TEST-10-RAID/create-root.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"
@@ -6,40 +9,39 @@ done
 rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
-# save a partition at the beginning for future flagging purposes
-sfdisk /dev/sda << EOF
-,4M
-,41M
-,41M
-,41M
-EOF
-udevadm settle
-mdadm --create /dev/md0 --run --auto=yes --level=5 --raid-devices=3 /dev/sda2 /dev/sda3 /dev/sda4
+set -ex
+mdadm --create /dev/md0 --run --auto=yes --level=5 --raid-devices=3 /dev/disk/by-id/ata-disk_raid[123]
 # wait for the array to finish initailizing, otherwise this sometimes fails
 # randomly.
-mdadm -W /dev/md0
-set -e
+mdadm -W /dev/md0 || :
 printf test > keyfile
 cryptsetup -q luksFormat /dev/md0 /keyfile
 echo "The passphrase is test"
 cryptsetup luksOpen /dev/md0 dracut_crypt_test < /keyfile
 lvm pvcreate -ff -y /dev/mapper/dracut_crypt_test
 lvm vgcreate dracut /dev/mapper/dracut_crypt_test
-lvm lvcreate -l 100%FREE -n root dracut \
-    && lvm vgchange -ay
-mke2fs /dev/dracut/root
+lvm lvcreate -l 100%FREE -n root dracut
+lvm vgchange -ay
+mke2fs -L root /dev/dracut/root
 mkdir -p /sysroot
 mount /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
+mkdir -p /sysroot/run
 umount /sysroot
 lvm lvchange -a n /dev/dracut/root
 udevadm settle
 cryptsetup luksClose /dev/mapper/dracut_crypt_test
 udevadm settle
+mdadm -W /dev/md0 || :
+udevadm settle
+mdadm --detail --export /dev/md0 | grep -F MD_UUID > /tmp/mduuid
+. /tmp/mduuid
+udevadm settle
 eval "$(udevadm info --query=env --name=/dev/md0 | while read -r line || [ -n "$line" ]; do [ "$line" != "${line#*ID_FS_UUID*}" ] && echo "$line"; done)"
 {
     echo "dracut-root-block-created"
+    echo MD_UUID="$MD_UUID"
     echo "ID_FS_UUID=$ID_FS_UUID"
-} | dd oflag=direct,dsync of=/dev/sda1
+} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 sync
 poweroff -f

--- a/test/TEST-10-RAID/test-init.sh
+++ b/test/TEST-10-RAID/test-init.sh
@@ -1,19 +1,24 @@
 #!/bin/sh
+: > /dev/watchdog
+
 . /lib/dracut-lib.sh
 
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/sda1
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+
 export TERM=linux
 export PS1='initramfs-test:\w\$ '
 [ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
 [ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
 stty sane
 echo "made it to the rootfs!"
-getargbool 0 rd.shell && sh -i
+if getargbool 0 rd.shell; then
+    strstr "$(setsid --help)" "control" && CTTY="-c"
+    setsid $CTTY sh -i
+fi
 echo "Powering down."
 mount -n -o remount,ro /
-sync
 poweroff -f

--- a/test/TEST-11-LVM/99-idesymlinks.rules
+++ b/test/TEST-11-LVM/99-idesymlinks.rules
@@ -1,8 +1,0 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hda", SYMLINK+="sda"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hda*", SYMLINK+="sda$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdb", SYMLINK+="sdb"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdb*", SYMLINK+="sdb$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdc", SYMLINK+="sdc"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdc*", SYMLINK+="sdc$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdd", SYMLINK+="sdd"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdd*", SYMLINK+="sdd$env{MINOR}"

--- a/test/TEST-11-LVM/create-root.sh
+++ b/test/TEST-11-LVM/create-root.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"
@@ -6,28 +9,20 @@ done
 rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
-# save a partition at the beginning for future flagging purposes
-sfdisk /dev/sda << EOF
-,2M
-,20M
-,20M
-,20M
-EOF
-udevadm settle
-for i in sda2 sda3 sda4; do
-    lvm pvcreate -ff -y /dev/$i
-done \
-    && lvm vgcreate dracut /dev/sda[234] \
-    && lvm lvcreate -l 100%FREE -n root dracut \
-    && lvm vgchange -ay \
-    && mke2fs /dev/dracut/root \
-    && mkdir -p /sysroot \
-    && mount /dev/dracut/root /sysroot \
-    && cp -a -t /sysroot /source/* \
-    && umount /sysroot \
-    && sleep 1 \
-    && lvm lvchange -a n /dev/dracut/root \
-    && sleep 1 \
-    && echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sda1
-sync
+
+set -ex
+for dev in /dev/disk/by-id/ata-disk_disk[123]; do
+    lvm pvcreate -ff -y "$dev"
+done
+
+lvm vgcreate dracut /dev/disk/by-id/ata-disk_disk[123]
+lvm lvcreate -l 100%FREE -n root dracut
+lvm vgchange -ay
+mke2fs /dev/dracut/root
+mkdir -p /sysroot
+mount /dev/dracut/root /sysroot
+cp -a -t /sysroot /source/*
+umount /sysroot
+lvm lvchange -a n /dev/dracut/root
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 poweroff -f

--- a/test/TEST-11-LVM/test-init.sh
+++ b/test/TEST-11-LVM/test-init.sh
@@ -1,19 +1,24 @@
 #!/bin/sh
+: > /dev/watchdog
+
 . /lib/dracut-lib.sh
 
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/sda1
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+
 export TERM=linux
 export PS1='initramfs-test:\w\$ '
 [ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
 [ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
 stty sane
 echo "made it to the rootfs!"
-getargbool 0 rd.shell && sh -i
+if getargbool 0 rd.shell; then
+    strstr "$(setsid --help)" "control" && CTTY="-c"
+    setsid $CTTY sh -i
+fi
 echo "Powering down."
 mount -n -o remount,ro /
-sync
 poweroff -f

--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -9,17 +9,24 @@ KVERSION=${KVERSION-$(uname -r)}
 #DEBUGFAIL="rd.break rd.shell"
 
 test_run() {
+    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
+    declare -a disk_args=()
+    # shellcheck disable=SC2034
+    declare -i disk_index=0
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-3.img disk3
+
     "$testdir"/run-qemu \
-        -drive format=raw,index=0,media=disk,file="$TESTDIR"/root.ext2 \
+        "${disk_args[@]}" \
         -append "panic=1 systemd.crash_reboot root=/dev/dracut/root rw rd.auto=1 quiet rd.retry=3 rd.info console=ttyS0,115200n81 selinux=0 rd.debug rd.shell=0 $DEBUGFAIL" \
-        -initrd "$TESTDIR"/initramfs.testing
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success "$TESTDIR"/root.ext2 || return 1
+        -initrd "$TESTDIR"/initramfs.testing || return 1
+
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success "$TESTDIR"/marker.img
 }
 
 test_setup() {
-    # Create the blank file to use as a root filesystem
-    dd if=/dev/zero of="$TESTDIR"/root.ext2 bs=1M count=80
-
     kernel=$KVERSION
     # Create what will eventually be our root filesystem onto an overlay
     (
@@ -69,7 +76,6 @@ test_setup() {
         inst_multiple sfdisk mke2fs poweroff cp umount dd sync
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
-        inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
     )
 
     # create an initramfs that will create the target root filesystem.
@@ -81,11 +87,26 @@ test_setup() {
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
-    # Invoke KVM and/or QEMU to actually create the target filesystem.
-    "$testdir"/run-qemu -drive format=raw,index=0,media=disk,file="$TESTDIR"/root.ext2 \
+
+    # Create the blank files to use as a root filesystem
+    dd if=/dev/zero of="$TESTDIR"/disk-1.img bs=1MiB count=40
+    dd if=/dev/zero of="$TESTDIR"/disk-2.img bs=1MiB count=40
+    dd if=/dev/zero of="$TESTDIR"/disk-3.img bs=1MiB count=40
+    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
+    declare -a disk_args=()
+    # shellcheck disable=SC2034
+    declare -i disk_index=0
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-3.img disk3
+
+    "$testdir"/run-qemu \
+        "${disk_args[@]}" \
         -append "root=/dev/fakeroot rw rootfstype=ext2 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/root.ext2 || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
+
     (
         # shellcheck disable=SC2031
         export initdir=$TESTDIR/overlay
@@ -94,7 +115,6 @@ test_setup() {
         inst_multiple poweroff shutdown dd
         inst_hook shutdown-emergency 000 ./hard-off.sh
         inst_hook emergency 000 ./hard-off.sh
-        inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
     )
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \

--- a/test/TEST-12-RAID-DEG/99-idesymlinks.rules
+++ b/test/TEST-12-RAID-DEG/99-idesymlinks.rules
@@ -1,8 +1,0 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hda", SYMLINK+="sda"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hda*", SYMLINK+="sda$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdb", SYMLINK+="sdb"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdb*", SYMLINK+="sdb$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdc", SYMLINK+="sdc"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdc*", SYMLINK+="sdc$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdd", SYMLINK+="sdd"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdd*", SYMLINK+="sdd$env{MINOR}"

--- a/test/TEST-12-RAID-DEG/create-root.sh
+++ b/test/TEST-12-RAID-DEG/create-root.sh
@@ -1,24 +1,22 @@
 #!/bin/sh
-# don't let udev and this script step on eachother's toes
 
 trap 'poweroff -f' EXIT
 
+# don't let udev and this script step on eachother's toes
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"
 done
 rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
-sleep 1
-mdadm --create /dev/md0 --run --auto=yes --level=5 --raid-devices=3 /dev/sdb /dev/sdc /dev/sdd
+set -ex
+mdadm --create /dev/md0 --run --auto=yes --level=5 --raid-devices=3 /dev/disk/by-id/ata-disk_raid[123]
 # wait for the array to finish initailizing, otherwise this sometimes fails
 # randomly.
-mdadm -W /dev/md0
+mdadm -W /dev/md0 || :
 printf test > keyfile
 cryptsetup -q luksFormat /dev/md0 /keyfile
 echo "The passphrase is test"
-set -e
-set -x
 cryptsetup luksOpen /dev/md0 dracut_crypt_test < /keyfile
 lvm pvcreate -ff -y /dev/mapper/dracut_crypt_test
 lvm vgcreate dracut /dev/mapper/dracut_crypt_test
@@ -44,6 +42,6 @@ eval "$(udevadm info --query=env --name=/dev/md0 | while read -r line || [ -n "$
     echo "dracut-root-block-created"
     echo MD_UUID="$MD_UUID"
     echo "ID_FS_UUID=$ID_FS_UUID"
-} | dd oflag=direct,dsync of=/dev/sda
+} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 sync
 poweroff -f

--- a/test/TEST-12-RAID-DEG/test-init.sh
+++ b/test/TEST-12-RAID-DEG/test-init.sh
@@ -1,23 +1,27 @@
 #!/bin/sh
+: > /dev/watchdog
+
 . /lib/dracut-lib.sh
 
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/sda
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+
 export TERM=linux
 export PS1='initramfs-test:\w\$ '
 [ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
 [ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
 stty sane
 echo "made it to the rootfs!"
-getargbool 0 rd.shell && sh -i
+if getargbool 0 rd.shell; then
+    strstr "$(setsid --help)" "control" && CTTY="-c"
+    setsid $CTTY sh -i
+fi
 echo "Powering down."
 mount -n -o remount,ro /
-#echo " rd.break=shutdown " >> /run/initramfs/etc/cmdline
 if [ -d /run/initramfs/etc ]; then
     echo " rd.debug=0 " >> /run/initramfs/etc/cmdline
 fi
-sync
 poweroff -f

--- a/test/TEST-13-ENC-RAID-LVM/99-idesymlinks.rules
+++ b/test/TEST-13-ENC-RAID-LVM/99-idesymlinks.rules
@@ -1,8 +1,0 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hda", SYMLINK+="sda"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hda*", SYMLINK+="sda$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdb", SYMLINK+="sdb"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdb*", SYMLINK+="sdb$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdc", SYMLINK+="sdc"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdc*", SYMLINK+="sdc$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdd", SYMLINK+="sdd"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdd*", SYMLINK+="sdd$env{MINOR}"

--- a/test/TEST-13-ENC-RAID-LVM/create-root.sh
+++ b/test/TEST-13-ENC-RAID-LVM/create-root.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
 set -x
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
@@ -7,53 +10,41 @@ done
 rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
-# save a partition at the beginning for future flagging purposes
-sfdisk /dev/sda << EOF
-,4M
-,43M
-,43M
-,43M
-EOF
-udevadm settle
+
+set -ex
 printf test > keyfile
-cryptsetup -q luksFormat /dev/sda2 /keyfile
-cryptsetup -q luksFormat /dev/sda3 /keyfile
-cryptsetup -q luksFormat /dev/sda4 /keyfile
-cryptsetup luksOpen /dev/sda2 dracut_sda2 < /keyfile
-cryptsetup luksOpen /dev/sda3 dracut_sda3 < /keyfile
-cryptsetup luksOpen /dev/sda4 dracut_sda4 < /keyfile
-mdadm --create /dev/md0 --run --auto=yes --level=5 --raid-devices=3 /dev/mapper/dracut_sda2 /dev/mapper/dracut_sda3 /dev/mapper/dracut_sda4
+cryptsetup -q luksFormat /dev/disk/by-id/ata-disk_disk1 /keyfile
+cryptsetup -q luksFormat /dev/disk/by-id/ata-disk_disk2 /keyfile
+cryptsetup -q luksFormat /dev/disk/by-id/ata-disk_disk3 /keyfile
+cryptsetup luksOpen /dev/disk/by-id/ata-disk_disk1 dracut_disk1 < /keyfile
+cryptsetup luksOpen /dev/disk/by-id/ata-disk_disk2 dracut_disk2 < /keyfile
+cryptsetup luksOpen /dev/disk/by-id/ata-disk_disk3 dracut_disk3 < /keyfile
+mdadm --create /dev/md0 --run --auto=yes --level=5 --raid-devices=3 /dev/mapper/dracut_disk1 /dev/mapper/dracut_disk2 /dev/mapper/dracut_disk3
 # wait for the array to finish initailizing, otherwise this sometimes fails
 # randomly.
 mdadm -W /dev/md0
-lvm pvcreate -ff -y /dev/md0 \
-    && lvm vgcreate dracut /dev/md0 \
-    && lvm lvcreate -l 100%FREE -n root dracut \
-    && lvm vgchange -ay \
-    && mke2fs /dev/dracut/root \
-    && mkdir -p /sysroot \
-    && mount /dev/dracut/root /sysroot \
-    && cp -a -t /sysroot /source/* \
-    && umount /sysroot \
-    && sleep 2 \
-    && lvm lvchange -a n /dev/dracut/root \
-    && sleep 2 \
-    && lvm vgchange -a n dracut \
-    && {
-        lvm vgdisplay \
-            && { mdadm -W /dev/md0 || :; } \
-            && mdadm --stop /dev/md0 \
-            && cryptsetup luksClose /dev/mapper/dracut_sda2 \
-            && cryptsetup luksClose /dev/mapper/dracut_sda3 \
-            && cryptsetup luksClose /dev/mapper/dracut_sda4 \
-            && :
-        :
-    } \
-    && {
-        echo "dracut-root-block-created"
-        for i in /dev/sda[234]; do
-            udevadm info --query=env --name="$i" | grep -F 'ID_FS_UUID='
-        done
-    } | dd oflag=direct,dsync of=/dev/sda1
+lvm pvcreate -ff -y /dev/md0
+lvm vgcreate dracut /dev/md0
+
+lvm lvcreate -l 100%FREE -n root dracut
+lvm vgchange -ay
+mke2fs /dev/dracut/root
+mkdir -p /sysroot
+mount /dev/dracut/root /sysroot
+cp -a -t /sysroot /source/*
+umount /sysroot
+lvm lvchange -a n /dev/dracut/root
+mdadm -W /dev/md0 || :
+mdadm --stop /dev/md0
+cryptsetup luksClose /dev/mapper/dracut_disk1
+cryptsetup luksClose /dev/mapper/dracut_disk2
+cryptsetup luksClose /dev/mapper/dracut_disk3
+
+{
+    echo "dracut-root-block-created"
+    for i in /dev/disk/by-id/ata-disk_disk[123]; do
+        udevadm info --query=env --name="$i" | grep -F 'ID_FS_UUID='
+    done
+} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 sync
 poweroff -f

--- a/test/TEST-13-ENC-RAID-LVM/test-init.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test-init.sh
@@ -1,11 +1,27 @@
 #!/bin/sh
+: > /dev/watchdog
+
+. /lib/dracut-lib.sh
+
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin
+command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/sdb
+
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+
 export TERM=linux
 export PS1='initramfs-test:\w\$ '
-[ -f /etc/fstab ] || ln -s /proc/mounts /etc/fstab
+[ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
+[ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
 stty sane
-echo "made it to the rootfs! Powering down."
+echo "made it to the rootfs!"
+if getargbool 0 rd.shell; then
+    strstr "$(setsid --help)" "control" && CTTY="-c"
+    setsid $CTTY sh -i
+fi
+echo "Powering down."
 mount -n -o remount,ro /
+if [ -d /run/initramfs/etc ]; then
+    echo " rd.debug=0 " >> /run/initramfs/etc/cmdline
+fi
 poweroff -f

--- a/test/TEST-13-ENC-RAID-LVM/test.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test.sh
@@ -12,47 +12,49 @@ KVERSION=${KVERSION-$(uname -r)}
 test_run() {
     LUKSARGS=$(cat "$TESTDIR"/luks.txt)
 
-    dd if=/dev/zero of="$TESTDIR"/check-success.img bs=1M count=1
+    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
 
     echo "CLIENT TEST START: $LUKSARGS"
+
+    declare -a disk_args=()
+    # shellcheck disable=SC2034
+    declare -i disk_index=0
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-3.img disk3
+
     "$testdir"/run-qemu \
-        -drive format=raw,index=0,media=disk,file="$TESTDIR"/root.ext2 \
-        -drive format=raw,index=1,media=disk,file="$TESTDIR"/check-success.img \
+        "${disk_args[@]}" \
         -append "panic=1 systemd.crash_reboot root=/dev/dracut/root rw rd.auto rd.retry=20 console=ttyS0,115200n81 selinux=0 rd.debug rootwait $LUKSARGS rd.shell=0 $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success "$TESTDIR"/check-success.img || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success "$TESTDIR"/marker.img || return 1
     echo "CLIENT TEST END: [OK]"
 
-    dd if=/dev/zero of="$TESTDIR"/check-success.img bs=1M count=1
+    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
 
     echo "CLIENT TEST START: Any LUKS"
     "$testdir"/run-qemu \
-        -drive format=raw,index=0,media=disk,file="$TESTDIR"/root.ext2 \
-        -drive format=raw,index=1,media=disk,file="$TESTDIR"/check-success.img \
+        "${disk_args[@]}" \
         -append "panic=1 systemd.crash_reboot root=/dev/dracut/root rw quiet rd.auto rd.retry=20 rd.info console=ttyS0,115200n81 selinux=0 rd.debug  $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success "$TESTDIR"/check-success.img || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success "$TESTDIR"/marker.img || return 1
     echo "CLIENT TEST END: [OK]"
 
-    dd if=/dev/zero of="$TESTDIR"/check-success.img bs=1M count=1
+    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
 
     echo "CLIENT TEST START: Wrong LUKS UUID"
     "$testdir"/run-qemu \
-        -drive format=raw,index=0,media=disk,file="$TESTDIR"/root.ext2 \
-        -drive format=raw,index=1,media=disk,file="$TESTDIR"/check-success.img \
+        "${disk_args[@]}" \
         -append "panic=1 systemd.crash_reboot root=/dev/dracut/root rw quiet rd.auto rd.retry=10 rd.info console=ttyS0,115200n81 selinux=0 rd.debug  $DEBUGFAIL rd.luks.uuid=failme" \
         -initrd "$TESTDIR"/initramfs.testing
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success "$TESTDIR"/check-success.img && return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success "$TESTDIR"/marker.img && return 1
     echo "CLIENT TEST END: [OK]"
 
     return 0
 }
 
 test_setup() {
-    # Create the blank file to use as a root filesystem
-    rm -f -- "$TESTDIR"/root.ext2
-    dd if=/dev/zero of="$TESTDIR"/root.ext2 bs=1M count=134
-
     kernel=$KVERSION
     # Create what will eventually be our root filesystem onto an overlay
     (
@@ -77,6 +79,12 @@ test_setup() {
         inst_multiple -o ${_terminfodir}/l/linux
         inst "$basedir/modules.d/35network-legacy/dhclient-script.sh" "/sbin/dhclient-script"
         inst "$basedir/modules.d/35network-legacy/ifup.sh" "/sbin/ifup"
+
+        inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
+        ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
+        ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
+
         inst_multiple grep
         inst_simple /etc/os-release
         inst ./test-init.sh /sbin/init
@@ -95,7 +103,6 @@ test_setup() {
         inst_multiple sfdisk mke2fs poweroff cp umount grep dd sync
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
-        inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
     )
 
     # create an initramfs that will create the target root filesystem.
@@ -107,12 +114,26 @@ test_setup() {
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
-    # Invoke KVM and/or QEMU to actually create the target filesystem.
-    "$testdir"/run-qemu -drive format=raw,index=0,media=disk,file="$TESTDIR"/root.ext2 \
+
+    # Create the blank files to use as a root filesystem
+    dd if=/dev/zero of="$TESTDIR"/disk-1.img bs=1MiB count=40
+    dd if=/dev/zero of="$TESTDIR"/disk-2.img bs=1MiB count=40
+    dd if=/dev/zero of="$TESTDIR"/disk-3.img bs=1MiB count=40
+    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
+    declare -a disk_args=()
+    # shellcheck disable=SC2034
+    declare -i disk_index=0
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-3.img disk3
+
+    "$testdir"/run-qemu \
+        "${disk_args[@]}" \
         -append "root=/dev/fakeroot rw rootfstype=ext2 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/root.ext2 || return 1
-    cryptoUUIDS=$(grep -F --binary-files=text -m 3 ID_FS_UUID "$TESTDIR"/root.ext2)
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
+    cryptoUUIDS=$(grep -F --binary-files=text -m 3 ID_FS_UUID "$TESTDIR"/marker.img)
     for uuid in $cryptoUUIDS; do
         eval "$uuid"
         printf ' rd.luks.uuid=luks-%s ' "$ID_FS_UUID"
@@ -126,16 +147,16 @@ test_setup() {
         inst_multiple poweroff shutdown dd
         inst_hook shutdown-emergency 000 ./hard-off.sh
         inst_hook emergency 000 ./hard-off.sh
-        inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
         inst ./cryptroot-ask.sh /sbin/cryptroot-ask
         mkdir -p "$initdir"/etc
-        i=2
+        i=1
         for uuid in $cryptoUUIDS; do
             eval "$uuid"
-            printf 'luks-%s /dev/sda%s /etc/key timeout=0\n' "$ID_FS_UUID" $i
+            printf 'luks-%s /dev/disk/by-id/ata-disk_disk%s /etc/key timeout=0\n' "$ID_FS_UUID" $i
             ((i += 1))
         done > "$initdir"/etc/crypttab
         echo -n test > "$initdir"/etc/key
+        chmod 0600 "$initdir"/etc/key
     )
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \

--- a/test/TEST-14-IMSM/99-idesymlinks.rules
+++ b/test/TEST-14-IMSM/99-idesymlinks.rules
@@ -1,8 +1,0 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hda", SYMLINK+="sda"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hda*", SYMLINK+="sda$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdb", SYMLINK+="sdb"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdb*", SYMLINK+="sdb$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdc", SYMLINK+="sdc"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdc*", SYMLINK+="sdc$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdd", SYMLINK+="sdd"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdd*", SYMLINK+="sdd$env{MINOR}"

--- a/test/TEST-14-IMSM/create-root.sh
+++ b/test/TEST-14-IMSM/create-root.sh
@@ -12,11 +12,7 @@ udevadm control --reload
 udevadm settle
 
 # dmraid does not want symlinks in --disk "..."
-if [ -e /dev/hda ]; then
-    echo y | dmraid -f isw -C Test0 --type 1 --disk "/dev/hdb /dev/hdc"
-else
-    echo y | dmraid -f isw -C Test0 --type 1 --disk "/dev/sdb /dev/sdc"
-fi
+echo y | dmraid -f isw -C Test0 --type 1 --disk "$(realpath /dev/disk/by-id/ata-disk_disk1) $(realpath /dev/disk/by-id/ata-disk_disk2)"
 udevadm settle
 
 SETS=$(dmraid -c -s)
@@ -78,7 +74,7 @@ echo "MD_UUID=$MD_UUID"
 {
     echo "dracut-root-block-created"
     echo MD_UUID="$MD_UUID"
-} | dd oflag=direct,dsync of=/dev/sda
+} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 mdadm --wait-clean /dev/md0
 sync
 poweroff -f

--- a/test/TEST-14-IMSM/test-init.sh
+++ b/test/TEST-14-IMSM/test-init.sh
@@ -1,19 +1,27 @@
 #!/bin/sh
+: > /dev/watchdog
+
 . /lib/dracut-lib.sh
 
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/sda
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+
 export TERM=linux
 export PS1='initramfs-test:\w\$ '
-cat /proc/mdstat
-[ -f /etc/fstab ] || ln -s /proc/mounts /etc/fstab
+[ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
+[ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
 stty sane
 echo "made it to the rootfs!"
-getargbool 0 rd.shell && sh -i
+if getargbool 0 rd.shell; then
+    strstr "$(setsid --help)" "control" && CTTY="-c"
+    setsid $CTTY sh -i
+fi
 echo "Powering down."
 mount -n -o remount,ro /
-sync
+if [ -d /run/initramfs/etc ]; then
+    echo " rd.debug=0 " >> /run/initramfs/etc/cmdline
+fi
 poweroff -f

--- a/test/TEST-15-BTRFSRAID/99-idesymlinks.rules
+++ b/test/TEST-15-BTRFSRAID/99-idesymlinks.rules
@@ -1,8 +1,0 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hda", SYMLINK+="sda"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hda*", SYMLINK+="sda$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdb", SYMLINK+="sdb"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdb*", SYMLINK+="sdb$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdc", SYMLINK+="sdc"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdc*", SYMLINK+="sdc$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdd", SYMLINK+="sdd"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdd*", SYMLINK+="sdd$env{MINOR}"

--- a/test/TEST-15-BTRFSRAID/create-root.sh
+++ b/test/TEST-15-BTRFSRAID/create-root.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"
@@ -6,24 +9,20 @@ done
 modprobe btrfs
 udevadm control --reload
 udevadm settle
-# save a partition at the beginning for future flagging purposes
-sfdisk -X gpt /dev/sda << EOF
-,10M
-,200M
-,200M
-,200M
-,200M
-EOF
+
+set -e
+
+mkfs.btrfs -draid10 -mraid10 -L root /dev/disk/by-id/ata-disk_raid[1234]
 udevadm settle
-mkfs.btrfs -draid10 -mraid10 -L root /dev/sda2 /dev/sda3 /dev/sda4 /dev/sda5
-udevadm settle
+
 btrfs device scan
 udevadm settle
-set -e
+
 mkdir -p /sysroot
-mount -t btrfs /dev/sda5 /sysroot
+mount -t btrfs /dev/disk/by-id/ata-disk_raid4 /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sda1
+
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 sync
 poweroff -f

--- a/test/TEST-15-BTRFSRAID/test-init.sh
+++ b/test/TEST-15-BTRFSRAID/test-init.sh
@@ -1,12 +1,25 @@
 #!/bin/sh
+: > /dev/watchdog
+
+. /lib/dracut-lib.sh
+
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin
+command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/sda
-sync
+
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+
 export TERM=linux
 export PS1='initramfs-test:\w\$ '
-[ -f /etc/fstab ] || ln -s /proc/mounts /etc/fstab
+[ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
+[ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
 stty sane
-echo "made it to the rootfs! Powering down."
+echo "made it to the rootfs!"
+if getargbool 0 rd.shell; then
+    strstr "$(setsid --help)" "control" && CTTY="-c"
+    setsid $CTTY sh -i
+fi
+echo "Powering down."
 mount -n -o remount,ro /
+
 poweroff -f

--- a/test/TEST-15-BTRFSRAID/test.sh
+++ b/test/TEST-15-BTRFSRAID/test.sh
@@ -7,15 +7,21 @@ KVERSION=${KVERSION-$(uname -r)}
 # Uncomment this to debug failures
 #DEBUGFAIL="rd.shell"
 test_run() {
-    DISKIMAGE=$TESTDIR/TEST-15-BTRFSRAID-root.img
-    MARKER_DISKIMAGE=$TESTDIR/TEST-15-BTRFSRAID-marker.img
-    dd if=/dev/zero of="$MARKER_DISKIMAGE" bs=512 count=10
+    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
+    declare -a disk_args=()
+    # shellcheck disable=SC2034
+    declare -i disk_index=0
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-2.img raid2
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-3.img raid3
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-4.img raid4
+
     "$testdir"/run-qemu \
-        -drive format=raw,index=0,media=disk,file="$MARKER_DISKIMAGE" \
-        -drive format=raw,index=1,media=disk,file="$DISKIMAGE" \
+        "${disk_args[@]}" \
         -append "panic=1 systemd.crash_reboot root=LABEL=root rw rd.retry=3 rd.info console=ttyS0,115200n81 selinux=0 rd.shell=0 $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success "$MARKER_DISKIMAGE" || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success "$TESTDIR"/marker.img || return 1
 }
 
 test_setup() {
@@ -48,6 +54,12 @@ test_setup() {
         inst_multiple -o ${_terminfodir}/l/linux
         inst "$basedir/modules.d/35network-legacy/dhclient-script.sh" "/sbin/dhclient-script"
         inst "$basedir/modules.d/35network-legacy/ifup.sh" "/sbin/ifup"
+
+        inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
+        ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
+        ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
+
         inst_multiple grep
         inst ./test-init.sh /sbin/init
         inst_simple /etc/os-release
@@ -66,7 +78,6 @@ test_setup() {
         inst_multiple sfdisk mkfs.btrfs poweroff cp umount dd sync
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
-        inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
     )
 
     # create an initramfs that will create the target root filesystem.
@@ -81,13 +92,27 @@ test_setup() {
 
     rm -rf -- "$TESTDIR"/overlay
 
-    # Invoke KVM and/or QEMU to actually create the target filesystem.
+    # Create the blank files to use as a root filesystem
+    dd if=/dev/zero of="$TESTDIR"/raid-1.img bs=1MiB count=150
+    dd if=/dev/zero of="$TESTDIR"/raid-2.img bs=1MiB count=150
+    dd if=/dev/zero of="$TESTDIR"/raid-3.img bs=1MiB count=150
+    dd if=/dev/zero of="$TESTDIR"/raid-4.img bs=1MiB count=150
+    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
+    declare -a disk_args=()
+    # shellcheck disable=SC2034
+    declare -i disk_index=0
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-2.img raid2
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-3.img raid3
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-4.img raid4
+
     "$testdir"/run-qemu \
-        -drive format=raw,index=0,media=disk,file="$DISKIMAGE" \
+        "${disk_args[@]}" \
         -append "root=/dev/fakeroot rw quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
 
-    dd if="$DISKIMAGE" bs=512 count=4 skip=2048 | grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
 
     (
         # shellcheck disable=SC2031
@@ -97,7 +122,6 @@ test_setup() {
         inst_multiple poweroff shutdown
         inst_hook shutdown-emergency 000 ./hard-off.sh
         inst_hook emergency 000 ./hard-off.sh
-        inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
     )
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \

--- a/test/TEST-16-DMSQUASH/99-idesymlinks.rules
+++ b/test/TEST-16-DMSQUASH/99-idesymlinks.rules
@@ -1,8 +1,0 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hda", SYMLINK+="sda"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hda*", SYMLINK+="sda$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdb", SYMLINK+="sdb"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdb*", SYMLINK+="sdb$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdc", SYMLINK+="sdc"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdc*", SYMLINK+="sdc$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdd", SYMLINK+="sdd"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdd*", SYMLINK+="sdd$env{MINOR}"

--- a/test/TEST-16-DMSQUASH/create.py
+++ b/test/TEST-16-DMSQUASH/create.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python3 -tt
 #
 # livecd-creator : Creates Live CD based for Fedora.
 #

--- a/test/TEST-16-DMSQUASH/test-init.sh
+++ b/test/TEST-16-DMSQUASH/test-init.sh
@@ -1,19 +1,25 @@
 #!/bin/sh
+: > /dev/watchdog
+
 . /lib/dracut-lib.sh
 
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/sdb
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+
 export TERM=linux
 export PS1='initramfs-test:\w\$ '
 [ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
 [ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
 stty sane
 echo "made it to the rootfs!"
-getargbool 0 rd.shell && sh -i
+if getargbool 0 rd.shell; then
+    strstr "$(setsid --help)" "control" && CTTY="-c"
+    setsid $CTTY sh -i
+fi
 echo "Powering down."
 mount -n -o remount,ro /
-sync
+
 poweroff -f

--- a/test/TEST-17-LVM-THIN/99-idesymlinks.rules
+++ b/test/TEST-17-LVM-THIN/99-idesymlinks.rules
@@ -1,8 +1,0 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hda", SYMLINK+="sda"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hda*", SYMLINK+="sda$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdb", SYMLINK+="sdb"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdb*", SYMLINK+="sdb$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdc", SYMLINK+="sdc"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdc*", SYMLINK+="sdc$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdd", SYMLINK+="sdd"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdd*", SYMLINK+="sdd$env{MINOR}"

--- a/test/TEST-17-LVM-THIN/create-root.sh
+++ b/test/TEST-17-LVM-THIN/create-root.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"
@@ -6,30 +9,26 @@ done
 rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
-# save a partition at the beginning for future flagging purposes
-sfdisk /dev/sda << EOF
-,4M
-,29M
-,29M
-,29M
-EOF
-udevadm settle
-for i in sda2 sda3 sda4; do
-    lvm pvcreate -ff -y /dev/$i
-done \
-    && lvm vgcreate dracut /dev/sda[234] \
-    && lvm lvcreate -l 17 -T dracut/mythinpool \
-    && lvm lvcreate -V1G -T dracut/mythinpool -n root \
-    && lvm vgchange -ay \
-    && mke2fs /dev/dracut/root \
-    && mkdir -p /sysroot \
-    && mount /dev/dracut/root /sysroot \
-    && cp -a -t /sysroot /source/* \
-    && umount /sysroot \
-    && sleep 1 \
-    && lvm lvchange -a n /dev/dracut/root \
-    && sleep 1
-dmsetup status | grep out_of_data_space \
-    || echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sda1
+
+set -ex
+for dev in /dev/disk/by-id/ata-disk_disk[123]; do
+    lvm pvcreate -ff -y "$dev"
+done
+
+lvm vgcreate dracut /dev/disk/by-id/ata-disk_disk[123]
+lvm lvcreate -l 17 -T dracut/mythinpool
+lvm lvcreate -V1G -T dracut/mythinpool -n root
+lvm vgchange -ay
+mke2fs /dev/dracut/root
+mkdir -p /sysroot
+mount /dev/dracut/root /sysroot
+cp -a -t /sysroot /source/*
+umount /sysroot
+lvm lvchange -a n /dev/dracut/root
+
+if ! dmsetup status | grep -q out_of_data_space; then
+    echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+fi
+
 sync
 poweroff -f

--- a/test/TEST-17-LVM-THIN/test-init.sh
+++ b/test/TEST-17-LVM-THIN/test-init.sh
@@ -1,19 +1,24 @@
 #!/bin/sh
+: > /dev/watchdog
+
 . /lib/dracut-lib.sh
 
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/sda1
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+
 export TERM=linux
 export PS1='initramfs-test:\w\$ '
 [ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
 [ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
 stty sane
 echo "made it to the rootfs!"
-getargbool 0 rd.shell && sh -i
+if getargbool 0 rd.shell; then
+    strstr "$(setsid --help)" "control" && CTTY="-c"
+    setsid $CTTY sh -i
+fi
 echo "Powering down."
 mount -n -o remount,ro /
-sync
 poweroff -f

--- a/test/TEST-20-NFS/99-idesymlinks.rules
+++ b/test/TEST-20-NFS/99-idesymlinks.rules
@@ -1,8 +1,0 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hda", SYMLINK+="sda"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hda*", SYMLINK+="sda$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdb", SYMLINK+="sdb"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdb*", SYMLINK+="sdb$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdc", SYMLINK+="sdc"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdc*", SYMLINK+="sdc$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdd", SYMLINK+="sdd"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdd*", SYMLINK+="sdd$env{MINOR}"

--- a/test/TEST-20-NFS/client-init.sh
+++ b/test/TEST-20-NFS/client-init.sh
@@ -19,7 +19,7 @@ echo "made it to the rootfs! Powering down."
 
 while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
     [ "$fstype" != "nfs" -a "$fstype" != "nfs4" ] && continue
-    echo "nfs-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/sda
+    echo "nfs-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
     break
 done < /proc/mounts
 

--- a/test/TEST-20-NFS/create-root.sh
+++ b/test/TEST-20-NFS/create-root.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"
@@ -7,20 +10,14 @@ rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
 
-set -e
-# save a partition at the beginning for future flagging purposes
-sfdisk /dev/sda << EOF
-,1M
-,
-EOF
+set -ex
 
-udevadm settle
-mkfs.ext3 -L dracut /dev/sda2
+mkfs.ext3 -L dracut /dev/disk/by-id/ata-disk_root
 mkdir -p /root
-mount /dev/sda2 /root
+mount /dev/disk/by-id/ata-disk_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sda1
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 sync
 poweroff -f

--- a/test/TEST-20-NFS/server-init.sh
+++ b/test/TEST-20-NFS/server-init.sh
@@ -52,15 +52,15 @@ linkup() {
     wait_for_if_link "$1" 2> /dev/null && ip link set "$1" up 2> /dev/null && wait_for_if_up "$1" 2> /dev/null
 }
 
-wait_for_if_link eth0 ens2
+wait_for_if_link eth0 enp0s1
 
 ip addr add 127.0.0.1/8 dev lo
 ip link set lo up
-ip link set dev eth0 name ens2
-ip addr add 192.168.50.1/24 dev ens2
-ip addr add 192.168.50.2/24 dev ens2
-ip addr add 192.168.50.3/24 dev ens2
-linkup ens2
+ip link set dev eth0 name enp0s1
+ip addr add 192.168.50.1/24 dev enp0s1
+ip addr add 192.168.50.2/24 dev enp0s1
+ip addr add 192.168.50.3/24 dev enp0s1
+linkup enp0s1
 
 echo > /dev/watchdog
 modprobe af_packet

--- a/test/TEST-30-ISCSI/99-idesymlinks.rules
+++ b/test/TEST-30-ISCSI/99-idesymlinks.rules
@@ -1,8 +1,0 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hda", SYMLINK+="sda"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hda*", SYMLINK+="sda$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdb", SYMLINK+="sdb"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdb*", SYMLINK+="sdb$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdc", SYMLINK+="sdc"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdc*", SYMLINK+="sdc$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdd", SYMLINK+="sdd"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdd*", SYMLINK+="sdd$env{MINOR}"

--- a/test/TEST-30-ISCSI/client-init.sh
+++ b/test/TEST-30-ISCSI/client-init.sh
@@ -11,13 +11,14 @@ stty sane
 echo "made it to the rootfs! Powering down."
 while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
     [ "$fstype" != "ext3" ] && continue
-    echo "iscsi-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/sda
+    echo "iscsi-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
     break
 done < /proc/mounts
-#sh -i
+
 if getargbool 0 rd.shell; then
     strstr "$(setsid --help)" "control" && CTTY="-c"
     setsid $CTTY sh -i
 fi
+
 sync
 poweroff -f

--- a/test/TEST-30-ISCSI/create-client-root.sh
+++ b/test/TEST-30-ISCSI/create-client-root.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"
@@ -7,25 +10,24 @@ rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
 
-echo "Size of /dev/sdc and /dev/sdd"
-blockdev --getsize64 /dev/sdc /dev/sdd
+set -ex
 
-mkfs.ext3 -j -L singleroot -F /dev/sda \
-    && mkdir -p /sysroot \
-    && mount /dev/sda /sysroot \
-    && cp -a -t /sysroot /source/* \
-    && umount /sysroot \
-    && mdadm --create /dev/md0 --run --auto=yes --level=stripe --raid-devices=2 /dev/sdc /dev/sdd \
-    && mdadm -W /dev/md0 || : \
-    && lvm pvcreate -ff -y /dev/md0 \
-    && lvm vgcreate dracut /dev/md0 \
-    && lvm lvcreate -l 100%FREE -n root dracut \
-    && lvm vgchange -ay \
-    && mkfs.ext3 -j -L sysroot /dev/dracut/root \
-    && mount /dev/dracut/root /sysroot \
-    && cp -a -t /sysroot /source/* \
-    && umount /sysroot \
-    && lvm lvchange -a n /dev/dracut/root \
-    && echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sdb
+mkfs.ext3 -j -L singleroot -F /dev/disk/by-id/ata-disk_singleroot
+mkdir -p /sysroot
+mount /dev/disk/by-id/ata-disk_singleroot /sysroot
+cp -a -t /sysroot /source/*
+umount /sysroot
+mdadm --create /dev/md0 --run --auto=yes --level=stripe --raid-devices=2 /dev/disk/by-id/ata-disk_raid0-1 /dev/disk/by-id/ata-disk_raid0-2
+mdadm -W /dev/md0 || :
+lvm pvcreate -ff -y /dev/md0
+lvm vgcreate dracut /dev/md0
+lvm lvcreate -l 100%FREE -n root dracut
+lvm vgchange -ay
+mkfs.ext3 -j -L sysroot /dev/dracut/root
+mount /dev/dracut/root /sysroot
+cp -a -t /sysroot /source/*
+umount /sysroot
+lvm lvchange -a n /dev/dracut/root
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 sync
 poweroff -f

--- a/test/TEST-30-ISCSI/create-server-root.sh
+++ b/test/TEST-30-ISCSI/create-server-root.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"
@@ -6,20 +9,12 @@ done
 rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
-set -e
-# save a partition at the beginning for future flagging purposes
-sfdisk /dev/sda << EOF
-,1M
-,
-EOF
 
-udevadm settle
-mkfs.ext3 -L dracut /dev/sda2
+mkfs.ext3 -L dracut /dev/disk/by-id/ata-disk_root
 mkdir -p /root
-mount /dev/sda2 /root
+mount /dev/disk/by-id/ata-disk_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sda1
-sync
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 poweroff -f

--- a/test/TEST-30-ISCSI/server-init.sh
+++ b/test/TEST-30-ISCSI/server-init.sh
@@ -14,27 +14,21 @@ wait_for_if_link() {
     while [ $cnt -lt 600 ]; do
         li=$(ip -o link show dev "$1" 2> /dev/null)
         [ -n "$li" ] && return 0
-        if [[ $2 ]]; then
-            li=$(ip -o link show dev "$2" 2> /dev/null)
-            [ -n "$li" ] && return 0
-        fi
         sleep 0.1
         cnt=$((cnt + 1))
     done
     return 1
 }
 
-wait_for_if_link eth0 ens2
-wait_for_if_link eth1 ens3
+wait_for_if_link enp0s1
+wait_for_if_link enp0s2
 
 ip addr add 127.0.0.1/8 dev lo
 ip link set lo up
-ip link set dev eth0 name ens2
-ip addr add 192.168.50.1/24 dev ens2
-ip link set ens2 up
-ip link set dev eth1 name ens3
-ip addr add 192.168.51.1/24 dev ens3
-ip link set ens3 up
+ip addr add 192.168.50.1/24 dev enp0s1
+ip link set enp0s1 up
+ip addr add 192.168.51.1/24 dev enp0s2
+ip link set enp0s2 up
 : > /var/lib/dhcpd/dhcpd.leases
 chmod 777 /var/lib/dhcpd/dhcpd.leases
 dhcpd -d -cf /etc/dhcpd.conf -lf /var/lib/dhcpd/dhcpd.leases &
@@ -43,9 +37,9 @@ tgtd
 tgtadm --lld iscsi --mode target --op new --tid 1 --targetname iqn.2009-06.dracut:target0
 tgtadm --lld iscsi --mode target --op new --tid 2 --targetname iqn.2009-06.dracut:target1
 tgtadm --lld iscsi --mode target --op new --tid 3 --targetname iqn.2009-06.dracut:target2
-tgtadm --lld iscsi --mode logicalunit --op new --tid 1 --lun 1 -b /dev/sdb
-tgtadm --lld iscsi --mode logicalunit --op new --tid 2 --lun 2 -b /dev/sdc
-tgtadm --lld iscsi --mode logicalunit --op new --tid 3 --lun 3 -b /dev/sdd
+tgtadm --lld iscsi --mode logicalunit --op new --tid 1 --lun 1 -b /dev/disk/by-id/ata-disk_singleroot
+tgtadm --lld iscsi --mode logicalunit --op new --tid 2 --lun 2 -b /dev/disk/by-id/ata-disk_raid0-1
+tgtadm --lld iscsi --mode logicalunit --op new --tid 3 --lun 3 -b /dev/disk/by-id/ata-disk_raid0-2
 tgtadm --lld iscsi --mode target --op bind --tid 1 -I 192.168.50.101
 tgtadm --lld iscsi --mode target --op bind --tid 2 -I 192.168.51.101
 tgtadm --lld iscsi --mode target --op bind --tid 3 -I 192.168.50.101

--- a/test/TEST-35-ISCSI-MULTI/client-init.sh
+++ b/test/TEST-35-ISCSI-MULTI/client-init.sh
@@ -14,6 +14,7 @@ while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
     echo "iscsi-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
     break
 done < /proc/mounts
+
 if getargbool 0 rd.shell; then
     strstr "$(setsid --help)" "control" && CTTY="-c"
     setsid $CTTY sh -i

--- a/test/TEST-35-ISCSI-MULTI/create-client-root.sh
+++ b/test/TEST-35-ISCSI-MULTI/create-client-root.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"

--- a/test/TEST-35-ISCSI-MULTI/create-server-root.sh
+++ b/test/TEST-35-ISCSI-MULTI/create-server-root.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"
@@ -6,8 +9,6 @@ done
 rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
-
-ls -al /dev/disk/by-id
 
 mkfs.ext3 -L dracut /dev/disk/by-id/ata-disk_root
 mkdir -p /root

--- a/test/TEST-40-NBD/99-idesymlinks.rules
+++ b/test/TEST-40-NBD/99-idesymlinks.rules
@@ -1,8 +1,0 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hda", SYMLINK+="sda"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hda*", SYMLINK+="sda$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdb", SYMLINK+="sdb"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdb*", SYMLINK+="sdb$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdc", SYMLINK+="sdc"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdc*", SYMLINK+="sdc$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdd", SYMLINK+="sdd"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdd*", SYMLINK+="sdd$env{MINOR}"

--- a/test/TEST-40-NBD/client-init.sh
+++ b/test/TEST-40-NBD/client-init.sh
@@ -1,11 +1,15 @@
 #!/bin/sh
 : > /dev/watchdog
+. /lib/dracut-lib.sh
+
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin
+command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
+
 while read -r dev fs fstype opts rest || [ -n "$dev" ]; do
     [ "$dev" = "rootfs" ] && continue
     [ "$fs" != "/" ] && continue
-    echo "nbd-OK $fstype $opts" | dd oflag=direct,dsync of=/dev/sda
+    echo "nbd-OK $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
     echo "nbd-OK $fstype $opts"
     break
 done < /proc/mounts
@@ -13,8 +17,13 @@ export TERM=linux
 export PS1='nbdclient-test:\w\$ '
 stty sane
 echo "made it to the rootfs! Powering down."
-#sh -i
-: > /dev/watchdog
-mount -n -o remount,ro / &> /dev/null
-: > /dev/watchdog
+
+if getargbool 0 rd.shell; then
+    strstr "$(setsid --help)" "control" && CTTY="-c"
+    setsid $CTTY sh -i
+fi
+
+mount -n -o remount,ro /
+
+sync
 poweroff -f

--- a/test/TEST-40-NBD/create-client-root.sh
+++ b/test/TEST-40-NBD/create-client-root.sh
@@ -1,23 +1,24 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"
 done
 rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
-udevadm settle
 set -e
 
 udevadm settle
-mkfs.ext3 -L dracut /dev/sda
+mkfs.ext3 -L dracut /dev/disk/by-id/ata-disk_root
 mkdir -p /root
-mount /dev/sda /root
+mount /dev/disk/by-id/ata-disk_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
 {
     echo "dracut-root-block-created"
     echo "ID_FS_UUID=$ID_FS_UUID"
-} | dd oflag=direct,dsync of=/dev/sdb
-sync
+} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 poweroff -f

--- a/test/TEST-40-NBD/create-encrypted-root.sh
+++ b/test/TEST-40-NBD/create-encrypted-root.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"
@@ -7,29 +10,31 @@ rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
 
+set -ex
+
 printf test > keyfile
-cryptsetup -q luksFormat /dev/sda /keyfile
+cryptsetup -q luksFormat /dev/disk/by-id/ata-disk_root /keyfile
 echo "The passphrase is test"
-cryptsetup luksOpen /dev/sda dracut_crypt_test < /keyfile \
-    && lvm pvcreate -ff -y /dev/mapper/dracut_crypt_test \
-    && lvm vgcreate dracut /dev/mapper/dracut_crypt_test \
-    && lvm lvcreate -l 100%FREE -n root dracut \
-    && lvm vgchange -ay \
-    && mkfs.ext3 -L dracut -j /dev/dracut/root \
-    && mkdir -p /sysroot \
-    && mount /dev/dracut/root /sysroot \
-    && cp -a -t /sysroot /source/* \
-    && umount /sysroot
+cryptsetup luksOpen /dev/disk/by-id/ata-disk_root dracut_crypt_test < /keyfile
+lvm pvcreate -ff -y /dev/mapper/dracut_crypt_test
+lvm vgcreate dracut /dev/mapper/dracut_crypt_test
+lvm lvcreate -l 100%FREE -n root dracut
+lvm vgchange -ay
+mkfs.ext3 -L dracut -j /dev/dracut/root
+mkdir -p /sysroot
+mount /dev/dracut/root /sysroot
+cp -a -t /sysroot /source/*
+umount /sysroot
 sleep 1
 lvm lvchange -a n /dev/dracut/root
 udevadm settle
 cryptsetup luksClose /dev/mapper/dracut_crypt_test
 udevadm settle
 sleep 1
-eval "$(udevadm info --query=env --name=/dev/sda | while read -r line || [ -n "$line" ]; do [ "$line" != "${line#*ID_FS_UUID*}" ] && echo "$line"; done)"
+eval "$(udevadm info --query=env --name=/dev/disk/by-id/ata-disk_root | while read -r line || [ -n "$line" ]; do [ "$line" != "${line#*ID_FS_UUID*}" ] && echo "$line"; done)"
 {
     echo "dracut-root-block-created"
     echo "ID_FS_UUID=$ID_FS_UUID"
-} | dd oflag=direct,dsync of=/dev/sdb
+} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 sync
 poweroff -f

--- a/test/TEST-40-NBD/create-server-root.sh
+++ b/test/TEST-40-NBD/create-server-root.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"
@@ -9,15 +12,15 @@ udevadm settle
 set -e
 
 udevadm settle
-mkfs.ext3 -L dracut /dev/sda
+mkfs.ext3 -L dracut /dev/disk/by-id/ata-disk_root
 mkdir -p /root
-mount /dev/sda /root
+mount /dev/disk/by-id/ata-disk_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
 {
     echo "dracut-root-block-created"
     echo "ID_FS_UUID=$ID_FS_UUID"
-} | dd oflag=direct,dsync of=/dev/sdb
+} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 sync
 poweroff -f

--- a/test/TEST-40-NBD/server-init.sh
+++ b/test/TEST-40-NBD/server-init.sh
@@ -14,10 +14,6 @@ wait_for_if_link() {
     while [ $cnt -lt 600 ]; do
         li=$(ip -o link show dev "$1" 2> /dev/null)
         [ -n "$li" ] && return 0
-        if [[ $2 ]]; then
-            li=$(ip -o link show dev "$2" 2> /dev/null)
-            [ -n "$li" ] && return 0
-        fi
         sleep 0.1
         cnt=$((cnt + 1))
     done
@@ -51,13 +47,12 @@ linkup() {
     wait_for_if_link "$1" 2> /dev/null && ip link set "$1" up 2> /dev/null && wait_for_if_up "$1" 2> /dev/null
 }
 
-wait_for_if_link eth0 ens3
-
 ip addr add 127.0.0.1/8 dev lo
 ip link set lo up
-ip link set dev eth0 name ens3
-ip addr add 192.168.50.1/24 dev ens3
-linkup ens3
+
+wait_for_if_link enp0s1
+ip addr add 192.168.50.1/24 dev enp0s1
+linkup enp0s1
 
 modprobe af_packet
 nbd-server

--- a/test/TEST-50-MULTINIC/99-idesymlinks.rules
+++ b/test/TEST-50-MULTINIC/99-idesymlinks.rules
@@ -1,8 +1,0 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hda", SYMLINK+="sda"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hda*", SYMLINK+="sda$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdb", SYMLINK+="sdb"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdb*", SYMLINK+="sdb$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdc", SYMLINK+="sdc"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdc*", SYMLINK+="sdc$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdd", SYMLINK+="sdd"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdd*", SYMLINK+="sdd$env{MINOR}"

--- a/test/TEST-50-MULTINIC/client-init.sh
+++ b/test/TEST-50-MULTINIC/client-init.sh
@@ -27,7 +27,7 @@ done
 {
     echo "OK"
     echo "$IFACES"
-} | dd oflag=direct,dsync of=/dev/sda
+} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 
 getargbool 0 rd.shell && sh -i
 

--- a/test/TEST-50-MULTINIC/create-root.sh
+++ b/test/TEST-50-MULTINIC/create-root.sh
@@ -1,25 +1,21 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"
 done
 rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
-udevadm settle
 set -e
-# save a partition at the beginning for future flagging purposes
-sfdisk /dev/sda << EOF
-,1M
-,
-EOF
 
 udevadm settle
-mkfs.ext3 -L dracut /dev/sda2
+mkfs.ext3 -L dracut /dev/disk/by-id/ata-disk_root
 mkdir -p /root
-mount /dev/sda2 /root
+mount /dev/disk/by-id/ata-disk_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sda1
-sync
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 poweroff -f

--- a/test/TEST-50-MULTINIC/server-init.sh
+++ b/test/TEST-50-MULTINIC/server-init.sh
@@ -15,10 +15,6 @@ wait_for_if_link() {
     while [ $cnt -lt 600 ]; do
         li=$(ip -o link show dev "$1" 2> /dev/null)
         [ -n "$li" ] && return 0
-        if [[ $2 ]]; then
-            li=$(ip -o link show dev "$2" 2> /dev/null)
-            [ -n "$li" ] && return 0
-        fi
         sleep 0.1
         cnt=$((cnt + 1))
     done
@@ -52,14 +48,14 @@ linkup() {
     wait_for_if_link "$1" 2> /dev/null && ip link set "$1" up 2> /dev/null && wait_for_if_up "$1" 2> /dev/null
 }
 
-wait_for_if_link eth0 ens2
+wait_for_if_link enp0s1
 
 : > /dev/watchdog
 ip addr add 127.0.0.1/8 dev lo
 linkup lo
-ip link set dev eth0 name ens2
-ip addr add 192.168.50.1/24 dev ens2
-linkup ens2
+
+ip addr add 192.168.50.1/24 dev enp0s1
+linkup enp0s1
 
 : > /dev/watchdog
 modprobe af_packet

--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/99-idesymlinks.rules
+++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/99-idesymlinks.rules
@@ -1,8 +1,0 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hda", SYMLINK+="sda"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hda*", SYMLINK+="sda$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdb", SYMLINK+="sdb"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdb*", SYMLINK+="sdb$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdc", SYMLINK+="sdc"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdc*", SYMLINK+="sdc$env{MINOR}"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="hdd", SYMLINK+="sdd"
-ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", KERNEL=="hdd*", SYMLINK+="sdd$env{MINOR}"

--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/create-root.sh
+++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/create-root.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+trap 'poweroff -f' EXIT
+
 # don't let udev and this script step on eachother's toes
 for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
     : > "/etc/udev/rules.d/$x"

--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
+++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
@@ -320,7 +320,6 @@ test_setup() {
         inst_multiple sfdisk mkfs.ext3 poweroff cp umount sync dd
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
-        inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
     )
 
     # create an initramfs that will create the target root filesystem.
@@ -349,7 +348,6 @@ test_setup() {
         . "$basedir"/dracut-init.sh
         inst_multiple poweroff shutdown
         inst_hook emergency 000 ./hard-off.sh
-        inst_simple ./99-idesymlinks.rules /etc/udev/rules.d/99-idesymlinks.rules
         inst_simple ./99-default.link /etc/systemd/network/99-default.link
     )
 

--- a/test/run-qemu
+++ b/test/run-qemu
@@ -18,7 +18,7 @@ export PATH=/sbin:/bin:/usr/sbin:/usr/bin
 }
 
 # Provide rng device sourcing the hosts /dev/urandom and other standard parameters
-ARGS+=(-smp 2 -m 512 -nodefaults -vga none -display none -no-reboot -device virtio-rng-pci)
+ARGS+=(-M q35 -smp 2 -m 512 -nodefaults -vga none -display none -no-reboot -device virtio-rng-pci)
 
 if ! [[ $* == *-daemonize* ]] && ! [[ $* == *-daemonize* ]]; then
     ARGS+=(-serial stdio)


### PR DESCRIPTION
Due to parallel probing of the linux kernel `/dev/sd*` can't be used to
reliably address a hard disk. This can be seen by the many spurious
failures of the dracut CI, where `mdadm` failed with error 524 or tests
failed due to the success marker message written to the wrong disk.

* don't rely on `/dev/sd*` but use disk ids and `/dev/disk/by-id/ata-disk_<name>`

* specify the exact qemu machine architecture `-M q35` needed for the
  disk ids. A later patch will move this to `run-qemu`, when all tests are converted

* due to `-M q35` the interface names have changed from
  `ens2` -> `enp0s1` and `ens3` -> `enp0s2`

