### PR TITLE
fix(base): suppress calls to getarg in build phase

### DIFF
--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -17,7 +17,7 @@ install() {
         sed ls flock cp mv dmesg rm ln rmmod mkfifo umount readlink setsid \
         modprobe chmod
 
-    inst_multiple -o findmnt less kmod dracut-getargs
+    inst_multiple -o findmnt less kmod
 
     inst_binary "${dracutsysrootdir}${dracutbasedir}/dracut-util" "/usr/bin/dracut-util"
 
@@ -117,6 +117,8 @@ install() {
                 fi
                 export PREFIX="$initdir"
 
+                # suppress getarg for `rd.memdebug`
+                export DEBUG_MEM_LEVEL=0
                 # shellcheck source=dracut-lib.sh
                 . "$moddir/dracut-lib.sh"
 


### PR DESCRIPTION
Setting `DEBUG_MEM_LEVEL` in the build phase prevents
`setmemdebug()` to call `getargnum`, which would use `dracut-getarg`
in the initrd runtime phase.

No more:

```
modules.d/99base/dracut-lib.sh: line 217: dracut-getarg: command not found
```
