### PR TITLE
fix(url-lib): fix passing args

### DIFF
--- a/modules.d/45url-lib/url-lib.sh
+++ b/modules.d/45url-lib/url-lib.sh
@@ -66,13 +66,15 @@ curl_fetch_url() {
     local url="$1" outloc="$2"
     echo "$url" > /proc/self/fd/0
     if [ -n "$outloc" ]; then
-        curl "$curl_args" --output - -- "$url" > "$outloc" || return $?
+        # shellcheck disable=SC2086
+        curl $curl_args --output - -- "$url" > "$outloc" || return $?
     else
         local outdir
         outdir="$(mkuniqdir /tmp curl_fetch_url)"
         (
             cd "$outdir" || exit
-            curl "$curl_args" --remote-name "$url" || return $?
+            # shellcheck disable=SC2086
+            curl $curl_args --remote-name "$url" || return $?
         )
         outloc="$outdir/$(ls -A "$outdir")"
     fi
@@ -98,13 +100,15 @@ ctorrent_fetch_url() {
     torrent_outloc="$outloc.torrent"
     echo "$url" > /proc/self/fd/0
     if [ -n "$outloc" ]; then
-        curl "$curl_args" --output - -- "$url" > "$torrent_outloc" || return $?
+        # shellcheck disable=SC2086
+        curl $curl_args --output - -- "$url" > "$torrent_outloc" || return $?
     else
         local outdir
         outdir="$(mkuniqdir /tmp torrent_fetch_url)"
         (
             cd "$outdir" || exit
-            curl "$curl_args" --remote-name "$url" || return $?
+            # shellcheck disable=SC2086
+            curl $curl_args --remote-name "$url" || return $?
         )
         torrent_outloc="$outdir/$(ls -A "$outdir")"
         outloc=${torrent_outloc%.*}
@@ -113,7 +117,8 @@ ctorrent_fetch_url() {
         warn "Downloading '$url' failed!"
         return 253
     fi
-    ctorrent "$ctorrent_args" -s "$outloc" "$torrent_outloc" >&2
+    # shellcheck disable=SC2086
+    ctorrent $ctorrent_args -s "$outloc" "$torrent_outloc" >&2
     if ! [ -f "$outloc" ]; then
         warn "Torrent download of '$url' failed!"
         return 253


### PR DESCRIPTION
Fixes: 8e84fa726 ("fix(url-lib): shellcheck for modules.d/45url-lib")

Behaviour introduced by that commit made the following to be run:
`curl "--globoff --location --retry 3 --fail --show-error" http://192.168.1.173:8000/test.ks`
instead of:
`curl --globoff --location --retry 3 --fail --show-error http://192.168.1.173:8000/test.ks`

This broke downloading kickstart file in anaconda-dracut.