### PR TITLE
feat(squash): install umount util

### DIFF
--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -42,11 +42,11 @@ installpost() {
     # Install required modules and binaries for the squash image init script.
     if [[ $_busybox ]]; then
         inst "$_busybox" /usr/bin/busybox
-        for _i in sh echo mount modprobe mkdir switch_root grep; do
+        for _i in sh echo mount modprobe mkdir switch_root grep umount; do
             ln_r /usr/bin/busybox /usr/bin/$_i
         done
     else
-        DRACUT_RESOLVE_DEPS=1 inst_multiple sh mount modprobe mkdir switch_root grep
+        DRACUT_RESOLVE_DEPS=1 inst_multiple sh mount modprobe mkdir switch_root grep umount
     fi
 
     hostonly="" instmods "loop" "squashfs" "overlay"


### PR DESCRIPTION
## Changes

Also install umount binary, make it possible to cleanup squash overlay
mounts. This is useful for other tools reusing the dracut initramfs built
with squash module enabled.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
