### PR TITLE
ci: don't use `rpm` to determine the kernel version

### DIFF
--- a/test/container/Dockerfile-Arch
+++ b/test/container/Dockerfile-Arch
@@ -5,7 +5,7 @@ MAINTAINER https://github.com/dracutdevs/dracut
 ENV container docker
 LABEL RUN="docker run -it --name NAME --privileged --ipc=host --net=host --pid=host -e NAME=NAME -e IMAGE=IMAGE IMAGE"
 
-RUN echo 'export DRACUT_NO_XATTR=1 KVERSION="$(rpm -qa kernel --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" | sort -rn | head -1)"' > /etc/profile.d/dracut-test.sh
+RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)' > /etc/profile.d/dracut-test.sh
 
 # Install needed packages for the dracut CI container
 RUN pacman --noconfirm -Sy \

--- a/test/container/Dockerfile-Fedora-33
+++ b/test/container/Dockerfile-Fedora-33
@@ -5,7 +5,7 @@ MAINTAINER https://github.com/dracutdevs/dracut
 ENV container docker
 LABEL RUN="docker run -it --name NAME --privileged --ipc=host --net=host --pid=host -e NAME=NAME -e IMAGE=IMAGE IMAGE"
 
-RUN echo 'export DRACUT_NO_XATTR=1 KVERSION="$(rpm -qa kernel --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" | sort -rn | head -1)"' > /etc/profile.d/dracut-test.sh
+RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)' > /etc/profile.d/dracut-test.sh
 
 # Install needed packages for the dracut CI container
 RUN dnf -y install --setopt=install_weak_deps=False \

--- a/test/container/Dockerfile-Fedora-34
+++ b/test/container/Dockerfile-Fedora-34
@@ -5,7 +5,7 @@ MAINTAINER https://github.com/dracutdevs/dracut
 ENV container docker
 LABEL RUN="docker run -it --name NAME --privileged --ipc=host --net=host --pid=host -e NAME=NAME -e IMAGE=IMAGE IMAGE"
 
-RUN echo 'export DRACUT_NO_XATTR=1 KVERSION="$(rpm -qa kernel --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" | sort -rn | head -1)"' > /etc/profile.d/dracut-test.sh
+RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)' > /etc/profile.d/dracut-test.sh
 
 # Install needed packages for the dracut CI container
 RUN dnf -y install --setopt=install_weak_deps=False \

--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -5,7 +5,7 @@ MAINTAINER https://github.com/dracutdevs/dracut
 ENV container docker
 LABEL RUN="docker run -it --name NAME --privileged --ipc=host --net=host --pid=host -e NAME=NAME -e IMAGE=IMAGE IMAGE"
 
-RUN echo 'export DRACUT_NO_XATTR=1 KVERSION="$(rpm -qa kernel --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" | sort -rn | head -1)"' > /etc/profile.d/dracut-test.sh
+RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)' > /etc/profile.d/dracut-test.sh
 
 # Install needed packages for the dracut CI container
 RUN dnf -y install --setopt=install_weak_deps=False \


### PR DESCRIPTION
for `/etc/profile.d/dracut-test.sh`

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
