### PR TITLE
fix(install): add a missing ret value assignment

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -1448,14 +1448,14 @@ static int install_firmware(struct kmod_module *mod)
                                 _cleanup_globfree_ glob_t globbuf;
                                 glob(fwpath, 0, NULL, &globbuf);
                                 for (i = 0; i < globbuf.gl_pathc; i++) {
-                                        install_firmware_fullpath(globbuf.gl_pathv[i]);
+                                        ret = install_firmware_fullpath(globbuf.gl_pathv[i]);
                                         if (ret != 0) {
                                                 log_info("Possible missing firmware %s for kernel module %s", value,
                                                          kmod_module_get_name(mod));
                                         }
                                 }
                         } else {
-                                install_firmware_fullpath(fwpath);
+                                ret = install_firmware_fullpath(fwpath);
                                 if (ret != 0) {
                                         log_info("Possible missing firmware %s for kernel module %s", value,
                                                  kmod_module_get_name(mod));


### PR DESCRIPTION
Spotted when reconfiguring LGTM for RHEL 9 dracut repo.

/cc @lnykryn 

LGTM link: https://lgtm.com/projects/g/redhat-plumbers/dracut-rhel9/snapshot/9bfa5beea1b251d28deaae948f4bce12d45b1abe/files/src/install/dracut-install.c?sort=name&dir=ASC&mode=heatmap#L1452