### PR TITLE
fix(systemd): include hosts and nsswitch.conf in hostonly mode

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -174,7 +174,9 @@ install() {
             /etc/systemd/journald.conf.d/*.conf \
             /etc/systemd/system.conf \
             /etc/systemd/system.conf.d/*.conf \
+            /etc/hosts \
             /etc/hostname \
+            /etc/nsswitch.conf \
             /etc/machine-id \
             /etc/machine-info \
             /etc/vconsole.conf \


### PR DESCRIPTION
Adding /etc/hosts and /etc/nsswitch.conf to the hostonly install section.

After careful consideration the systemd module is the most logical place to have this. 

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
