### PR TITLE
fix(base): split out `dracut-dev-lib.sh`

### DIFF
--- a/modules.d/99base/dracut-dev-lib.sh
+++ b/modules.d/99base/dracut-dev-lib.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+
+# get a systemd-compatible unit name from a path
+# (mimicks unit_name_from_path_instance())
+dev_unit_name() {
+    local dev="$1"
+
+    if command -v systemd-escape > /dev/null; then
+        systemd-escape -p -- "$dev"
+        return $?
+    fi
+
+    if [ "$dev" = "/" -o -z "$dev" ]; then
+        printf -- "-"
+        return 0
+    fi
+
+    dev="${1%%/}"
+    dev="${dev##/}"
+    # shellcheck disable=SC1003
+    dev="$(str_replace "$dev" '\' '\x5c')"
+    dev="$(str_replace "$dev" '-' '\x2d')"
+    if [ "${dev##.}" != "$dev" ]; then
+        dev="\x2e${dev##.}"
+    fi
+    dev="$(str_replace "$dev" '/' '-')"
+
+    printf -- "%s" "$dev"
+}
+
+# set_systemd_timeout_for_dev [-n] <dev> [<timeout>]
+# Set 'rd.timeout' as the systemd timeout for <dev>
+set_systemd_timeout_for_dev() {
+    local _name
+    local _needreload
+    local _noreload
+    local _timeout
+
+    [ -z "$DRACUT_SYSTEMD" ] && return 0
+
+    if [ "$1" = "-n" ]; then
+        _noreload=1
+        shift
+    fi
+
+    if [ -n "$2" ]; then
+        _timeout="$2"
+    else
+        _timeout=$(getarg rd.timeout)
+    fi
+
+    _timeout=${_timeout:-0}
+
+    _name=$(dev_unit_name "$1")
+    if ! [ -L "${PREFIX}/etc/systemd/system/initrd.target.wants/${_name}.device" ]; then
+        [ -d "${PREFIX}"/etc/systemd/system/initrd.target.wants ] || mkdir -p "${PREFIX}"/etc/systemd/system/initrd.target.wants
+        ln -s ../"${_name}".device "${PREFIX}/etc/systemd/system/initrd.target.wants/${_name}.device"
+        type mark_hostonly > /dev/null 2>&1 && mark_hostonly /etc/systemd/system/initrd.target.wants/"${_name}".device
+        _needreload=1
+    fi
+
+    if ! [ -f "${PREFIX}/etc/systemd/system/${_name}.device.d/timeout.conf" ]; then
+        mkdir -p "${PREFIX}/etc/systemd/system/${_name}.device.d"
+        {
+            echo "[Unit]"
+            echo "JobTimeoutSec=$_timeout"
+            echo "JobRunningTimeoutSec=$_timeout"
+        } > "${PREFIX}/etc/systemd/system/${_name}.device.d/timeout.conf"
+        type mark_hostonly > /dev/null 2>&1 && mark_hostonly /etc/systemd/system/"${_name}".device.d/timeout.conf
+        _needreload=1
+    fi
+
+    if [ -z "$PREFIX" ] && [ "$_needreload" = 1 ] && [ -z "$_noreload" ]; then
+        /sbin/initqueue --onetime --unique --name daemon-reload systemctl daemon-reload
+    fi
+}
+
+# wait_for_dev <dev> [<timeout>]
+#
+# Installs a initqueue-finished script,
+# which will cause the main loop only to exit,
+# if the device <dev> is recognized by the system.
+wait_for_dev() {
+    local _name
+    local _noreload
+
+    if [ "$1" = "-n" ]; then
+        _noreload=-n
+        shift
+    fi
+
+    _name="$(str_replace "$1" '/' '\x2f')"
+
+    type mark_hostonly > /dev/null 2>&1 && mark_hostonly "$hookdir/initqueue/finished/devexists-${_name}.sh"
+
+    [ -e "${PREFIX}$hookdir/initqueue/finished/devexists-${_name}.sh" ] && return 0
+
+    printf '[ -e "%s" ]\n' "$1" \
+        >> "${PREFIX}$hookdir/initqueue/finished/devexists-${_name}.sh"
+    {
+        printf '[ -e "%s" ] || ' "$1"
+        printf 'warn "\"%s\" does not exist"\n' "$1"
+    } >> "${PREFIX}$hookdir/emergency/80-${_name}.sh"
+
+    set_systemd_timeout_for_dev $_noreload "$@"
+}
+
+cancel_wait_for_dev() {
+    local _name
+    _name="$(str_replace "$1" '/' '\x2f')"
+    rm -f -- "$hookdir/initqueue/finished/devexists-${_name}.sh"
+    rm -f -- "$hookdir/emergency/80-${_name}.sh"
+    if [ -n "$DRACUT_SYSTEMD" ]; then
+        _name=$(dev_unit_name "$1")
+        rm -f -- "${PREFIX}/etc/systemd/system/initrd.target.wants/${_name}.device"
+        rm -f -- "${PREFIX}/etc/systemd/system/${_name}.device.d/timeout.conf"
+        /sbin/initqueue --onetime --unique --name daemon-reload systemctl daemon-reload
+    fi
+}

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+type wait_for_dev > /dev/null 2>&1 || . /lib/dracut-dev-lib.sh
+
 export DRACUT_SYSTEMD
 export NEWROOT
 if [ -n "$NEWROOT" ]; then
