### PR TITLE
Support ZSTD-compressed kernel modules

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -625,6 +625,7 @@ get_decompress_cmd() {
         *.gz) echo 'gzip -f -d' ;;
         *.bz2) echo 'bzip2 -d' ;;
         *.xz) echo 'xz -f -d' ;;
+        *.zst) echo 'zstd -f -d ' ;;
     esac
 }
 

--- a/dracut.sh
+++ b/dracut.sh
@@ -1271,6 +1271,7 @@ if [[ $no_kernel != yes ]] && [[ -d $srcmods ]]; then
             case "$_mod" in
                 *.ko.gz) kcompress=gzip ;;
                 *.ko.xz) kcompress=xz ;;
+                *.ko.zst) kcompress=zstd ;;
             esac
             if [[ $kcompress ]]; then
                 if ! command -v "$kcompress" &> /dev/null; then

--- a/install/dracut-install.c
+++ b/install/dracut-install.c
@@ -1937,6 +1937,10 @@ static int install_modules(int argc, char **argv)
                                 int len = strlen(modname);
                                 modname[len - 6] = 0;
                         }
+                        if (endswith(modname, ".ko.zst")) {
+                                int len = strlen(modname);
+                                modname[len - 7] = 0;
+                        }
                         r = kmod_module_new_from_lookup(ctx, modname, &modlist);
                         if (r < 0) {
                                 if (!arg_optional) {


### PR DESCRIPTION
Modern Linux kernels support zstd-compressed modules, which was added
by commit 73f3d1b48f50 ("lib: Add zstd modules").

Commit c3d7ef377eb ("kbuild: add support for zstd compressed modules")
added support of compressing modules with zstd to kernel Makefiles.

libkmod >= 28 built with libzstd is also required.

P.S. Support of decompressing zstd-compressed /lib/firmware seems to be missing in dracut-install, I did not try.