### PR TITLE
fix(udev-rules): remove sourcing of network link files

### DIFF
--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -21,6 +21,13 @@ installkernel() {
 # called by dracut
 install() {
     local _arch
+
+    #Adding default link
+    if dracut_module_included "systemd"; then
+        inst_multiple -o "${systemdutildir}/network/99-default.link"
+        [[ $hostonly ]] && inst_multiple -H -o "${systemdsystemconfdir}/network/*.link"
+    fi
+
     inst_multiple ip dhclient sed awk grep pgrep tr
 
     inst_multiple -o arping arping2

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -45,6 +45,10 @@ install() {
         inst_simple "$moddir"/nm-initrd.service "$systemdsystemunitdir"/nm-initrd.service
         inst_simple "$moddir"/nm-wait-online-initrd.service "$systemdsystemunitdir"/nm-wait-online-initrd.service
 
+        # Adding default link
+         inst_multiple -o "${systemdutildir}/network/99-default.link"
+         [[ $hostonly ]] && inst_multiple -H -o "${systemdsystemconfdir}/network/*.link"
+
         $SYSTEMCTL -q --root "$initdir" enable nm-initrd.service
     fi
 

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -57,11 +57,6 @@ install() {
     # legacy persistent network device name rules
     [[ $hostonly ]] && inst_rules 70-persistent-net.rules
 
-    if dracut_module_included "systemd"; then
-        inst_multiple -o "${systemdutildir}/network/*.link"
-        [[ $hostonly ]] && inst_multiple -H -o "/etc/systemd/network/*.link"
-    fi
-
     {
         for i in cdrom tape dialout floppy; do
             if ! grep -q "^$i:" "$initdir"/etc/group 2> /dev/null; then

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -242,8 +242,7 @@ test_setup() {
         )
         inst /etc/passwd /etc/passwd
         inst_multiple sh ls shutdown poweroff stty cat ps ln ip \
-            dmesg mkdir cp ping \
-            modprobe tcpdump setsid \
+            dmesg mkdir cp ping modprobe tcpdump setsid \
             /etc/services sleep mount chmod pidof
         inst_multiple tgtd tgtadm
         for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
@@ -314,7 +313,6 @@ test_setup() {
         inst_multiple poweroff shutdown
         inst_hook shutdown-emergency 000 ./hard-off.sh
         inst_hook emergency 000 ./hard-off.sh
-        inst_simple ./99-default.link /etc/systemd/network/99-default.link
     )
 
     # Make server's dracut image


### PR DESCRIPTION
Removing sourcing of network link files from the udev-rules module.
What always should be included should be placed in the systemd-network
module and other modules that provide/require spesific link files
should add them, themselves via their relevant include section.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
