### PR TITLE
fix(iscsi): only rely on socket activiation

### DIFF
--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -235,21 +235,14 @@ install() {
             $SYSTEMCTL -q --root "$initdir" enable "$i"
         done
 
-        for i in \
-            iscsid.service \
-            iscsiuio.service; do
-            $SYSTEMCTL -q --root "$initdir" add-wants basic.target "$i"
-        done
-
-        # Make sure iscsid is started after dracut-cmdline and ready for the initqueue
         mkdir -p "${initdir}/$systemdsystemunitdir/iscsid.service.d"
         (
             echo "[Unit]"
-            echo "After=dracut-cmdline.service"
-            echo "Before=dracut-initqueue.service"
+            echo "DefaultDependencies=no"
+            echo "Conflicts=shutdown.target"
+            echo "Before=shutdown.target"
         ) > "${initdir}/$systemdsystemunitdir/iscsid.service.d/dracut.conf"
 
-        # The iscsi deamon does not need to wait for any storage inside initrd
         mkdir -p "${initdir}/$systemdsystemunitdir/iscsid.socket.d"
         (
             echo "[Unit]"
@@ -257,6 +250,15 @@ install() {
             echo "Conflicts=shutdown.target"
             echo "Before=shutdown.target sockets.target"
         ) > "${initdir}/$systemdsystemunitdir/iscsid.socket.d/dracut.conf"
+
+        mkdir -p "${initdir}/$systemdsystemunitdir/iscsiuio.service.d"
+        (
+            echo "[Unit]"
+            echo "DefaultDependencies=no"
+            echo "Conflicts=shutdown.target"
+            echo "Before=shutdown.target"
+        ) > "${initdir}/$systemdsystemunitdir/iscsiuio.service.d/dracut.conf"
+
         mkdir -p "${initdir}/$systemdsystemunitdir/iscsiuio.socket.d"
         (
             echo "[Unit]"


### PR DESCRIPTION
Only rely on socket activation. This speeds up in case iscsi isn't used
and also prevents failures, where iscsiuio stopping somehow disables
iscsi.

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
