### PR TITLE
fix(crypt-gpg): Execute --card-status on each try

### DIFF
--- a/modules.d/91crypt-gpg/crypt-gpg-lib.sh
+++ b/modules.d/91crypt-gpg/crypt-gpg-lib.sh
@@ -51,7 +51,7 @@ gpg_decrypt() {
     fi
 
     ask_for_password \
-        --cmd "gpg $opts --decrypt $mntp/$keypath" \
+        --cmd "GNUPGHOME=$gpghome gpg --card-status --no-tty > /dev/null 2>&1; gpg $opts --decrypt $mntp/$keypath" \
         --prompt "${inputPrompt:-Password ($keypath on $keydev for $device)}" \
         --tries 3 --tty-echo-off
 


### PR DESCRIPTION
## Changes
Sometimes I forget to insert the gpg card before the first password prompt is printed. 

If the gpg card is not inserted before the `--card-status` command is executed then the public key is not linked with the card. Therefore, the LUKS partition cannot be decrypted. To solve this, the `--card--status` command is executed on each try.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
