### PR TITLE
fix(squash): only load modules if they are not already loaded

### DIFF
--- a/modules.d/99squash/init-squash.sh
+++ b/modules.d/99squash/init-squash.sh
@@ -8,10 +8,10 @@ mount -t sysfs -o nosuid,noexec,nodev sysfs /sys
 mount -t devtmpfs -o mode=755,noexec,nosuid,strictatime devtmpfs /dev
 mount -t tmpfs -o mode=755,nodev,nosuid,strictatime tmpfs /run
 
-# Load required modules
-modprobe loop
-modprobe squashfs
-modprobe overlay
+# load required modules if they are not already loaded
+[ -d /sys/module/loop ] || modprobe loop
+[ -d /sys/module/squashfs ] || modprobe squashfs
+[ -d /sys/module/overlay ] || modprobe overlay
 
 # Mount the squash image
 mount -t ramfs ramfs /squash


### PR DESCRIPTION
Let's only load modules if they are not already loaded

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
