### PR TITLE
fix(iscsi): add iscsid.service requirements

### DIFF
--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -223,6 +223,7 @@ install() {
     else
         inst_multiple -o \
             "$systemdsystemunitdir"/iscsi.service \
+            "$systemdsystemunitdir"/iscsi-init.service \
             "$systemdsystemunitdir"/iscsid.service \
             "$systemdsystemunitdir"/iscsid.socket \
             "$systemdsystemunitdir"/iscsiuio.service \
@@ -236,38 +237,57 @@ install() {
         done
 
         mkdir -p "${initdir}/$systemdsystemunitdir/iscsid.service.d"
-        (
+        {
             echo "[Unit]"
             echo "DefaultDependencies=no"
             echo "Conflicts=shutdown.target"
             echo "Before=shutdown.target"
-        ) > "${initdir}/$systemdsystemunitdir/iscsid.service.d/dracut.conf"
+        } > "${initdir}/$systemdsystemunitdir/iscsid.service.d/dracut.conf"
 
         mkdir -p "${initdir}/$systemdsystemunitdir/iscsid.socket.d"
-        (
+        {
             echo "[Unit]"
             echo "DefaultDependencies=no"
             echo "Conflicts=shutdown.target"
             echo "Before=shutdown.target sockets.target"
-        ) > "${initdir}/$systemdsystemunitdir/iscsid.socket.d/dracut.conf"
+        } > "${initdir}/$systemdsystemunitdir/iscsid.socket.d/dracut.conf"
 
         mkdir -p "${initdir}/$systemdsystemunitdir/iscsiuio.service.d"
-        (
+        {
             echo "[Unit]"
             echo "DefaultDependencies=no"
             echo "Conflicts=shutdown.target"
             echo "Before=shutdown.target"
-        ) > "${initdir}/$systemdsystemunitdir/iscsiuio.service.d/dracut.conf"
+        } > "${initdir}/$systemdsystemunitdir/iscsiuio.service.d/dracut.conf"
 
         mkdir -p "${initdir}/$systemdsystemunitdir/iscsiuio.socket.d"
-        (
+        {
             echo "[Unit]"
             echo "DefaultDependencies=no"
             echo "Conflicts=shutdown.target"
             echo "Before=shutdown.target sockets.target"
-        ) > "${initdir}/$systemdsystemunitdir/iscsiuio.socket.d/dracut.conf"
+        } > "${initdir}/$systemdsystemunitdir/iscsiuio.socket.d/dracut.conf"
 
+        # Fedora 34 iscsid requires iscsi-shutdown.service
+        # which would terminate all iSCSI connections on switch root
+        cat > "${initdir}/$systemdsystemunitdir/iscsi-shutdown.service" << EOF
+[Unit]
+Description=Dummy iscsi-shutdown.service for the initrd
+Documentation=man:iscsid(8) man:iscsiadm(8)
+DefaultDependencies=no
+Conflicts=shutdown.target
+After=systemd-remount-fs.service network.target iscsid.service iscsiuio.service
+Before=remote-fs-pre.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=false
+ExecStart=-/usr/bin/true
+EOF
     fi
     inst_dir /var/lib/iscsi
+    mkdir -p "${initdir}/var/lib/iscsi/nodes"
+    # Fedora 34 iscsid wants a non-empty /var/lib/iscsi/nodes directory
+    : > "${initdir}/var/lib/iscsi/nodes/.dracut"
     dracut_need_initqueue
 }


### PR DESCRIPTION
This pull request changes...

## Changes

Since Fedora 34, iscsid.service requires:
- iscsi-init.service
- iscsi-shutdown.service
- a non-empty /var/lib/iscsi/nodes/.dracut


## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

