### PR TITLE
fix(network-manager): set timeout via command line option

### DIFF
--- a/modules.d/35network-manager/nm-wait-online-initrd.service
+++ b/modules.d/35network-manager/nm-wait-online-initrd.service
@@ -8,9 +8,8 @@ ConditionPathExists=/run/NetworkManager/initrd/neednet
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/nm-online -s -q
+ExecStart=/usr/bin/nm-online -s -q -t 3600
 RemainAfterExit=yes
-Environment=NM_ONLINE_TIMEOUT=3600
 
 [Install]
 WantedBy=initrd.target


### PR DESCRIPTION
With Fedora 32, only the command line option works for `nm-online`.

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
