### PR TITLE
fix: search for btrfs devices from actual mount poiont

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1419,8 +1419,10 @@ for line in "${fstab_lines[@]}"; do
     esac
     [ -z "$dev" ] && dwarn "Bad fstab entry $*" && continue
     if [[ $3 == btrfs ]]; then
-        for i in $(btrfs_devs "$2"); do
-            push_host_devs "$i"
+        for mp in $(findmnt --source "$1" -o TARGET -n); do
+            for i in $(btrfs_devs "$mp"); do
+                push_host_devs "$i"
+            done
         done
     fi
     push_host_devs "$dev"


### PR DESCRIPTION
Currently when dracut search for btrfs device used for initramfs, it
assumes the mount points passed in with "--mount" are all mounted with
given mount path. If user want the device to be mounted to a different
location in initramfs, this will not be true.

eg. with "--mount '/dev/mapper/vol /sysroot btrfs rw,relatime,subvolid=256,subvol=/root'"
and having '/dev/mapper/vol' currently mounted on '/', will raise an
error:
    ERROR: cannot access '/sysroot': No such file or directory

So search for actual mount point of given device.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it