### PR TITLE
fix(dracut): prevent symbolic links containing `//`

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1838,6 +1838,7 @@ fi
 
 if [[ $prefix ]]; then
     for d in bin etc lib sbin tmp usr var $libdirs; do
+        d=${d#/}
         [[ $d == */* ]] && continue
         ln -sfn "${prefix#/}/${d#/}" "$initdir/$d"
     done
@@ -1845,6 +1846,7 @@ fi
 
 if [[ $kernel_only != yes ]]; then
     for d in usr usr/bin usr/sbin bin etc lib sbin tmp var var/tmp $libdirs; do
+        d=${d#/}
         [[ -e "${initdir}${prefix}/$d" ]] && continue
         if [ -L "/$d" ]; then
             inst_symlink "/$d" "${prefix}/$d"


### PR DESCRIPTION
Results in `usr/lib64 -> ..//usr/lib` for Arch Linux otherwise.

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
