### PR TITLE
feat: also restore the initramfs from /lib/modules

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -24,13 +24,16 @@ elif [[ -d /boot/loader/entries || -L /boot/loader/entries ]] \
     && [[ $MACHINE_ID ]] \
     && [[ -d /boot/${MACHINE_ID} || -L /boot/${MACHINE_ID} ]]; then
     IMG="/boot/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
-else
+elif [[ -f /boot/initramfs-${KERNEL_VERSION}.img ]]; then
     IMG="/boot/initramfs-${KERNEL_VERSION}.img"
+elif [[ -f /lib/modules/${KERNEL_VERSION}/initrd ]]; then
+    IMG="/lib/modules/${KERNEL_VERSION}/initrd"
+else
+    echo "No initramfs image found to restore!"
+    exit 1
 fi
 
 cd /run/initramfs
-
-[ -f .need_shutdown -a -f "$IMG" ] || exit 1
 
 if $SKIP "$IMG" | zcat | cpio -id --no-absolute-filenames --quiet > /dev/null; then
     rm -f -- .need_shutdown


### PR DESCRIPTION
Fallback to /lib/modules/$(uname -r)/initrd, if present and all other
files don't exist.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
