### PR TITLE
fix(network): use global variable for sdnetworkd instead of path

### DIFF
--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -21,7 +21,7 @@ depends() {
             network_handler="network-wicked"
         elif [[ -x $dracutsysrootdir/usr/libexec/nm-initrd-generator ]]; then
             network_handler="network-manager"
-        elif [[ -x $dracutsysrootdir/usr/lib/systemd/systemd-networkd ]]; then
+        elif [[ -x $dracutsysrootdir$systemdutildir/systemd-networkd ]]; then
             network_handler="systemd-networkd"
         else
             network_handler="network-legacy"


### PR DESCRIPTION
Use globalvariable for systemd networkd instead of path

Pointed out by @shaba here 

https://github.com/dracutdevs/dracut/commit/ea779750c371102c04252b48f1b7d9c7ece7cf93#r49856218

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
