### PR TITLE
fix(install): configure logging earlier

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -1164,6 +1164,10 @@ static int parse_argv(int argc, char *argv[])
                 }
         }
 
+        if (arg_loglevel >= 0) {
+                log_set_max_level(arg_loglevel);
+        }
+
         if (!kerneldir) {
                 struct utsname buf;
                 uname(&buf);
@@ -2002,17 +2006,13 @@ int main(int argc, char **argv)
         char *path = NULL;
         char *env_no_xattr = NULL;
 
+        log_set_target(LOG_TARGET_CONSOLE);
+        log_parse_environment();
+        log_open();
+
         r = parse_argv(argc, argv);
         if (r <= 0)
                 return r < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
-
-        log_set_target(LOG_TARGET_CONSOLE);
-        log_parse_environment();
-
-        if (arg_loglevel >= 0)
-                log_set_max_level(arg_loglevel);
-
-        log_open();
 
         modules_loaded = hashmap_new(string_hash_func, string_compare_func);
         if (arg_modalias) {


### PR DESCRIPTION
There are log_error() and log_debug() calls in parse_argv().