### PR TITLE
fix(network-manager): don't pull in systemd-udev-settle

### DIFF
--- a/modules.d/35network-manager/nm-initrd.service
+++ b/modules.d/35network-manager/nm-initrd.service
@@ -1,7 +1,7 @@
 [Unit]
 DefaultDependencies=no
-Wants=systemd-udev-settle.service
-After=systemd-udev-settle.service
+Wants=systemd-udev-trigger.service
+After=systemd-udev-trigger.service
 After=dracut-cmdline.service
 Wants=network.target
 Before=network.target


### PR DESCRIPTION
We get a nice warning about it being deprecated:

```
systemd-udev-settle.service is deprecated. Please fix nm-initrd.service not to pull it in.
```

The service is deprecated because its purpose was to wait for the
discovery of all hardware, but it didn't guarantee that (see the
systemd-udev-settle man page).

NM now runs as an independent service and can deal with devices showing
up at any point, but it does need udev to be started. For now just
Want/After systemd-udev-trigger.