### PR TITLE
WIP: feat(lvm-systemd): introducing the lvm-systemd module

### DIFF
--- a/modules.d/90lvm-systemd/module-setup.sh
+++ b/modules.d/90lvm-systemd/module-setup.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Prerequisite check(s) for module.
+check() {
+
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
+        for fs in "${host_fs_types[@]}"; do
+            [[ $fs == LVM*_member ]] && return 0
+        done
+        return 255
+    }
+
+    # If the binary(s) requirements are not fulfilled the module can't be installed.
+    require_binaries \
+        lvm \
+        "$udevdir"/pvscan-udev-initrd.sh \
+        || return 1
+
+    # Return 0 to include the module.
+    return 0
+
+}
+
+# Module dependency requirements.
+depends() {
+
+    # This module has external dependency on other module(s).
+    echo rootfs-block dm systemd-udevd
+    # Return 0 to include the dependent module(s) in the initramfs.
+    return 0
+
+}
+
+# Commandline.
+cmdline() {
+    local _activated
+    declare -A _activated
+
+    for dev in "${!host_fs_types[@]}"; do
+        [ -e /sys/block/"${dev#/dev/}"/dm/name ] || continue
+        [ -e /sys/block/"${dev#/dev/}"/dm/uuid ] || continue
+        uuid=$(< /sys/block/"${dev#/dev/}"/dm/uuid)
+        [[ ${uuid#LVM-} == "$uuid" ]] && continue
+        dev=$(< /sys/block/"${dev#/dev/}"/dm/name)
+        eval "$(dmsetup splitname --nameprefixes --noheadings --rows "$dev" 2> /dev/null)"
+        [[ ${DM_VG_NAME} ]] && [[ ${DM_LV_NAME} ]] || return 1
+        if ! [[ ${_activated[DM_VG_NAME / DM_LV_NAME]} ]]; then
+            printf " rd.lvm.lv=%s " "${DM_VG_NAME}/${DM_LV_NAME} "
+            _activated["${DM_VG_NAME}/${DM_LV_NAME}"]=1
+        fi
+    done
+}
+
+# Install kernel module(s).
+installkernel() {
+    hostonly='' instmods dm-snapshot
+}
+
+# Install the required file(s) and directories for the module in the initramfs.
+install() {
+
+    if [[ $hostonly_cmdline == "yes" ]]; then
+        # shellcheck disable=SC2155
+        local _lvmconf=$(cmdline)
+        [[ $_lvmconf ]] && printf "%s\n" "$_lvmconf" >> "${initdir}/etc/cmdline.d/90lvm.conf"
+    fi
+
+    inst_hook cmdline 30 "$moddir/parse-lvm.sh"
+
+    inst_multiple -o \
+        "$udevdir"/pvscan-udev-initrd.sh \
+        "$udevrulesdir"/11-dm-lvm.rules \
+        "$udevrulesdir"/64-lvm.rules \
+        cache_dump cache_restore cache_check cache_repair \
+        era_check era_dump era_invalidate era_restore lvm \
+        thin_dump thin_restore thin_check thin_repair
+
+    # Install required libraries.
+    _arch=${DRACUT_ARCH:-$(uname -m)}
+    inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"libdevmapper-event-lvm*.so"
+
+    # Install the hosts local user configurations if enabled.
+    if [[ $hostonly ]]; then
+        inst_multiple -H -o \
+            /etc/lvm/lvm.conf \
+            /etc/lvm/lvmlocal.conf
+    fi
+
+}

--- a/modules.d/90lvm-systemd/parse-lvm.sh
+++ b/modules.d/90lvm-systemd/parse-lvm.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# This file is part of dracut lvm-systemd module.
+
+if [ -e /etc/lvm/lvm.conf ] && ! getargbool 1 rd.lvm.conf -d -n rd_NO_LVMCONF; then
+    rm -f -- /etc/lvm/lvm.conf
+fi
+
+LV_DEVS="$(getargs rd.lvm.vg -d rd_LVM_VG=) $(getargs rd.lvm.lv -d rd_LVM_LV=)"
+
+# shellcheck disable=SC2030
+# shellcheck disable=SC2031
+if ! getargbool 1 rd.lvm -d -n rd_NO_LVM \
+    || ([ -z "$LV_DEVS" ] && ! getargbool 0 rd.auto); then
+    info "rd.lvm=0: removing LVM activation"
+    rm -f -- /etc/udev/rules.d/64-lvm*.rules
+else
+    for dev in $LV_DEVS; do
+        wait_for_dev -n "/dev/$dev"
+    done
+fi

--- a/pkgbuild/dracut.spec
+++ b/pkgbuild/dracut.spec
@@ -365,6 +365,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/modules.d/90kernel-modules
 %{dracutlibdir}/modules.d/90kernel-modules-extra
 %{dracutlibdir}/modules.d/90lvm
+%{dracutlibdir}/modules.d/90lvm-systemd
 %{dracutlibdir}/modules.d/90mdraid
 %{dracutlibdir}/modules.d/90multipath
 %{dracutlibdir}/modules.d/90nvdimm


### PR DESCRIPTION
Let's get the ball rolling on this one...

Introducing the lvm-systemd module which is basically somewhat sanitized version of those upstream changes here [1]. 

I went with the lvm-systemd naming since we need to split modules into systemd based and none systemd based and those upstream changes bring a hard dependency on systemd.

I made a hard requirement of the existence of the relevant udev script which should be included in the distribution package along with the 64-lvm.rules as in those should normal not be included with the module but handled on a distribution level. 

I cleaned up the entire host section of the shebang flare of what's being done upstream and simply included the relevant hostonly files which should be done anyway since administrators own /etc and we expect them to make changes there as opposed to in other parts of the filesystem.
  
Afaikt that "rework" should not make any functional change.

I left the command line parser script untouched even thou the whole rm foo probably wont work in practice.

1. https://sourceware.org/git/?p=lvm2.git;a=tree;f=dracut;hb=c53bb2b5ea5e5a985e32235515ad21fff62e3b5b