### PR TITLE
Remove quotes from cryptsetupopts in 90crypt module

### DIFF
--- a/modules.d/90crypt/cryptroot-ask.sh
+++ b/modules.d/90crypt/cryptroot-ask.sh
@@ -138,8 +138,9 @@ unset allowdiscards
 ask_passphrase=1
 
 if [ -n "$luksfile" -a "$luksfile" != "none" -a -e "$luksfile" ]; then
+    # shellcheck disable=SC2086
     if readkey "$luksfile" / "$device" \
-        | cryptsetup -d - "$cryptsetupopts" luksOpen "$device" "$luksname"; then
+        | cryptsetup -d - $cryptsetupopts luksOpen "$device" "$luksname"; then
         ask_passphrase=0
     fi
 elif [ "$is_keysource" -ne 0 ]; then
@@ -164,8 +165,9 @@ else
         unset tmp
 
         info "Using '$keypath' on '$keydev'"
+        # shellcheck disable=SC2086
         readkey "$keypath" "$keydev" "$device" \
-            | cryptsetup -d - "$cryptsetupopts" luksOpen "$device" "$luksname" \
+            | cryptsetup -d - $cryptsetupopts luksOpen "$device" "$luksname" \
             && ask_passphrase=0
         unset keypath keydev
         break


### PR DESCRIPTION
Fixes a regression that prevents unlocking of a luks volume with a key file using the 90crypt module.

The reason for the regression is the incorrectly quoted variable $cryptsetupoptions that can contain multiple arguments separated by spaces.

## Changes
* Remove quotes from $cryptsetupopts in 90crypt module.

Fixes #1528
