### PR TITLE
fix(multipath): drop dependency on systemd-udev-settle.service

### DIFF
--- a/modules.d/90multipath/multipathd-configure.service
+++ b/modules.d/90multipath/multipathd-configure.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Device-Mapper Multipath Default Configuration
 Before=iscsi.service iscsid.service lvm2-activation-early.service
-Wants=systemd-udev-trigger.service systemd-udev-settle.service local-fs-pre.target
-After=systemd-udev-trigger.service systemd-udev-settle.service
+Wants=systemd-udev-trigger.service local-fs-pre.target
+After=systemd-udev-trigger.service
 Before=local-fs-pre.target multipathd.service
 DefaultDependencies=no
 Conflicts=shutdown.target

--- a/modules.d/90multipath/multipathd.service
+++ b/modules.d/90multipath/multipathd.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Device-Mapper Multipath Device Controller
 Before=iscsi.service iscsid.service lvm2-activation-early.service
-Wants=systemd-udev-trigger.service systemd-udev-settle.service local-fs-pre.target
-After=systemd-udev-trigger.service systemd-udev-settle.service
+Wants=systemd-udev-trigger.service local-fs-pre.target
+After=systemd-udev-trigger.service
 Before=local-fs-pre.target
 Before=initrd-cleanup.service
 DefaultDependencies=no


### PR DESCRIPTION
Rawhide systemd warns about this now:

    udevadm[445]: systemd-udev-settle.service is deprecated. Please fix
    multipathd-configure.service, multipathd.service not to pull it in.

Similarly to #1552, we don't actually need that dependency anyway here.
`multipathd-configure.service` just outputs a file in /etc and shouldn't
need to probe devices, and `multipathd` itself by nature is designed to
handle dynamic udev changes.

So just drop it.