### PR TITLE
fix(multipath): get config. dir from configuration

### DIFF
--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -63,6 +63,7 @@ installkernel() {
 # called by dracut
 install() {
     local -A _allow
+    local config_dir
 
     add_hostonly_mpath_conf() {
         if is_mpath "$1"; then
@@ -73,6 +74,16 @@ install() {
             _allow["$_dev"]="$_dev"
         fi
     }
+
+    local k v
+    while read -r k v; do
+        if [[ $k == "config_dir" ]]; then
+            v="${v#\"}"
+            config_dir="${v%\"}"
+            break
+        fi
+    done < <(multipath -t 2> /dev/null)
+    [[ -d $config_dir ]] || config_dir=/etc/multipath/conf.d
 
     inst_multiple \
         pkill \
@@ -91,7 +102,7 @@ install() {
         /etc/xdrdevices.conf \
         /etc/multipath.conf \
         /etc/multipath/* \
-        /etc/multipath/conf.d/*
+        "$config_dir"/*
 
     [[ $hostonly ]] && [[ $hostonly_mode == "strict" ]] && {
         for_each_host_dev_and_slaves_all add_hostonly_mpath_conf


### PR DESCRIPTION
Include additional multipath configuration files even if they are placed in a non-default location.

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it