### PR TITLE
fix: deprecate gummiboot

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1338,13 +1338,9 @@ if [[ ! $print_cmdline ]]; then
         esac
 
         if ! [[ -s $uefi_stub ]]; then
-            for uefi_stub in \
-                "$dracutsysrootdir${systemdutildir}/boot/efi/linux${EFI_MACHINE_TYPE_NAME}.efi.stub" \
-                "$dracutsysrootdir/usr/lib/gummiboot/linux${EFI_MACHINE_TYPE_NAME}.efi.stub"; do
-                [[ -s $uefi_stub ]] || continue
-                break
-            done
+            uefi_stub="$dracutsysrootdir${systemdutildir}/boot/efi/linux${EFI_MACHINE_TYPE_NAME}.efi.stub"
         fi
+
         if ! [[ -s $uefi_stub ]]; then
             dfatal "Can't find a uefi stub '$uefi_stub' to create a UEFI executable"
             exit 1

--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -521,7 +521,6 @@ will not be able to boot.
     Specifies the UEFI stub loader, which will load the attached kernel, initramfs and
     kernel command line and boots the kernel. The default is
     _$prefix/lib/systemd/boot/efi/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
-    or _$prefix/lib/gummiboot/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
 
 **--uefi-splash-image _<FILE>_**::
     Specifies the UEFI stub loader's splash image. Requires bitmap (**.bmp**) image

--- a/man/dracut.conf.5.asc
+++ b/man/dracut.conf.5.asc
@@ -204,7 +204,6 @@ provide a valid _/etc/fstab_.
     Specifies the UEFI stub loader, which will load the attached kernel, initramfs and
     kernel command line and boots the kernel. The default is
     _/lib/systemd/boot/efi/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
-    or _/usr/lib/gummiboot/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
 
 *uefi_splash_image=*"_<FILE>_"::
     Specifies the UEFI stub loader's splash image. Requires bitmap (**.bmp**) image format.


### PR DESCRIPTION
Gummiboot was merged into systemd and official became systemd-boot in 2015 ( 6 years ago )
and no longer was being maintained as Gummiboot from that point.

It's safe to say distribution should have migrated to sd-boot by now so let's deprecate
it.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
