### PR TITLE
90kernel-modules: add watchdog drivers for generic initrd

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -52,7 +52,8 @@ installkernel() {
             "=drivers/input/keyboard" \
             "=drivers/pci/host" \
             "=drivers/pci/controller" \
-            "=drivers/pinctrl"
+            "=drivers/pinctrl" \
+            "=drivers/watchdog"
 
         instmods \
             yenta_socket \


### PR DESCRIPTION
The watchdog module pulls in the device specific watchdog if that
module is enabled, but in the case where we need a generic initrd
we don't get all watchdog drivers which means if we have a watchdog
enabled for that usecase it may get kicked too late in the boot
process so we need the drivers in the initrd for the generic case too.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
