### PR TITLE
fix(crypt): install all crypto modules in the generic initrd

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -30,7 +30,7 @@ installkernel() {
     # in case some of the crypto modules moved from compiled in
     # to module based, try to install those modules
     # best guess
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
+    if [[ $hostonly ]] || [[ $mount_needs ]]; then
         # dmsetup returns s.th. like
         # cryptvol: 0 2064384 crypt aes-xts-plain64 :64:logon:cryptsetup:....
         dmsetup table | while read -r name _ _ is_crypt cipher _; do
@@ -47,7 +47,9 @@ installkernel() {
                 hostonly='' instmods "${mods[@]/#/crypto-}" "crypto-$cipher"
             fi
         done
-    }
+    else
+        instmods "=crypto"
+    fi
     return 0
 }
 


### PR DESCRIPTION
## Changes

Just install all `=crypto` drivers in the generic initramfs, because who
are we to decide which combinations are allowed in current and future
`cryptsetup`. We only could install blacklist filter in the future, if
there are modules, which are definetely not used and are huge in size.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
