### PR TITLE
fix(img-lib): Fixed the "ignored null byte in input" issue

### DIFF
--- a/modules.d/99img-lib/img-lib.sh
+++ b/modules.d/99img-lib/img-lib.sh
@@ -13,7 +13,7 @@ det_archive() {
     xz="$(/bin/echo -e '\xfd7zXZ')"
     gz="$(/bin/echo -e '\x1f\x8b')"
     zs="$(/bin/echo -e '\x28\xB5\x2F\xFD')"
-    headerblock="$(dd ${1:+if=$1} bs=262 count=1 2> /dev/null)"
+    headerblock="$(dd ${1:+if=$1} bs=262 count=1 2> /dev/null | tr -d '\0')"
     case "$headerblock" in
         $xz*) echo "xz" ;;
         $gz*) echo "gzip" ;;

--- a/modules.d/99img-lib/module-setup.sh
+++ b/modules.d/99img-lib/module-setup.sh
@@ -3,7 +3,7 @@
 
 # called by dracut
 check() {
-    require_binaries tar gzip dd echo || return 1
+    require_binaries tar gzip dd echo tr || return 1
     return 255
 }
 
@@ -14,7 +14,7 @@ depends() {
 
 # called by dracut
 install() {
-    inst_multiple tar gzip dd echo
+    inst_multiple tar gzip dd echo tr
     # TODO: make this conditional on a cmdline flag / config option
     inst_multiple -o cpio xz bzip2 zstd
     inst_simple "$moddir/img-lib.sh" "/lib/img-lib.sh"


### PR DESCRIPTION
The system currently throws numerous nasty warning messages during
the boot, about ignored null bytes in input.

This patch adds a filter to the dd command, to filter these null
bytes out, and thus to prevent these warning messages.

Signed-off-by: Lev Veyde <lveyde@redhat.com>

This pull request changes...

## Changes

## Checklist
- [V] I have tested it locally

Fixes #
This patch fixes the warning messages about the "ignored null byte in input" during the boot.