### PR TITLE
 fix(multipath): stop multipath before udev db cleanup

### DIFF
--- a/modules.d/90multipath/multipathd.service
+++ b/modules.d/90multipath/multipathd.service
@@ -4,8 +4,10 @@ Before=iscsi.service iscsid.service lvm2-activation-early.service
 Wants=systemd-udev-trigger.service systemd-udev-settle.service local-fs-pre.target
 After=systemd-udev-trigger.service systemd-udev-settle.service
 Before=local-fs-pre.target
+Before=initrd-cleanup.service
 DefaultDependencies=no
 Conflicts=shutdown.target
+Conflicts=initrd-cleanup.service
 ConditionKernelCommandLine=!nompath
 ConditionKernelCommandLine=!rd.multipath=0
 ConditionKernelCommandLine=!rd_NO_MULTIPATH


### PR DESCRIPTION
## Changes

fix(multipath): stop multipath before udev db cleanup

All device-mapper based devices, including device-mapper-multipath,
do reuse the udev db from the initramfs after switching to the root fs.

Therefore device-mapper devices have to be correctly initialized before
the udev daemon is stopped, to have the correct entries in the udev db.

See also https://bugzilla.redhat.com/show_bug.cgi?id=1949076

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
