### PR TITLE
fix(network-manager): create /run directories

### DIFF
--- a/modules.d/35network-manager/nm-lib.sh
+++ b/modules.d/35network-manager/nm-lib.sh
@@ -13,7 +13,9 @@ nm_generate_connections() {
             /etc/NetworkManager/system-connections/* \
             /etc/sysconfig/network-scripts/ifcfg-*; do
             [ -f "$i" ] || continue
+            mkdir -p "$hookdir"/initqueue/finished
             echo '[ -f /tmp/nm.done ]' > "$hookdir"/initqueue/finished/nm.sh
+            mkdir -p /run/NetworkManager/initrd
             : > /run/NetworkManager/initrd/neednet # activate NM services
             break
         done


### PR DESCRIPTION
Create the `/run/NetworkManager/initrd` directory before creating
`/run/NetworkManager/initrd/neednet`. Somehow on Fedora 32 this
directory is missing, when the script is running.

This fixes all NetworkManager tests for Fedora 32.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
