### PR TITLE
fix(network-manager): pull in network.target in nm-initrd.service

### DIFF
--- a/modules.d/35network-manager/nm-initrd.service
+++ b/modules.d/35network-manager/nm-initrd.service
@@ -3,6 +3,7 @@ DefaultDependencies=no
 Wants=systemd-udev-settle.service
 After=systemd-udev-settle.service
 After=dracut-cmdline.service
+Wants=network.target
 Before=network.target
 ConditionPathExists=/run/NetworkManager/initrd/neednet
 ConditionPathExistsGlob=|/usr/lib/NetworkManager/system-connections/*


### PR DESCRIPTION
Otherwise units with `After=network.target` won't have any effect.