### PR TITLE
style: make indent and let shfmt fail again

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
         uses: luizm/action-sh-checker@v0.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SHFMT_OPTS: -s # arguments to shfmt.
+          SHFMT_OPTS: -d -s # arguments to shfmt.
         with:
           sh_checker_shellcheck_disable: false
           sh_checker_comment: true

--- a/dracut.sh
+++ b/dracut.sh
@@ -1770,7 +1770,6 @@ fi
 
 [[ -d $dracutsysrootdir$depmodconfdir ]] || depmodconfdir=/etc/depmod.d
 
-
 export initdir dracutbasedir \
     dracutmodules force_add_dracutmodules add_dracutmodules omit_dracutmodules \
     mods_to_load \

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -46,8 +46,8 @@ install() {
         inst_simple "$moddir"/nm-wait-online-initrd.service "$systemdsystemunitdir"/nm-wait-online-initrd.service
 
         # Adding default link
-         inst_multiple -o "${systemdutildir}/network/99-default.link"
-         [[ $hostonly ]] && inst_multiple -H -o "${systemdsystemconfdir}/network/*.link"
+        inst_multiple -o "${systemdutildir}/network/99-default.link"
+        [[ $hostonly ]] && inst_multiple -H -o "${systemdsystemconfdir}/network/*.link"
 
         $SYSTEMCTL -q --root "$initdir" enable nm-initrd.service
     fi

--- a/modules.d/98integrity/evm-enable.sh
+++ b/modules.d/98integrity/evm-enable.sh
@@ -147,17 +147,17 @@ enable_evm() {
     # initialize EVM
     info "Enabling EVM"
     if [ "$((evm_configured & EVM_INIT_X509))" -ne 0 ]; then
-      # Older kernels did not support EVM_ALLOW_METADATA_WRITES, try for
-      # newer ones first that need it when an x509 is used
-      echo $((evm_configured | EVM_ALLOW_METADATA_WRITES | EVM_ACTIVATION_BITS)) > "${EVMSECFILE}" ||
-        echo $((evm_configured | EVM_ACTIVATION_BITS)) > "${EVMSECFILE}"
+        # Older kernels did not support EVM_ALLOW_METADATA_WRITES, try for
+        # newer ones first that need it when an x509 is used
+        echo $((evm_configured | EVM_ALLOW_METADATA_WRITES | EVM_ACTIVATION_BITS)) > "${EVMSECFILE}" \
+            || echo $((evm_configured | EVM_ACTIVATION_BITS)) > "${EVMSECFILE}"
     else
-      echo $((evm_configured | EVM_ACTIVATION_BITS)) > "${EVMSECFILE}"
+        echo $((evm_configured | EVM_ACTIVATION_BITS)) > "${EVMSECFILE}"
     fi
 
     if [ "$((evm_configured & EVM_INIT_HMAC))" -ne 0 ]; then
-      # unload the EVM encrypted key
-      unload_evm_key || return 1
+        # unload the EVM encrypted key
+        unload_evm_key || return 1
     fi
 
     return 0


### PR DESCRIPTION
The bump of removed the `-d` option for `shfmt`. Readd it until upstream
is fixed.

See also:
https://github.com/luizm/action-sh-checker/issues/44
