### PR TITLE
feat(systemd-network-management): introducing the systemd-network-man…

### DIFF
--- a/dracut.spec
+++ b/dracut.spec
@@ -316,6 +316,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %endif
 %{dracutlibdir}/modules.d/00bash
 %{dracutlibdir}/modules.d/00systemd
+%{dracutlibdir}/modules.d/00systemd-network-management
 %ifnarch s390 s390x
 %{dracutlibdir}/modules.d/00warpclock
 %endif

--- a/modules.d/00systemd-network-management/module-setup.sh
+++ b/modules.d/00systemd-network-management/module-setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Prerequisite check(s) for module.
+check() {
+
+    # Return 255 to only include the module, if another module requires it.
+    return 255
+
+}
+
+# Module dependency requirements.
+depends() {
+
+    # This module has external dependency on other module(s).
+    echo systemd systemd-hostnamed systemd-networkd systemd-resolved systemd-timedated systemd-timesyncd
+    # Return 0 to include the dependent module(s) in the initramfs.
+    return 0
+
+}


### PR DESCRIPTION
…agement meta module

Introducing the systemd-network-management meta module which will
allow distribution users and vendors to easily include
systemd + systemd's network management modules by simply include this
module instead of systemd network modules individually.

Obviously if the intent is to glue together somekind of network stack
out of random existing modules such as NetworkManager and or Wicked,
this meta module should not be enabled.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
