### PR TITLE
network: add option to specify preferred network module

### DIFF
--- a/dracut.conf.5.asc
+++ b/dracut.conf.5.asc
@@ -106,6 +106,11 @@ Configuration files must have the extension .conf; other extensions are ignored.
 *tmpdir=*"__<temporary directory>__"::
     Specify temporary directory to use.
 
+*preferred_network_handler=*"__{network-wicked|network-manager|network-legacy|systemd-networkd}__"::
+    Multiple modules which can setup network network are available.
+    By default one of them is chosen.
+    You can specify a preferred one which will be used if it is available.
+
 [WARNING]
 ====
 If chrooted to another root other than the real root device, use --fstab and

--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -9,12 +9,23 @@ check() {
 depends() {
     is_qemu_virtualized && echo -n "qemu-net "
 
-    for module in network-wicked network-manager network-legacy systemd-networkd; do
-        if dracut_module_included "$module"; then
-            network_handler="$module"
-            break
-        fi
-    done
+    preferred_network_handler="${preferred_network_handler:-none}"
+    case "$preferred_network_handler" in
+		none )
+			for module in network-wicked network-manager network-legacy systemd-networkd; do
+				if dracut_module_included "$module"; then
+					network_handler="$module"
+					break
+				fi
+			done
+		;;
+		network-wicked | network-manager | network-legacy | systemd-networkd )
+			network_handler="$preferred_network_handler"
+		;;
+		* )
+			dwarn "Preferred network module $preferred_network_handler is not known, ignoring."
+		;;
+    esac
 
     if [ -z "$network_handler" ]; then
         if [[ -x $dracutsysrootdir$systemdsystemunitdir/wicked.service ]]; then


### PR DESCRIPTION
Most desktop Linux systems have NetworkManager, many of them have systemd-networkd inside the systemd package and many of them have dhclient installed.

Current code oft he network meta module, if no specific network module is included, pulls NetworkManager and its dependency dbus into the initramfs.

I want to avoid such complex systems inside initrd and want to avoid necessity to rebuild initrds when NetworkManager and dbus packages are updated to keep them in the initrd and on the host in sync, and also want to standartize initrds by having the same network module in most of them.

If I add a specific network module into the distribution (ROSA) default config of dracut, e.g. let it be systemd-networkd, dracut will try to include it even on systems where systemd-networkd is not installed and fill fail with error.

So adding a config option which allows to change the _preferred_ default if no specific network module is configured to be added into the initrd.

For now I will set it in ROSA to network-legacy to avoid pulling dbus, maybe it will have to be changed to systemd-networkd later when this module matures in dracut or when network-legacy is dropped.

Fixes: https://github.com/dracutdevs/dracut/issues/1404
