### PR TITLE
docs: introduce a 'ib-pkey=' command line argument

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -575,6 +575,11 @@ USB Android phone::
 * enp0s29u1u2
 =====================
 
+The following options are supported by the 'network-legacy' dracut
+module. Other network modules might support a slightly different set of
+options; refer to the documentation of the specific network module in use. For
+NetworkManager, see *nm-initrd-generator*(8).
+
 **ip=**__{dhcp|on|any|dhcp6|auto6|either6|link6|single-dhcp}__::
     dhcp|on|any::: get ip from dhcp server from all interfaces. If netroot=dhcp,
     loop sequentially through all interfaces (eth0, eth1, ...) and use the first


### PR DESCRIPTION
An Infiniband network can be segmented in different partitions, similar to VLANs. Each partition is identified by a partition key (P_Key).

On Linux, a new partition for a IP-over-Infiniband device can be created via e.g.:
```
echo 0x8001 > /sys/class/net/ib0/create_child
```
The resulting interface will be `ib0.8001` with P_Key 0x8001.

Document a new command line argument to create the partition.

NetworkManager is going to implement the new option in [1].

[1] https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/884

