### PR TITLE
fix(squash): create relative symlinks

### DIFF
--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -53,8 +53,8 @@ installpost() {
     dracut_kernel_post
 
     # Install squash image init script.
-    ln -sfn /usr/bin "$initdir/bin"
-    ln -sfn /usr/sbin "$initdir/sbin"
+    ln_r /usr/bin /bin
+    ln_r /usr/sbin /sbin
     inst_simple "$moddir"/init-squash.sh /init
 }
 


### PR DESCRIPTION
Don't use absolute path, or it may resolve to wrong files after unpack
the initramfs to a subpath on a running system.

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
