### PR TITLE
dracut-util: print error message with newline

### DIFF
--- a/src/util/util.c
+++ b/src/util/util.c
@@ -123,7 +123,7 @@ static void usage(enum EXEC_MODE enumExecMode, int ret, char *msg)
 {
         switch (enumExecMode) {
         case UNDEFINED:
-                fprintf(stderr, "ERROR: 'dracut-util' has to be called via a symlink to the tool name.");
+                fprintf(stderr, "ERROR: 'dracut-util' has to be called via a symlink to the tool name.\n");
                 break;
         case GETARG:
                 fprintf(stderr, "ERROR: %s\nUsage: dracut-getarg <KEY>[=[<VALUE>]]\n", msg);


### PR DESCRIPTION
This pull request fixes a - very minor - issue that `dracut-util` emits an error mesage without a trailing newline which looks quite ugly.

The other error I attempted to fix became worse with my patch so I removed it again. I will file an issue instead.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
