### PR TITLE
ci: ensure pigz is installed in the CI containers

### DIFF
--- a/test/container/Dockerfile-Fedora-33
+++ b/test/container/Dockerfile-Fedora-33
@@ -10,6 +10,7 @@ RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)'
 # Install needed packages for the dracut CI container
 RUN dnf -y install --setopt=install_weak_deps=False \
     dash \
+    pigz \
     asciidoc \
     mdadm \
     lvm2 \

--- a/test/container/Dockerfile-Fedora-34
+++ b/test/container/Dockerfile-Fedora-34
@@ -10,6 +10,7 @@ RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)'
 # Install needed packages for the dracut CI container
 RUN dnf -y install --setopt=install_weak_deps=False \
     dash \
+    pigz \
     asciidoc \
     mdadm \
     lvm2 \

--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -10,6 +10,7 @@ RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)'
 # Install needed packages for the dracut CI container
 RUN dnf -y install --setopt=install_weak_deps=False \
     dash \
+    pigz \
     asciidoc \
     mdadm \
     lvm2 \

--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -13,7 +13,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     strace libkmod-devel gcc bzip2 xz tar wget rpm-build make git bash-completion \
     sudo kernel dhcp-client qemu-kvm /usr/bin/qemu-system-$(uname -m) e2fsprogs \
     tcpdump iproute iputils kbd NetworkManager btrfsprogs tgt dbus-broker \
-    iscsiuio open-iscsi which ShellCheck procps \
+    iscsiuio open-iscsi which ShellCheck procps pigz \
     && dnf -y update && dnf clean all
 
 RUN shfmt_version=3.2.4; wget "https://github.com/mvdan/sh/releases/download/v${shfmt_version}/shfmt_v${shfmt_version}_linux_amd64" -O /usr/local/bin/shfmt \


### PR DESCRIPTION
pigz speeds up things considerably. Although pigz is already installed
by default, explicitely adding it makes sure, it will not disappear
unnoticed.

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
