### PR TITLE
fix: include `modules.builtin.alias` in the initramfs

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -998,7 +998,7 @@ for_each_module_dir() {
 }
 
 dracut_kernel_post() {
-    for _f in modules.builtin modules.builtin.modinfo modules.order; do
+    for _f in modules.builtin modules.builtin.alias modules.builtin.modinfo modules.order; do
         [[ -e $srcmods/$_f ]] && inst_simple "$srcmods/$_f" "/lib/modules/$kernel/$_f"
     done
 


### PR DESCRIPTION
Let's also resolve the compiled in aliases to builtin modules.
