### PR TITLE
Introduce --no-nm-initrd-generator option

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -178,6 +178,9 @@ Creates initial ramdisk images for preloading modules
   --no-hostonly-i18n    Install all keyboard and font files available.
   --hostonly-nics [LIST]
                         Only enable listed NICs in the initramfs.
+  --no-nm-initrd-generator
+                        Don't call nm-initrd-generator to generate network
+                        configuration files
   --persistent-policy [POLICY]
                         Use [POLICY] to address disks and partitions.
                         POLICY can be any directory name found in /dev/disk.
@@ -418,6 +421,7 @@ rearrange_params() {
             --long printsize \
             --long regenerate-all \
             --long noimageifnotneeded \
+            --long no-nm-initrd-generator \
             --long early-microcode \
             --long no-early-microcode \
             --long reproducible \
@@ -778,6 +782,7 @@ while :; do
         --printsize) printsize="yes" ;;
         --regenerate-all) regenerate_all="yes" ;;
         --noimageifnotneeded) noimageifnotneeded="yes" ;;
+        --no-nm-initrd-generator) no_nm_initrd_generator="yes" ;;
         --reproducible) reproducible_l="yes" ;;
         --no-reproducible) reproducible_l="no" ;;
         --uefi) uefi_l="yes" ;;
@@ -1987,6 +1992,12 @@ if [[ $no_kernel != yes ]]; then
             done
         fi
     fi
+fi
+
+if [[ $no_nm_initrd_generator == yes ]]; then
+    mkdir -p "${initdir}"/etc/cmdline.d
+    dinfo "Don't call nm-initrd-generator"
+    echo "rd.no_nm_initrd_generator=1" >> "$initdir"/etc/cmdline.d/20nm-inird-generator.conf
 fi
 
 if [[ $kernel_only != yes ]]; then

--- a/modules.d/35network-manager/nm-lib.sh
+++ b/modules.d/35network-manager/nm-lib.sh
@@ -3,13 +3,14 @@
 type getcmdline > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 nm_generate_connections() {
+
     rm -f /run/NetworkManager/system-connections/*
     if [ -x /usr/libexec/nm-initrd-generator ]; then
         # shellcheck disable=SC2046
-        /usr/libexec/nm-initrd-generator -- $(getcmdline)
+        ! getargbool 0 rd.no_nm_initrd_generator && /usr/libexec/nm-initrd-generator -- $(getcmdline)
     elif [ -x /usr/lib/nm-initrd-generator ]; then
         # shellcheck disable=SC2046
-        /usr/lib/nm-initrd-generator -- $(getcmdline)
+        ! getargbool 0 rd.no_nm_initrd_generator && /usr/lib/nm-initrd-generator -- $(getcmdline)
     else
         derror "nm-initrd-generator not found"
     fi


### PR DESCRIPTION
With this option, kexec-tools can copy the network configurations files in
/etc/NetworkManager/system-connections/ or /etc/sysconfig/network-scripts/ifcfg
to the kdump initramfs directly. Thus it would be much easier for kexec-tools
to set up network to dump vmcore to a remote fs.

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
