### PR TITLE
fix(nvmf): validate_ip_conn

### DIFF
--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -40,15 +40,15 @@ validate_ip_conn() {
         return 1
     fi
 
-    ifname=$(ip -o route get to "$local_address" | sed -n 's/.*dev \([^ ]*\).*/\1/p')
+    ifname=$(ip -o route get from "$local_address" to "$traddr" | sed -n 's/.*dev \([^ ]*\).*/\1/p')
 
-    if ip l show "$ifname" > /dev/null 2>&1; then
+    if ! ip l show "$ifname" > /dev/null 2>&1; then
         warn "invalid network interface $ifname"
         return 1
     fi
 
     # confirm there's a route to destination
-    if ip route get "$traddr" > /dev/null 2>&1; then
+    if ! ip route get "$traddr" > /dev/null 2>&1; then
         warn "no route to $traddr"
         return 1
     fi


### PR DESCRIPTION
1. ifname should be the interface on which $traddr can be reached. It currently gets set to "lo", which is incorrect. This patch identifies the correct interface that would be used for the nvme-of-tcp connection.
2. 'ip l show' and 'ip route get' both succeed if interface and route are present. Current 'if' condition (wrongly) produces a warning when the commands succed. This patch fixes that.

Signed-off-by: Charles Rose <charles.rose@dell.com>

This pull request changes...

## Changes
- fix ifname and route check for nvmf tcp connections.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
