### PR TITLE
fix(squash): don't mount the mount points if already mounted

### DIFF
--- a/modules.d/99squash/init-squash.sh
+++ b/modules.d/99squash/init-squash.sh
@@ -1,12 +1,17 @@
 #!/bin/sh
 PATH=/bin:/sbin
 
-# Basic mounts for mounting a squash image
-mkdir /proc /sys /dev /run
-mount -t proc -o nosuid,noexec,nodev proc /proc
-mount -t sysfs -o nosuid,noexec,nodev sysfs /sys
-mount -t devtmpfs -o mode=755,noexec,nosuid,strictatime devtmpfs /dev
-mount -t tmpfs -o mode=755,nodev,nosuid,strictatime tmpfs /run
+[ -e /proc/self/mounts ] \
+    || (mkdir -p /proc && mount -t proc -o nosuid,noexec,nodev proc /proc)
+
+grep -q '^sysfs /sys sysfs' /proc/self/mounts \
+    || (mkdir -p /sys && mount -t sysfs -o nosuid,noexec,nodev sysfs /sys)
+
+grep -q '^devtmpfs /dev devtmpfs' /proc/self/mounts \
+    || (mkdir -p /dev && mount -t devtmpfs -o mode=755,noexec,nosuid,strictatime devtmpfs /dev)
+
+grep -q '^tmpfs /run tmpfs' /proc/self/mounts \
+    || (mkdir -p /run && mount -t tmpfs -o mode=755,noexec,nosuid,strictatime tmpfs /run)
 
 # Load required modules
 modprobe loop

--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -42,11 +42,11 @@ installpost() {
     # Install required modules and binaries for the squash image init script.
     if [[ $_busybox ]]; then
         inst "$_busybox" /usr/bin/busybox
-        for _i in sh echo mount modprobe mkdir switch_root; do
+        for _i in sh echo mount modprobe mkdir switch_root grep; do
             ln_r /usr/bin/busybox /usr/bin/$_i
         done
     else
-        DRACUT_RESOLVE_DEPS=1 inst_multiple sh mount modprobe mkdir switch_root
+        DRACUT_RESOLVE_DEPS=1 inst_multiple sh mount modprobe mkdir switch_root grep
     fi
 
     hostonly="" instmods "loop" "squashfs" "overlay"


### PR DESCRIPTION
It is possible that user setup some early mount in the rootfs even
earlier, so just be more robust and cover that case too.

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
