### PR TITLE
fix: adding crc32c for ext3

### DIFF
--- a/modules.d/99fs-lib/module-setup.sh
+++ b/modules.d/99fs-lib/module-setup.sh
@@ -37,7 +37,7 @@ echo_fs_helper() {
 include_fs_helper_modules() {
     local fs=$2
     case "$fs" in
-        xfs | btrfs | ext4)
+        xfs | btrfs | ext4 | ext3)
             instmods crc32c
             ;;
         f2fs)


### PR DESCRIPTION
Noticed that ext3 is still being used in the wild so let's add it to the crc32c list
so downstream does not have to carry a patch for it.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