@@ -836,119 +838,6 @@ wait_for_mount() {
         printf 'ismounted "%s" || ' "$1"
         printf 'warn "\"%s\" is not mounted"\n' "$1"
     } >> "$hookdir/emergency/90-${_name}.sh"
-}
-
-# get a systemd-compatible unit name from a path
-# (mimicks unit_name_from_path_instance())
-dev_unit_name() {
-    local dev="$1"
-
-    if command -v systemd-escape > /dev/null; then
-        systemd-escape -p -- "$dev"
-        return
-    fi
-
-    if [ "$dev" = "/" -o -z "$dev" ]; then
-        printf -- "-"
-        exit 0
-    fi
-
-    dev="${1%%/}"
-    dev="${dev##/}"
-    # shellcheck disable=SC1003
-    dev="$(str_replace "$dev" '\' '\x5c')"
-    dev="$(str_replace "$dev" '-' '\x2d')"
-    if [ "${dev##.}" != "$dev" ]; then
-        dev="\x2e${dev##.}"
-    fi
-    dev="$(str_replace "$dev" '/' '-')"
-
-    printf -- "%s" "$dev"
-}
-
-# set_systemd_timeout_for_dev <dev>
-# Set 'rd.timeout' as the systemd timeout for <dev>
-
-set_systemd_timeout_for_dev() {
-    local _name
-    local _needreload
-    local _noreload
-    local _timeout
-
-    if [ "$1" = "-n" ]; then
-        _noreload=1
-        shift
-    fi
-
-    _timeout=$(getarg rd.timeout)
-    _timeout=${_timeout:-0}
-
-    if [ -n "$DRACUT_SYSTEMD" ]; then
-        _name=$(dev_unit_name "$1")
-        if ! [ -L "${PREFIX}/etc/systemd/system/initrd.target.wants/${_name}.device" ]; then
-            [ -d "${PREFIX}"/etc/systemd/system/initrd.target.wants ] || mkdir -p "${PREFIX}"/etc/systemd/system/initrd.target.wants
-            ln -s ../"${_name}".device "${PREFIX}/etc/systemd/system/initrd.target.wants/${_name}.device"
-            type mark_hostonly > /dev/null 2>&1 && mark_hostonly /etc/systemd/system/initrd.target.wants/"${_name}".device
-            _needreload=1
-        fi
-
-        if ! [ -f "${PREFIX}/etc/systemd/system/${_name}.device.d/timeout.conf" ]; then
-            mkdir -p "${PREFIX}/etc/systemd/system/${_name}.device.d"
-            {
-                echo "[Unit]"
-                echo "JobTimeoutSec=$_timeout"
-                echo "JobRunningTimeoutSec=$_timeout"
-            } > "${PREFIX}/etc/systemd/system/${_name}.device.d/timeout.conf"
-            type mark_hostonly > /dev/null 2>&1 && mark_hostonly /etc/systemd/system/"${_name}".device.d/timeout.conf
-            _needreload=1
-        fi
-
-        if [ -z "$PREFIX" ] && [ "$_needreload" = 1 ] && [ -z "$_noreload" ]; then
-            /sbin/initqueue --onetime --unique --name daemon-reload systemctl daemon-reload
-        fi
-    fi
-}
-# wait_for_dev <dev>
-#
-# Installs a initqueue-finished script,
-# which will cause the main loop only to exit,
-# if the device <dev> is recognized by the system.
-wait_for_dev() {
-    local _name
-    local _noreload
-
-    if [ "$1" = "-n" ]; then
-        _noreload=-n
-        shift
-    fi
-
-    _name="$(str_replace "$1" '/' '\x2f')"
-
-    type mark_hostonly > /dev/null 2>&1 && mark_hostonly "$hookdir/initqueue/finished/devexists-${_name}.sh"
-
-    [ -e "${PREFIX}$hookdir/initqueue/finished/devexists-${_name}.sh" ] && return 0
-
-    printf '[ -e "%s" ]\n' "$1" \
-        >> "${PREFIX}$hookdir/initqueue/finished/devexists-${_name}.sh"
-    {
-        printf '[ -e "%s" ] || ' "$1"
-        printf 'warn "\"%s\" does not exist"\n' "$1"
-    } >> "${PREFIX}$hookdir/emergency/80-${_name}.sh"
-
-    set_systemd_timeout_for_dev $_noreload "$1"
-}
-
-cancel_wait_for_dev() {
-    local _name
-    _name="$(str_replace "$1" '/' '\x2f')"
-    rm -f -- "$hookdir/initqueue/finished/devexists-${_name}.sh"
-    rm -f -- "$hookdir/emergency/80-${_name}.sh"
-    if [ -n "$DRACUT_SYSTEMD" ]; then
-        _name=$(dev_unit_name "$1")
-        rm -f -- "${PREFIX}/etc/systemd/system/initrd.target.wants/${_name}.device"
-        rm -f -- "${PREFIX}/etc/systemd/system/${_name}.device.d/timeout.conf"
-        /sbin/initqueue --onetime --unique --name daemon-reload systemctl daemon-reload
-    fi
 }
 
 killproc() {

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -50,6 +50,7 @@ install() {
     mkdir -p "${initdir}"/tmp
 
     inst_simple "$moddir/dracut-lib.sh" "/lib/dracut-lib.sh"
+    inst_simple "$moddir/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
     mkdir -p "${initdir}"/var
 
     if ! dracut_module_included "systemd"; then
@@ -117,10 +118,8 @@ install() {
                 fi
                 export PREFIX="$initdir"
 
-                # suppress getarg for `rd.memdebug`
-                export DEBUG_MEM_LEVEL=0
-                # shellcheck source=dracut-lib.sh
-                . "$moddir/dracut-lib.sh"
+                # shellcheck source=dracut-dev-lib.sh
+                . "$moddir/dracut-dev-lib.sh"
 
                 for _dev in "${host_devs[@]}"; do
                     for _dev2 in "${root_devs[@]}"; do
@@ -137,7 +136,7 @@ install() {
                     _pdev=$(get_persistent_dev "$_dev")
 
                     case "$_pdev" in
-                        /dev/?*) wait_for_dev "$_pdev" ;;
+                        /dev/?*) wait_for_dev "$_pdev" 0 ;;
                         *) ;;
                     esac
                 done

--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -49,6 +49,7 @@ test_setup() {
         inst "$basedir/modules.d/35network-legacy/ifup.sh" "/sbin/ifup"
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -48,6 +48,7 @@ test_setup() {
         inst "$basedir/modules.d/35network-legacy/ifup.sh" "/sbin/ifup"
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/test/TEST-03-USR-MOUNT/test.sh
+++ b/test/TEST-03-USR-MOUNT/test.sh
@@ -69,6 +69,7 @@ test_setup() {
         inst "$basedir/modules.d/35network-legacy/ifup.sh" "/sbin/ifup"
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -93,6 +93,7 @@ test_setup() {
         inst_multiple -o {,/usr}/lib/systemd/system/"dracut*"
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/test/TEST-10-RAID/test.sh
+++ b/test/TEST-10-RAID/test.sh
@@ -46,6 +46,7 @@ test_setup() {
         inst_multiple -o ${_terminfodir}/l/linux
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -50,6 +50,7 @@ test_setup() {
         inst "$basedir/modules.d/35network-legacy/ifup.sh" "/sbin/ifup"
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -80,6 +80,7 @@ test_setup() {
         inst "$basedir/modules.d/35network-legacy/ifup.sh" "/sbin/ifup"
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/test/TEST-13-ENC-RAID-LVM/test.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test.sh
@@ -78,6 +78,7 @@ test_setup() {
         inst "$basedir/modules.d/35network-legacy/ifup.sh" "/sbin/ifup"
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/test/TEST-14-IMSM/test.sh
+++ b/test/TEST-14-IMSM/test.sh
@@ -75,6 +75,7 @@ test_setup() {
         inst "$basedir/modules.d/35network-legacy/ifup.sh" "/sbin/ifup"
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/test/TEST-15-BTRFSRAID/test.sh
+++ b/test/TEST-15-BTRFSRAID/test.sh
@@ -53,6 +53,7 @@ test_setup() {
         inst "$basedir/modules.d/35network-legacy/ifup.sh" "/sbin/ifup"
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -88,6 +88,7 @@ test_setup() {
         inst "$basedir/modules.d/35network-legacy/ifup.sh" "/sbin/ifup"
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -48,6 +48,7 @@ test_setup() {
         inst "$basedir/modules.d/35network-legacy/ifup.sh" "/sbin/ifup"
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -320,6 +320,7 @@ test_setup() {
         done
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -162,6 +162,7 @@ test_setup() {
         inst_simple /etc/os-release
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -174,6 +174,7 @@ test_setup() {
         inst_simple /etc/os-release
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -219,6 +219,7 @@ make_encrypted_root() {
         inst_multiple -o ${_terminfodir}/l/linux
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
@@ -299,6 +300,7 @@ make_client_root() {
         inst_multiple -o ${_terminfodir}/l/linux
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -270,6 +270,7 @@ test_setup() {
         done
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/test/TEST-98-GETARG/test.sh
+++ b/test/TEST-98-GETARG/test.sh
@@ -15,6 +15,7 @@ test_setup() {
     ln -sfnr "$basedir"/dracut-util "$TESTDIR"/dracut-getarg
     ln -sfnr "$basedir"/dracut-util "$TESTDIR"/dracut-getargs
     ln -sfnr "$basedir"/modules.d/99base/dracut-lib.sh "$TESTDIR"/dracut-lib.sh
+    ln -sfnr "$basedir"/modules.d/99base/dracut-dev-lib.sh "$TESTDIR"/dracut-dev-lib.sh
     return 0
 }
 
@@ -85,6 +86,7 @@ test_run() {
 
         export PATH=".:$PATH"
 
+        . dracut-dev-lib.sh
         . dracut-lib.sh
 
         debug_off() {


### PR DESCRIPTION
To share the `wait_for_dev` function and use it without side effects on
install time, split out the needed functions in an extra library.

Fixes: https://github.com/dracutdevs/dracut/issues/1494