### PR TITLE
fix(network-legacy): add missing options to dhclient.conf

### DIFF
--- a/modules.d/35network-legacy/dhclient.conf
+++ b/modules.d/35network-legacy/dhclient.conf
@@ -5,4 +5,7 @@ send dhcp-client-identifier = hardware;
 
 request subnet-mask, broadcast-address, time-offset, routers,
         domain-name, domain-name-servers, domain-search, host-name,
-        root-path, interface-mtu, classless-static-routes;
+        root-path, interface-mtu, classless-static-routes,
+        netbios-name-servers, netbios-scope, ntp-servers,
+        dhcp6.domain-search, dhcp6.fqdn,
+        dhcp6.name-servers, dhcp6.sntp-servers;


### PR DESCRIPTION
Adding the following commonly used options to dhclient.conf
- netbios-name-servers
- netbios-scope
- ntp-servers
- dhcp6.domain-search
- dhcp6.fqdn
- dhcp6.name-servers
- dhcp6.sntp-servers

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
