### PR TITLE
fix(dracut-init): add src path for install

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -184,6 +184,8 @@ if ! [[ $DRACUT_INSTALL ]] && [[ -x $dracutbasedir/dracut-install ]]; then
     DRACUT_INSTALL=$dracutbasedir/dracut-install
 elif ! [[ $DRACUT_INSTALL ]] && [[ -x $dracutbasedir/install/dracut-install ]]; then
     DRACUT_INSTALL=$dracutbasedir/install/dracut-install
+elif ! [[ $DRACUT_INSTALL ]] && [[ -x $dracutbasedir/src/install/dracut-install ]]; then
+    DRACUT_INSTALL=$dracutbasedir/src/install/dracut-install
 fi
 
 # Test if dracut-install is a standalone executable with no options.


### PR DESCRIPTION
We probably end up having to add more if statements like this one for install for everything that we moved into the src directory so dracut src files themselves can be moved there and will work in test cases...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
