### PR TITLE
ci: remove label cron job

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,15 +1,11 @@
-name: Label the Pull Requests automatically via Cron
+name: "Pull Request Labeler"
 
-on:
-    schedule:
-        - cron: '*/15 * * * *'
+on: pull_request_target
 
 jobs:
-    label:
-        runs-on: ubuntu-18.04
+    triage:
+        runs-on: ubuntu-latest
         steps:
-            - uses: paulfantom/periodic-labeler@master
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  GITHUB_REPOSITORY: ${{ github.repository }}
-                  LABEL_MAPPINGS_FILE: .github/labeler.yml
+            - uses: actions/labeler@main
+              with:
+                  repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
With the event called pull_request_target added to GitHub Actions, the
cron job can be removed.

See:
https://www.jclem.net/posts/labeling-prs-on-public-github-repositories
