### PR TITLE
fix: quotes in systemd modules

### DIFF
--- a/modules.d/01systemd-coredump/module-setup.sh
+++ b/modules.d/01systemd-coredump/module-setup.sh
@@ -41,11 +41,11 @@ install() {
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$systemdutilconfdir"/coredump.conf \
-            "$systemdsystemconfdir"/coredump.conf.d/*.conf \
+            "$systemdsystemconfdir/coredump.conf.d/*.conf" \
             "$systemdsystemconfdir"/systemd-coredump.socket \
-            "$systemdsystemconfdir"/systemd-coredump.socket.d/*.conf \
+            "$systemdsystemconfdir/systemd-coredump.socket.d/*.conf" \
             "$systemdsystemconfdir"/systemd-coredump@.service \
-            "$systemdsystemconfdir"/systemd-coredump@.service.d/*.conf \
+            "$systemdsystemconfdir/systemd-coredump@.service.d/*.conf" \
             "$systemdsystemconfdir"/sockets.target.wants/systemd-coredump.socket
     fi
 }

--- a/modules.d/01systemd-repart/module-setup.sh
+++ b/modules.d/01systemd-repart/module-setup.sh
@@ -5,7 +5,7 @@
 # Prerequisite check(s) for module.
 check() {
 
-    # If the binary(s) requirements are not fulfilled the module can't be installed
+    # If the binary(s) requirements are not fulfilled the module can't be installed.
     require_binaries systemd-repart || return 1
 
     # Return 255 to only include the module, if another module requires it.
@@ -25,7 +25,7 @@ depends() {
 install() {
 
     inst_multiple -o \
-        "$libdir"/repart.d/*.conf \
+        "$libdir/repart.d/*.conf" \
         "$systemdsystemunitdir"/systemd-repart.service \
         "$systemdsystemunitdir"/initrd-root-fs.target.wants/systemd-repart.service \
         systemd-repart
@@ -33,8 +33,8 @@ install() {
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
-            /etc/repart.d/*.conf \
+            "/etc/repart.d/*.conf" \
             "$systemdsystemconfdir"/systemd-repart.service \
-            "$systemdsystemconfdir"/systemd-repart.service.d/*.conf
+            "$systemdsystemconfdir/systemd-repart.service.d/*.conf"
     fi
 }

--- a/modules.d/01systemd-sysctl/module-setup.sh
+++ b/modules.d/01systemd-sysctl/module-setup.sh
@@ -27,7 +27,7 @@ depends() {
 install() {
 
     inst_multiple -o \
-        "$sysctld"/*.conf \
+        "$sysctld/*.conf" \
         "$systemdsystemunitdir"/systemd-sysctl.service \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-sysctl.service \
         "$systemdutildir"/systemd-sysctl
@@ -36,9 +36,9 @@ install() {
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
             /etc/sysctl.conf \
-            "$sysctlconfdir"/*.conf \
+            "$sysctlconfdir/*.conf" \
             "$systemdsystemconfdir"/systemd-sysctl.service \
-            "$systemdsystemconfdir"/systemd-sysctl.service.d/*.conf
+            "$systemdsystemconfdir/systemd-sysctl.service.d/*.conf"
     fi
 
     # Enable the systemd type service unit for sysctl.

--- a/modules.d/01systemd-sysusers/module-setup.sh
+++ b/modules.d/01systemd-sysusers/module-setup.sh
@@ -41,7 +41,7 @@ install() {
             "$sysusersconfdir"/basic.conf \
             "$sysusersconfdir"/systemd.conf \
             "$systemdsystemconfdir"/systemd-sysusers.service \
-            "$systemdsystemconfdir"/systemd-sysusers.service.d/*.conf
+            "$systemdsystemconfdir/systemd-sysusers.service.d/*.conf"
     fi
 
     # Enable the systemd type service unit for sysusers.


### PR DESCRIPTION
Fixing quotes around *.conf entries in systemd modules

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
