### PR TITLE
fix(dracut-functions): get_maj_min without get_maj_min_cache_file set

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -234,13 +234,20 @@ get_fs_env() {
 # 8:2
 get_maj_min() {
     local _majmin
-    out="$(grep -m1 -oP "^$1 \K\S+$" "${get_maj_min_cache_file:?}")"
-    if [ -z "$out" ]; then
-        _majmin="$(stat -L -c '%t:%T' "$1" 2> /dev/null)"
-        out="$(printf "%s" "$((0x${_majmin%:*})):$((0x${_majmin#*:}))")"
-        echo "$1 $out" >> "${get_maj_min_cache_file:?}"
+    local _out
+
+    if [[ $get_maj_min_cache_file ]]; then
+        _out="$(grep -m1 -oP "^$1 \K\S+$" "$get_maj_min_cache_file")"
     fi
-    echo -n "$out"
+
+    if ! [[ "$_out" ]]; then
+        _majmin="$(stat -L -c '%t:%T' "$1" 2> /dev/null)"
+        _out="$(printf "%s" "$((0x${_majmin%:*})):$((0x${_majmin#*:}))")"
+        if [[ $get_maj_min_cache_file ]]; then
+            echo "$1 $_out" >> "$get_maj_min_cache_file"
+        fi
+    fi
+    echo -n "$_out"
 }
 
 # get_devpath_block <device>


### PR DESCRIPTION
This pull request changes...

## Changes

If `get_maj_min_cache_file` is unset `get_maj_min()` would error out.

Fix it to work without a cache file set.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
