### PR TITLE
fix(network): use wicked unit instead of find_binary

### DIFF
--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -17,7 +17,7 @@ depends() {
     done
 
     if [ -z "$network_handler" ]; then
-        if find_binary wicked &> /dev/null; then
+        if [[ -x $dracutsysrootdir$systemdsystemunitdir/wicked.service ]]; then
             network_handler="network-wicked"
         elif [[ -x $dracutsysrootdir/usr/libexec/nm-initrd-generator ]]; then
             network_handler="network-manager"


### PR DESCRIPTION
dracut-install triggers "ERROR: installing '/usr/lib/wicked/bin/*'"
when find_binary is being used to determine if wicked is installed
so let's just check for the wicked type service unit instead.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
