### PR TITLE
fix(dmsquash-live): set correct path to checkisomd5

### DIFF
--- a/modules.d/90dmsquash-live/checkisomd5@.service
+++ b/modules.d/90dmsquash-live/checkisomd5@.service
@@ -6,7 +6,7 @@ Before=shutdown.target
 [Service]
 Type=oneshot
 RemainAfterExit=no
-ExecStart=/bin/checkisomd5 --verbose %f
+ExecStart=/usr/bin/checkisomd5 --verbose %f
 StandardInput=tty-force
 StandardOutput=inherit
 StandardError=inherit


### PR DESCRIPTION
isomd5sum (https://github.com/rhinstaller/isomd5sum) installs the binary into /usr/bin.
/bin/checkisomd5 does not exist in the initrd in ROSA rosa2019.1, but /usr/bin/checkisomd5 does exist.
Maybe "ExecStart=/bin/checkisomd5" works ok on Fedora because /bin is a symlink to /usr/bin?
isomd5sum package in Fedora has only the file /usr/bin/checkisomd5 and does not have /bin/*.

Here we could set "ExecStart=checkisomd5" and avoid relying on any absolute path,
but it is supported in systemd >= 239 from 06.2018 (https://github.com/systemd/systemd/blob/5b8fdb1/NEWS#L4420),
probably it is better to avoid breakages on systems with older systemd like RHEL 7 in this case.
There is no reason why anyone would install checkisomd5 into /bin but not /usr/bin.