### PR TITLE
fix(integrity): Require ALLOW_METADATA_WRITES to come from EVM config…

### DIFF
--- a/modules.d/98integrity/evm-enable.sh
+++ b/modules.d/98integrity/evm-enable.sh
@@ -17,7 +17,7 @@ EVM_ACTIVATION_BITS=0
 # EVMKEY: path to the symmetric key; defaults to /etc/keys/evm-trusted.blob
 # EVMKEYDESC: Description of the symmetric key; default is 'evm-key'
 # EVMKEYTYPE: Type of the symmetric key; default is 'encrypted'
-# EMX509: path to x509 cert; default is /etc/keys/x509_evm.der
+# EVMX509: path to x509 cert; default is /etc/keys/x509_evm.der
 # EVM_ACTIVATION_BITS: additional EVM activation bits, such as
 #                      EVM_SETUP_COMPLETE; default is 0
 
@@ -131,7 +131,7 @@ enable_evm() {
     fi
 
     local evm_configured=0
-    local EVM_INIT_HMAC=1 EVM_INIT_X509=2 EVM_ALLOW_METADATA_WRITES=4
+    local EVM_INIT_HMAC=1 EVM_INIT_X509=2
 
     # try to load the EVM encrypted key
     load_evm_key && evm_configured=${EVM_INIT_HMAC}
@@ -146,14 +146,7 @@ enable_evm() {
 
     # initialize EVM
     info "Enabling EVM"
-    if [ "$((evm_configured & EVM_INIT_X509))" -ne 0 ]; then
-        # Older kernels did not support EVM_ALLOW_METADATA_WRITES, try for
-        # newer ones first that need it when an x509 is used
-        echo $((evm_configured | EVM_ALLOW_METADATA_WRITES | EVM_ACTIVATION_BITS)) > "${EVMSECFILE}" \
-            || echo $((evm_configured | EVM_ACTIVATION_BITS)) > "${EVMSECFILE}"
-    else
-        echo $((evm_configured | EVM_ACTIVATION_BITS)) > "${EVMSECFILE}"
-    fi
+    echo $((evm_configured | EVM_ACTIVATION_BITS)) > "${EVMSECFILE}"
 
     if [ "$((evm_configured & EVM_INIT_HMAC))" -ne 0 ]; then
         # unload the EVM encrypted key


### PR DESCRIPTION
… file

Upcoming versions of EVM will not require the ALLOW_METADATA_WRITES anymore,
therefore we remove it from the script and require it to be set in the EVM
config file variable EVM_ACTIVATION_BITS for those versions that need it.

Patch 9 in this patch set deprecates the EVM_ALLOW_METADATA_WRITES flag:
https://lore.kernel.org/linux-integrity/20210514152753.982958-1-roberto.sassu@huawei.com/

Suggested-by: Roberto Sassu <roberto.sassu@huawei.com>
Reviewed-by: Roberto Sassu <roberto.sassu@huawei.com>
Reviewed-by: Mimi Zohar <zohar@linux.ibm.com>
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
