### PR TITLE
fix(dracut.sh): handle symlinks and files beginning with '.' appropriately while using '-i' option

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2071,7 +2071,7 @@ for ((i = 0; i < ${#include_src[@]}; i++)); do
             shopt -q -s dotglob
             for objectname in "$src"/*; do
                 [[ -e $objectname || -L $objectname ]] || continue
-                if [[ -d $objectname ]]; then
+                if [[ -d $objectname ]] && [[ ! -L $objectname ]]; then
                     # objectname is a directory, let's compute the final directory name
                     object_destdir=${destdir}/${objectname#$src/}
                     if ! [[ -e $object_destdir ]]; then

--- a/dracut.sh
+++ b/dracut.sh
@@ -2067,6 +2067,8 @@ for ((i = 0; i < ${#include_src[@]}; i++)); do
             # check for preexisting symlinks, so we can cope with the
             # symlinks to $prefix
             # Objectname is a file or a directory
+            reset_dotglob="$(shopt -p dotglob)"
+            shopt -q -s dotglob
             for objectname in "$src"/*; do
                 [[ -e $objectname || -L $objectname ]] || continue
                 if [[ -d $objectname ]]; then
@@ -2077,11 +2079,12 @@ for ((i = 0; i < ${#include_src[@]}; i++)); do
                         mkdir -m 0755 -p "$object_destdir"
                         chmod --reference="$objectname" "$object_destdir"
                     fi
-                    $DRACUT_CP -t "$object_destdir" "$dracutsysrootdir$objectname"/*
+                    $DRACUT_CP -t "$object_destdir" "$dracutsysrootdir$objectname"/.
                 else
                     $DRACUT_CP -t "$destdir" "$dracutsysrootdir$objectname"
                 fi
             done
+            eval "$reset_dotglob"
         elif [[ -e $src ]]; then
             derror "$src is neither a directory nor a regular file"
         else


### PR DESCRIPTION
While including a directory using '--include' option, the file and
subdirectory names that begin with '.' are not included. Also, dracut
throws a warning message when a subdirectory is empty or only has
files or subdirectories that begin with '.'.

For example, while trying to include /tmpdata directory with the
below tree:

```  # tree -a /tmpdata
  /tmpdata
  ├── .anothertestdir
  ├── testdir
  │   └── .testsubdir
  └── .testfile
```
dracut throws the below warning message:

```
  # dracut --include /tmpdata /root
  cp: cannot stat '/tmpdata/testdir/*': No such file or directory
  #
```

and this is how the included /tmpdata directory tree looks:

```
  # tree -a root
  root
  └── testdir
```

No file or directory beginning with '.' is included & also, copying
/tmpdata/testdir reported "No such file or directory" warning. Using
'.' instead of '*' in the below command will fix the warning whether
the directory being copied is empty or only has files or directories
that begin with dot:

```  $DRACUT_CP -t "$object_destdir" "$dracutsysrootdir$objectname"/*```

Also, enable 'dotglob' temporarily to include files and directories
beginning with a `.' in the results of pathname expansion of source
directory being included.

With the above mentioned changes files and directories beginning
with '.' are also included successfully. The included /tmpdata looks
like below with the patch:

```  # tree -a root
  root
  ├── .anothertestdir
  ├── testdir
  │   └── .testsubdir
  └── .testfile
```

 Also, "No such file or directory" warning is not seen anymore for an
empty subdirectory after the patch:

```
  # dracut --include /tmpdata /root
  #
```

Also, if the first level sub-directory is a symlink, a directory is created instead and
all the files in the directory pointed to by the symlink are copied. Ensure a symlink
is created instead by checking for it..


## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
