### PR TITLE
fix(network-manager): support teaming under NM+systemd

### DIFF
--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -38,6 +38,11 @@ install() {
         inst "$dbussystem"/org.freedesktop.NetworkManager.conf
         inst_multiple nmcli nm-online
 
+        # teaming support under systemd+dbus
+        inst_multiple -o \
+            "$dbussystem"/teamd.conf \
+            "$dbussystemconfdir"/teamd.conf
+
         # Install a configuration snippet to prevent the automatic creation of
         # "Wired connection #" DHCP connections for Ethernet interfaces
         inst_simple "$moddir"/initrd-no-auto-default.conf /usr/lib/NetworkManager/conf.d/


### PR DESCRIPTION
Previously when NM was run without dbus then teaming would come
up appropriately [1], but now that dbus exists we also need to
include some supporting infrastructure to allow for it to work
again.

[1] https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/d689380cfc5734a29b1302d68027190e1a606265
