### PR TITLE
fix(dracut): pipe hardlink output to `dinfo`

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2092,7 +2092,7 @@ done
 
 if [[ $do_hardlink == yes ]] && command -v hardlink > /dev/null; then
     dinfo "*** Hardlinking files ***"
-    hardlink "$initdir" 2>&1
+    hardlink "$initdir" 2>&1 | dinfo
     dinfo "*** Hardlinking files done ***"
 fi
 


### PR DESCRIPTION
Otherwise the output is cluttered with:
```
Mode:           real
Files:          1364
Linked:         5 files
Compared:       0 xattrs
Compared:       384 files
Saved:          12.84 KiB
Duration:       0.052674 seconds
```

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
