### PR TITLE
fix(systemd-sysusers): misc fixes and cleanup

### DIFF
--- a/modules.d/01systemd-sysusers/module-setup.sh
+++ b/modules.d/01systemd-sysusers/module-setup.sh
@@ -1,12 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 # This file is part of dracut.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Prerequisite check(s) for module.
 check() {
 
-    # If the binary(s) requirements are not fulfilled
-    # return 1 to not include the binary.
+    # If the binary(s) requirements are not fulfilled the module can't be installed.
     require_binaries systemd-sysusers || return 1
 
     # Return 255 to only include the module, if another module requires it.
@@ -22,17 +21,14 @@ depends() {
 
 }
 
-# Install the required file(s) for the module in the initramfs.
+# Install the required file(s) and directories for the module in the initramfs.
 install() {
 
-    # Install the system users and groups configuration file.
-    # Install the systemd users and groups configuration file.
-    # Install the systemd type service unit for sysusers.
-    # Install the binary executable(s) for sysusers.
     inst_multiple -o \
         "$sysusers"/basic.conf \
         "$sysusers"/systemd.conf \
         "$systemdsystemunitdir"/systemd-sysusers.service \
+        "$systemdsystemunitdir"/sysinit.target.wants/systemd-sysusers.service \
         systemd-sysusers
 
     # Install the hosts local user configurations if enabled.
@@ -43,8 +39,5 @@ install() {
             "$systemdsystemconfdir"/systemd-sysusers.service \
             "$systemdsystemconfdir/systemd-sysusers.service.d/*.conf"
     fi
-
-    # Enable the systemd type service unit for sysusers.
-    $SYSTEMCTL -q --root "$initdir" enable systemd-sysusers.service
 
 }


### PR DESCRIPTION
This has been tested along with #1417, #1418, #1419 and with the entire install section of udev-rules module commented out. 

The sd-udevd module correctly detects and loads all it's included udev files. 
The sd-sysusers  correctly creates all users/groups for the included rules file in sd-udevd.
The sd-tmpfiles correctly creates everything on the host as well. 

Afaikt now with sd-udevd completed systemd based initrd should no longer have to require the udev-rules module in other words it can be cleaned up and left for legacy/alternative init system to strictly use.

## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
