### PR TITLE
test(ISCSI): fix the watchdog loop

### DIFF
--- a/test/TEST-30-ISCSI/server-init.sh
+++ b/test/TEST-30-ISCSI/server-init.sh
@@ -44,11 +44,14 @@ tgtadm --lld iscsi --mode target --op bind --tid 1 -I 192.168.50.101
 tgtadm --lld iscsi --mode target --op bind --tid 2 -I 192.168.51.101
 tgtadm --lld iscsi --mode target --op bind --tid 3 -I 192.168.50.101
 
+echo "Serving iSCSI"
+
 # Wait forever for the VM to die
-while :; do
-    echo "Serving iSCSI"
-    [ -n "$(jobs -rp)" ] && echo > /dev/watchdog
-    sleep 10
+while pidof tgtd > /dev/null; do
+    : > /dev/watchdog
+    dmesg -c
+    sleep 1
 done
+dmesg -c
 mount -n -o remount,ro /
 poweroff -f

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -244,7 +244,7 @@ test_setup() {
         inst_multiple sh ls shutdown poweroff stty cat ps ln ip \
             dmesg mkdir cp ping \
             modprobe tcpdump setsid \
-            /etc/services sleep mount chmod
+            /etc/services sleep mount chmod pidof
         inst_multiple tgtd tgtadm
         for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
             [ -f ${_terminfodir}/l/linux ] && break

--- a/test/TEST-35-ISCSI-MULTI/server-init.sh
+++ b/test/TEST-35-ISCSI-MULTI/server-init.sh
@@ -78,9 +78,11 @@ tgtadm --lld iscsi --mode target --op bind --tid 3 -I 192.168.50.101
 
 # Wait forever for the VM to die
 echo "Serving iSCSI"
-while :; do
-    [ -n "$(jobs -rp)" ] && echo > /dev/watchdog
-    sleep 10
+while pidof tgtd > /dev/null; do
+    : > /dev/watchdog
+    dmesg -c
+    sleep 1
 done
+dmesg -c
 mount -n -o remount,ro /
 poweroff -f

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -248,7 +248,7 @@ test_setup() {
         inst_multiple sh ls shutdown poweroff stty cat ps ln ip \
             dmesg mkdir cp ping \
             modprobe tcpdump setsid \
-            /etc/services sleep mount chmod
+            /etc/services sleep mount chmod pidof
         inst_multiple tgtd tgtadm
         for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
             [ -f ${_terminfodir}/l/linux ] && break


### PR DESCRIPTION
## Changes

Test for `pidof tgtd` and not the shell background jobs.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

# Fixes

Spurious ISCSI CI test failures.
