### PR TITLE
fix: install all depmod relevant configuration files

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1760,6 +1760,17 @@ if ! [[ -d $dracutsysrootdir$tmpfilesdir ]]; then
     [[ -d $dracutsysrootdir/usr/lib/tmpfiles.d ]] && tmpfilesdir=/usr/lib/tmpfiles.d
 fi
 
+[[ -d $dracutsysrootdir$depmodd ]] \
+    || sysctld=$(pkg-config libkmod --variable=depmodd 2> /dev/null)
+
+[[ -d $dracutsysrootdir$depmodd ]] || depmodd=/usr/lib/depmod.d
+
+[[ -d $dracutsysrootdir$depmodconfdir ]] \
+    || sysctlconfdir=$(pkg-config libkmod --variable=depmodconfdir 2> /dev/null)
+
+[[ -d $dracutsysrootdir$depmodconfdir ]] || depmodconfdir=/etc/depmod.d
+
+
 export initdir dracutbasedir \
     dracutmodules force_add_dracutmodules add_dracutmodules omit_dracutmodules \
     mods_to_load \
@@ -1776,7 +1787,7 @@ export initdir dracutbasedir \
     modulesloadconfdir sysctl sysctlconfdir sysusers sysusersconfdir \
     systemdutildir systemdutilconfdir systemdcatalog systemdntpunits \
     systemdntpunitsconfdir systemdsystemunitdir systemdsystemconfdir \
-    hostonly_cmdline loginstall tmpfilesdir
+    hostonly_cmdline loginstall tmpfilesdir depmodd depmodconfdir
 
 mods_to_load=""
 # check all our modules to see if they should be sourced.

--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -128,6 +128,11 @@ installkernel() {
         hostonly='' instmods "=crypto"
         instmods "=arch/$arch/crypto" "=drivers/crypto"
     fi
+
+    inst_multiple -o "$depmodd/*.conf"
+    if [[ $hostonly ]]; then
+        inst_multiple -H -o "$depmodconfdir/*.conf"
+    fi
     :
 }
 


### PR DESCRIPTION
This is important for running `depmod` in the initrd.
