### PR TITLE
fix(base): add missing `str_replace` to `dracut-dev-lib.sh`

### DIFF
--- a/modules.d/99base/dracut-dev-lib.sh
+++ b/modules.d/99base/dracut-dev-lib.sh
@@ -1,5 +1,25 @@
 #!/bin/sh
 
+# replaces all occurrences of 'search' in 'str' with 'replacement'
+#
+# str_replace str search replacement
+#
+# example:
+# str_replace '  one two  three  ' ' ' '_'
+str_replace() {
+    local in="$1"
+    local s="$2"
+    local r="$3"
+    local out=''
+
+    while [ "${in##*"$s"*}" != "$in" ]; do
+        chop="${in%%"$s"*}"
+        out="${out}${chop}$r"
+        in="${in#*"$s"}"
+    done
+    echo "${out}${in}"
+}
+
 # get a systemd-compatible unit name from a path
 # (mimicks unit_name_from_path_instance())
 dev_unit_name() {

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -117,6 +117,7 @@ install() {
                     export DRACUT_SYSTEMD=1
                 fi
                 export PREFIX="$initdir"
+                export hookdir=/lib/dracut/hooks
 
                 # shellcheck source=dracut-dev-lib.sh
                 . "$moddir/dracut-dev-lib.sh"


### PR DESCRIPTION
```
dracut-dev-lib.sh: line 92: str_replace: command not found
dracut-dev-lib.sh: line 98: /var/tmp/dracut.sabKZg/initramfs/initqueue/finished/devexists-.sh: No such file or directory
dracut-dev-lib.sh: line 83: /var/tmp/dracut.sabKZg/initramfs/emergency/80-.sh: No such file or directory
```

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
