### PR TITLE
fix(systemd-modules): remove dependency on systemd meta module

### DIFF
--- a/modules.d/01systemd-ask-password/module-setup.sh
+++ b/modules.d/01systemd-ask-password/module-setup.sh
@@ -17,9 +17,7 @@ check() {
 # Module dependency requirements.
 depends() {
 
-    # This module has external dependency on the systemd module.
-    echo systemd
-    # Return 0 to include the dependent systemd module in the initramfs.
+    # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 
 }

--- a/modules.d/01systemd-coredump/module-setup.sh
+++ b/modules.d/01systemd-coredump/module-setup.sh
@@ -18,8 +18,8 @@ check() {
 depends() {
 
     # This module has external dependency on the systemd module.
-    echo systemd systemd-journald systemd-sysctl
-    # Return 0 to include the dependent systemd module in the initramfs.
+    echo systemd-journald systemd-sysctl
+    # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 
 }

--- a/modules.d/01systemd-repart/module-setup.sh
+++ b/modules.d/01systemd-repart/module-setup.sh
@@ -16,9 +16,7 @@ check() {
 # Module dependency requirements.
 depends() {
 
-    # This module has external dependency on the systemd module.
-    echo systemd
-    # Return 0 to include the dependent systemd module in the initramfs.
+    # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 
 }

--- a/modules.d/01systemd-sysctl/module-setup.sh
+++ b/modules.d/01systemd-sysctl/module-setup.sh
@@ -17,7 +17,7 @@ check() {
 depends() {
 
     # This module has external dependency on other module(s).
-    echo systemd systemd-modules-load
+    echo systemd-modules-load
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 

--- a/modules.d/01systemd-sysusers/module-setup.sh
+++ b/modules.d/01systemd-sysusers/module-setup.sh
@@ -17,9 +17,7 @@ check() {
 # Module dependency requirements.
 depends() {
 
-    # This module has external dependency on the systemd module.
-    echo systemd
-    # Return 0 to include the dependent systemd module in the initramfs.
+    # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 
 }


### PR DESCRIPTION
Depending on systemd meta module causes circular dependency,
prevents the existance of multiple systemd based meta modules
and is redunant.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
