### PR TITLE
fix(emergency): clarify that emergency shell is provided by dracut

### DIFF
--- a/modules.d/98dracut-systemd/dracut-emergency.sh
+++ b/modules.d/98dracut-systemd/dracut-emergency.sh
@@ -23,7 +23,7 @@ if getargbool 1 rd.shell -d -y rdshell || getarg rd.break -d rdbreak; then
             echo "$RDSOSREPORT"
             echo
             echo
-            echo 'Entering emergency mode. Exit the shell to continue.'
+            echo 'Entering dracut emergency mode. Exit the shell to continue.'
             echo 'Type "journalctl" to view system logs.'
             echo 'You might want to save "/run/initramfs/rdsosreport.txt" to a USB stick or /boot'
             echo 'after mounting them and attach it to a bug report.'


### PR DESCRIPTION
Dears, Dracut emergency shell looks similar to Systemd emergency shell: 

[ OK ] Started Tell Plymouth To Write Out Runtime Data.
You are in emergency mode. After logging in, type "journalctl -xb" to view
system logs, "systemctl reboot" to reboot, "systemctl default" or ^D to boot
into default mode.
Give root password for maintenance
(or press Control-D to continue):


---- 

Please print, Entering dracut emergency shell.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
