### PR TITLE
feat(iscsi): Skip iscsi parsing on systems without iSCSI boot

### DIFF
--- a/modules.d/95iscsi/parse-iscsiroot.sh
+++ b/modules.d/95iscsi/parse-iscsiroot.sh
@@ -11,6 +11,19 @@
 # root= takes precedence over netroot= if root=iscsi[...]
 #
 
+# For a PV VM, there is no ipxe and hence no ipxe added iBFT ACPI table.
+# So we check for the precence of this table to determine if we are
+# a PV or iSCSI VM/BM.
+
+acpi_ibft="/sys/firmware/acpi/tables/iBFT"
+
+if [ ! -f $acpi_ibft ]; then
+    echo "No $acpi_ibft, assuming PV boot"
+    return 1
+else
+    echo "Found $acpi_ibft, assuming iSCSI boot"
+fi
+
 # This script is sourced, so root should be set. But let's be paranoid
 [ -z "$root" ] && root=$(getarg root=)
 if [ -z "$netroot" ]; then


### PR DESCRIPTION
This fix gives a boot improvement of about 4-5secs on non-iSCSI boot systems

For a system which did not boot via iSCSI, there is no ipxe and hence no
ipxe added iBFT ACPI table - /sys/firmware/acpi/tables/iBFT.

So we check for the precence of this table to determine if we can skip
iscsi parsing and then subsequently skip running iscsiroot.sh script.

This pull request changes...

## Changes

## Checklist
- [x ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
