### PR TITLE
fix(network-manager): cope with distributions not using `libexec`

### DIFF
--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -30,7 +30,7 @@ install() {
     inst_multiple ip sed grep
 
     inst NetworkManager
-    inst /usr/libexec/nm-initrd-generator
+    inst_multiple -o /usr/{lib,libexec}/nm-initrd-generator
     inst_multiple -o teamd dhclient
     inst_hook cmdline 99 "$moddir/nm-config.sh"
     if dracut_module_included "systemd"; then
@@ -59,7 +59,7 @@ install() {
     inst_simple "$moddir/nm-lib.sh" "/lib/nm-lib.sh"
 
     if [[ -x "$initdir/usr/sbin/dhclient" ]]; then
-        inst /usr/libexec/nm-dhcp-helper
+        inst_multiple -o /usr/{lib,libexec}/nm-dhcp-helper
     elif ! [[ -e "$initdir/etc/machine-id" ]]; then
         # The internal DHCP client silently fails if we
         # have no machine-id

--- a/modules.d/35network-manager/nm-lib.sh
+++ b/modules.d/35network-manager/nm-lib.sh
@@ -4,8 +4,15 @@ type getcmdline > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 nm_generate_connections() {
     rm -f /run/NetworkManager/system-connections/*
-    # shellcheck disable=SC2046
-    /usr/libexec/nm-initrd-generator -- $(getcmdline)
+    if [ -x /usr/libexec/nm-initrd-generator ]; then
+        # shellcheck disable=SC2046
+        /usr/libexec/nm-initrd-generator -- $(getcmdline)
+    elif [ -x /usr/lib/nm-initrd-generator ]; then
+        # shellcheck disable=SC2046
+        /usr/lib/nm-initrd-generator -- $(getcmdline)
+    else
+        derror "nm-initrd-generator not found"
+    fi
 
     if getargbool 0 rd.neednet; then
         for i in /usr/lib/NetworkManager/system-connections/* \


### PR DESCRIPTION
This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
