### PR TITLE
fix(install): reduce cppcheck warnings

### DIFF
--- a/src/install/hashmap.c
+++ b/src/install/hashmap.c
@@ -40,20 +40,20 @@ struct Hashmap {
         compare_func_t compare_func;
 
         struct hashmap_entry *iterate_list_head, *iterate_list_tail;
-        unsigned n_entries;
+        unsigned int n_entries;
 };
 
 #define BY_HASH(h) ((struct hashmap_entry**) ((uint8_t*) (h) + ALIGN(sizeof(Hashmap))))
 
-unsigned string_hash_func(const void *p)
+unsigned int string_hash_func(const void *p)
 {
-        unsigned hash = 5381;
+        unsigned int hash = 5381;
         const signed char *c;
 
         /* DJB's hash function */
 
         for (c = p; *c; c++)
-                hash = (hash << 5) + hash + (unsigned)*c;
+                hash = (hash << 5) + hash + (unsigned int)*c;
 
         return hash;
 }
@@ -63,7 +63,7 @@ int string_compare_func(const void *a, const void *b)
         return strcmp(a, b);
 }
 
-unsigned trivial_hash_func(const void *p)
+unsigned int trivial_hash_func(const void *p)
 {
         return PTR_TO_UINT(p);
 }
@@ -107,7 +107,7 @@ int hashmap_ensure_allocated(Hashmap **h, hash_func_t hash_func, compare_func_t 
         return 0;
 }
 
-static void link_entry(Hashmap *h, struct hashmap_entry *e, unsigned hash)
+static void link_entry(Hashmap *h, struct hashmap_entry *e, unsigned int hash)
 {
         assert(h);
         assert(e);
@@ -135,7 +135,7 @@ static void link_entry(Hashmap *h, struct hashmap_entry *e, unsigned hash)
         assert(h->n_entries >= 1);
 }
 
-static void unlink_entry(Hashmap *h, struct hashmap_entry *e, unsigned hash)
+static void unlink_entry(Hashmap *h, struct hashmap_entry *e, unsigned int hash)
 {
         assert(h);
         assert(e);
@@ -167,7 +167,7 @@ static void unlink_entry(Hashmap *h, struct hashmap_entry *e, unsigned hash)
 static void remove_entry(Hashmap *h, struct hashmap_entry **ep)
 {
         struct hashmap_entry *e = *ep;
-        unsigned hash;
+        unsigned int hash;
 
         assert(h);
         assert(e);
@@ -212,7 +212,7 @@ void hashmap_clear(Hashmap *h)
         }
 }
 
-static struct hashmap_entry *hash_scan(Hashmap *h, unsigned hash, const void *key)
+static struct hashmap_entry *hash_scan(Hashmap *h, unsigned int hash, const void *key)
 {
         struct hashmap_entry *e;
         assert(h);
@@ -228,7 +228,7 @@ static struct hashmap_entry *hash_scan(Hashmap *h, unsigned hash, const void *ke
 int hashmap_put(Hashmap *h, const void *key, void *value)
 {
         struct hashmap_entry *e;
-        unsigned hash;
+        unsigned int hash;
 
         assert(h);
 
@@ -258,7 +258,7 @@ int hashmap_put(Hashmap *h, const void *key, void *value)
 int hashmap_replace(Hashmap *h, const void *key, void *value)
 {
         struct hashmap_entry *e;
-        unsigned hash;
+        unsigned int hash;
 
         assert(h);
 
@@ -275,7 +275,7 @@ int hashmap_replace(Hashmap *h, const void *key, void *value)
 
 void *hashmap_get(Hashmap *h, const void *key)
 {
-        unsigned hash;
+        unsigned int hash;
         struct hashmap_entry *e;
 
         if (!h)
@@ -292,7 +292,7 @@ void *hashmap_get(Hashmap *h, const void *key)
 void *hashmap_remove(Hashmap *h, const void *key)
 {
         struct hashmap_entry *e;
-        unsigned hash;
+        unsigned int hash;
         void *data;
 
         if (!h)
@@ -312,7 +312,7 @@ void *hashmap_remove(Hashmap *h, const void *key)
 int hashmap_remove_and_put(Hashmap *h, const void *old_key, const void *new_key, void *value)
 {
         struct hashmap_entry *e;
-        unsigned old_hash, new_hash;
+        unsigned int old_hash, new_hash;
 
         if (!h)
                 return -ENOENT;
@@ -338,7 +338,7 @@ int hashmap_remove_and_put(Hashmap *h, const void *old_key, const void *new_key,
 int hashmap_remove_and_replace(Hashmap *h, const void *old_key, const void *new_key, void *value)
 {
         struct hashmap_entry *e, *k;
-        unsigned old_hash, new_hash;
+        unsigned int old_hash, new_hash;
 
         if (!h)
                 return -ENOENT;
@@ -366,7 +366,7 @@ int hashmap_remove_and_replace(Hashmap *h, const void *old_key, const void *new_
 void *hashmap_remove_value(Hashmap *h, const void *key, void *value)
 {
         struct hashmap_entry *e;
-        unsigned hash;
+        unsigned int hash;
 
         if (!h)
                 return NULL;
@@ -458,7 +458,7 @@ at_beginning:
 
 void *hashmap_iterate_skip(Hashmap *h, const void *key, Iterator *i)
 {
-        unsigned hash;
+        unsigned int hash;
         struct hashmap_entry *e;
 
         if (!h)
@@ -546,7 +546,7 @@ void *hashmap_steal_first_key(Hashmap *h)
         return key;
 }
 
-unsigned hashmap_size(Hashmap *h)
+unsigned int hashmap_size(Hashmap *h)
 {
 
         if (!h)
@@ -597,7 +597,7 @@ void hashmap_move(Hashmap *h, Hashmap *other)
                 return;
 
         for (e = other->iterate_list_head; e; e = n) {
-                unsigned h_hash, other_hash;
+                unsigned int h_hash, other_hash;
 
                 n = e->iterate_next;
 
@@ -615,7 +615,7 @@ void hashmap_move(Hashmap *h, Hashmap *other)
 
 int hashmap_move_one(Hashmap *h, Hashmap *other, const void *key)
 {
-        unsigned h_hash, other_hash;
+        unsigned int h_hash, other_hash;
         struct hashmap_entry *e;
 
         if (!other)

--- a/src/install/hashmap.h
+++ b/src/install/hashmap.h
@@ -34,13 +34,13 @@ typedef _IteratorStruct *Iterator;
 #define ITERATOR_FIRST ((Iterator) 0)
 #define ITERATOR_LAST ((Iterator) -1)
 
-typedef unsigned (*hash_func_t)(const void *p);
+typedef unsigned int (*hash_func_t)(const void *p);
 typedef int (*compare_func_t)(const void *a, const void *b);
 
-unsigned string_hash_func(const void *p);
+unsigned int string_hash_func(const void *p);
 int string_compare_func(const void *a, const void *b);
 
-unsigned trivial_hash_func(const void *p);
+unsigned int trivial_hash_func(const void *p);
 int trivial_compare_func(const void *a, const void *b);
 
 Hashmap *hashmap_new(hash_func_t hash_func, compare_func_t compare_func);
@@ -60,7 +60,7 @@ int hashmap_merge(Hashmap *h, Hashmap *other);
 void hashmap_move(Hashmap *h, Hashmap *other);
 int hashmap_move_one(Hashmap *h, Hashmap *other, const void *key);
 
-unsigned hashmap_size(Hashmap *h);
+unsigned int hashmap_size(Hashmap *h);
 bool hashmap_isempty(Hashmap *h);
 
 void *hashmap_iterate(Hashmap *h, Iterator *i, const void **key);

--- a/src/install/log.c
+++ b/src/install/log.c
@@ -105,7 +105,7 @@ static int write_to_console(int level, const char *file, unsigned int line, cons
 {
 
         struct iovec iovec[5];
-        unsigned n = 0;
+        unsigned int n = 0;
 
         if (console_fd < 0)
                 return 0;
@@ -130,7 +130,7 @@ static int write_to_console(int level, const char *file, unsigned int line, cons
         return 1;
 }
 
-static int log_dispatch(int level, const char *file, int line, const char *func, char *buffer)
+static int log_dispatch(int level, const char *file, unsigned int line, const char *func, char *buffer)
 {
 
         int r = 0;
@@ -163,7 +163,7 @@ static int log_dispatch(int level, const char *file, int line, const char *func,
         return r;
 }
 
-int log_metav(int level, const char *file, int line, const char *func, const char *format, va_list ap)
+int log_metav(int level, const char *file, unsigned int line, const char *func, const char *format, va_list ap)
 {
 
         char buffer[LINE_MAX];
@@ -182,7 +182,7 @@ int log_metav(int level, const char *file, int line, const char *func, const cha
         return r;
 }
 
-int log_meta(int level, const char *file, int line, const char *func, const char *format, ...)
+int log_meta(int level, const char *file, unsigned int line, const char *func, const char *format, ...)
 {
 
         int r;
@@ -197,7 +197,8 @@ int log_meta(int level, const char *file, int line, const char *func, const char
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
-_noreturn_ static void log_assert(const char *text, const char *file, int line, const char *func, const char *format)
+_noreturn_ static void log_assert(const char *text, const char *file, unsigned int line, const char *func,
+                                  const char *format)
 {
         static char buffer[LINE_MAX];
 
@@ -212,12 +213,12 @@ _noreturn_ static void log_assert(const char *text, const char *file, int line, 
 
 #pragma GCC diagnostic pop
 
-_noreturn_ void log_assert_failed(const char *text, const char *file, int line, const char *func)
+_noreturn_ void log_assert_failed(const char *text, const char *file, unsigned int line, const char *func)
 {
         log_assert(text, file, line, func, "Assertion '%s' failed at %s:%u, function %s(). Aborting.");
 }
 
-_noreturn_ void log_assert_failed_unreachable(const char *text, const char *file, int line, const char *func)
+_noreturn_ void log_assert_failed_unreachable(const char *text, const char *file, unsigned int line, const char *func)
 {
         log_assert(text, file, line, func, "Code should not be reached '%s' at %s:%u, function %s(). Aborting.");
 }

--- a/src/install/log.h
+++ b/src/install/log.h
@@ -67,12 +67,13 @@ void log_close_console(void);
 
 void log_parse_environment(void);
 
-int log_meta(int level, const char *file, int line, const char *func, const char *format, ...) _printf_attr_(5, 6);
+int log_meta(int level, const char *file, unsigned int line, const char *func,
+             const char *format, ...) _printf_attr_(5, 6);
 
-int log_metav(int level, const char *file, int line, const char *func, const char *format, va_list ap);
+int log_metav(int level, const char *file, unsigned int line, const char *func, const char *format, va_list ap);
 
-_noreturn_ void log_assert_failed(const char *text, const char *file, int line, const char *func);
-_noreturn_ void log_assert_failed_unreachable(const char *text, const char *file, int line, const char *func);
+_noreturn_ void log_assert_failed(const char *text, const char *file, unsigned int line, const char *func);
+_noreturn_ void log_assert_failed_unreachable(const char *text, const char *file, unsigned int line, const char *func);
 
 /* This modifies the buffer passed! */
 int log_dump_internal(int level, const char *file, int line, const char *func, char *buffer);

--- a/src/install/macro.h
+++ b/src/install/macro.h
@@ -190,9 +190,9 @@ static inline size_t ALIGN_TO(size_t l, size_t ali)
                 _i->iov_len = strlen(_s);       \
         } while(false)
 
-static inline size_t IOVEC_TOTAL_SIZE(const struct iovec *i, unsigned n)
+static inline size_t IOVEC_TOTAL_SIZE(const struct iovec *i, unsigned int n)
 {
-        unsigned j;
+        unsigned int j;
         size_t r = 0;
 
         for (j = 0; j < n; j++)
@@ -201,9 +201,9 @@ static inline size_t IOVEC_TOTAL_SIZE(const struct iovec *i, unsigned n)
         return r;
 }
 
-static inline size_t IOVEC_INCREMENT(struct iovec *i, unsigned n, size_t k)
+static inline size_t IOVEC_INCREMENT(struct iovec *i, unsigned int n, size_t k)
 {
-        unsigned j;
+        unsigned int j;
 
         for (j = 0; j < n; j++) {
                 size_t sub;

--- a/src/install/strv.c
+++ b/src/install/strv.c
@@ -90,7 +90,7 @@ char **strv_copy(char *const *l)
 
 unsigned int strv_length(char *const *l)
 {
-        unsigned n = 0;
+        unsigned int n = 0;
 
         if (!l)
                 return 0;
@@ -105,7 +105,7 @@ char **strv_new_ap(const char *x, va_list ap)
 {
         const char *s;
         char **a;
-        unsigned n = 0, i = 0;
+        unsigned int n = 0, i = 0;
         va_list aq;
 
         /* As a special trick we ignore all listed strings that equal
@@ -248,7 +248,7 @@ char **strv_split(const char *s, const char *separator)
         char *state;
         char *w;
         size_t l;
-        unsigned n, i;
+        unsigned int n, i;
         char **r;
 
         assert(s);
@@ -282,7 +282,7 @@ char **strv_split_quoted(const char *s)
         char *state;
         char *w;
         size_t l;
-        unsigned n, i;
+        unsigned int n, i;
         char **r;
 
         assert(s);
@@ -406,7 +406,7 @@ fail:
 int strv_push(char ***l, char *value)
 {
         char **c;
-        unsigned n;
+        unsigned int n;
 
         if (!value)
                 return 0;
@@ -510,7 +510,7 @@ char **strv_remove_prefix(char **l, const char *s)
 char **strv_parse_nulstr(const char *s, size_t l)
 {
         const char *p;
-        unsigned c = 0, i = 0;
+        unsigned int c = 0, i = 0;
         char **v;
 
         assert(s || l == 0);

--- a/src/install/strv.h
+++ b/src/install/strv.h
@@ -95,7 +95,7 @@ void strv_print(char **l);
                 if (!first)                                     \
                         _l = (char**) &first;                   \
                 else {                                          \
-                        unsigned _n;                            \
+                        unsigned int _n;                        \
                         va_list _ap;                            \
                                                                 \
                         _n = 1;                                 \

--- a/src/install/util.c
+++ b/src/install/util.c
@@ -96,7 +96,7 @@ void close_nointr_nofail(int fd)
 int open_terminal(const char *name, int mode)
 {
         int fd, r;
-        unsigned c = 0;
+        unsigned int c = 0;
 
         /*
          * If a TTY is in the process of being closed opening it might
@@ -161,7 +161,7 @@ bool is_main_thread(void)
         return cached > 0;
 }
 
-int safe_atou(const char *s, unsigned *ret_u)
+int safe_atou(const char *s, unsigned int *ret_u)
 {
         char *x = NULL;
         unsigned long l;
@@ -175,10 +175,10 @@ int safe_atou(const char *s, unsigned *ret_u)
         if (!x || *x || errno)
                 return errno ? -errno : -EINVAL;
 
-        if ((unsigned long)(unsigned)l != l)
+        if ((unsigned long)(unsigned int)l != l)
                 return -ERANGE;
 
-        *ret_u = (unsigned)l;
+        *ret_u = (unsigned int)l;
         return 0;
 }
 

--- a/src/install/util.h
+++ b/src/install/util.h
@@ -155,7 +155,7 @@ bool first_word(const char *s, const char *word);
 
 int close_nointr(int fd);
 void close_nointr_nofail(int fd);
-void close_many(const int fds[], unsigned n_fd);
+void close_many(const int fds[], unsigned int n_fd);
 
 int parse_boolean(const char *v);
 int parse_usec(const char *t, usec_t *usec);
@@ -165,7 +165,7 @@ int parse_pid(const char *s, pid_t *ret_pid);
 int parse_uid(const char *s, uid_t *ret_uid);
 #define parse_gid(s, ret_uid) parse_uid(s, ret_uid)
 
-int safe_atou(const char *s, unsigned *ret_u);
+int safe_atou(const char *s, unsigned int *ret_u);
 int safe_atoi(const char *s, int *ret_i);
 
 int safe_atollu(const char *s, unsigned long long *ret_u);
@@ -174,8 +174,8 @@ int safe_atolli(const char *s, long long int *ret_i);
 #if LONG_MAX == INT_MAX
 static inline int safe_atolu(const char *s, unsigned long *ret_u)
 {
-        assert_cc(sizeof(unsigned long) == sizeof(unsigned));
-        return safe_atou(s, (unsigned *)ret_u);
+        assert_cc(sizeof(unsigned long) == sizeof(unsigned int));
+        return safe_atou(s, (unsigned int *)ret_u);
 }
 
 static inline int safe_atoli(const char *s, long int *ret_u)
@@ -199,8 +199,8 @@ static inline int safe_atoli(const char *s, long int *ret_u)
 
 static inline int safe_atou32(const char *s, uint32_t *ret_u)
 {
-        assert_cc(sizeof(uint32_t) == sizeof(unsigned));
-        return safe_atou(s, (unsigned *)ret_u);
+        assert_cc(sizeof(uint32_t) == sizeof(unsigned int));
+        return safe_atou(s, (unsigned int *)ret_u);
 }
 
 static inline int safe_atoi32(const char *s, int32_t *ret_i)
@@ -312,7 +312,7 @@ unsigned long long random_ull(void);
         }                                                               \
         scope type name##_from_string(const char *s) {                  \
                 type i;                                                 \
-                unsigned u = 0;                                         \
+                unsigned int u = 0;                                     \
                 assert(s);                                              \
                 for (i = 0; i < (type)ELEMENTSOF(name##_table); i++)    \
                         if (name##_table[i] &&                          \
@@ -331,7 +331,7 @@ unsigned long long random_ull(void);
 int fd_nonblock(int fd, bool nonblock);
 int fd_cloexec(int fd, bool cloexec);
 
-int close_all_fds(const int except[], unsigned n_except);
+int close_all_fds(const int except[], unsigned int n_except);
 
 bool fstype_is_network(const char *fstype);
 
@@ -385,22 +385,22 @@ int rm_rf(const char *path, bool only_dirs, bool delete_root, bool honour_sticky
 
 int pipe_eof(int fd);
 
-cpu_set_t *cpu_set_malloc(unsigned *ncpus);
+cpu_set_t *cpu_set_malloc(unsigned int *ncpus);
 
 void status_vprintf(const char *status, bool ellipse, const char *format, va_list ap);
 void status_printf(const char *status, bool ellipse, const char *format, ...);
 void status_welcome(void);
 
 int fd_columns(int fd);
-unsigned columns(void);
+unsigned int columns(void);
 
 int fd_lines(int fd);
-unsigned lines(void);
+unsigned int lines(void);
 
 int running_in_chroot(void);
 
-char *ellipsize(const char *s, size_t length, unsigned percent);
-char *ellipsize_mem(const char *s, size_t old_length, size_t new_length, unsigned percent);
+char *ellipsize(const char *s, size_t length, unsigned int percent);
+char *ellipsize_mem(const char *s, size_t old_length, size_t new_length, unsigned int percent);
 
 int touch(const char *path);
 
@@ -575,7 +575,7 @@ static inline void umaskp(mode_t *u)
 int fd_inc_sndbuf(int fd, size_t n);
 int fd_inc_rcvbuf(int fd, size_t n);
 
-int fork_agent(pid_t *pid, const int except[], unsigned n_except, const char *path, ...);
+int fork_agent(pid_t *pid, const int except[], unsigned int n_except, const char *path, ...);
 
 int setrlimit_closest(int resource, const struct rlimit *rlim);
 


### PR DESCRIPTION
Fixed few cppcheck warnings

Find the attached for cppcheck results
[cppcheck-results.txt](https://github.com/dracutdevs/dracut/files/6806386/cppcheck-results.txt)

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>
Signed-off-by: Shreenidhi Shedi <yesshedi@gmail.com>

This pull request changes...

## Changes
installer code fixes

## Checklist
- [] I have tested it locally
- [] I have reviewed and updated any documentation if relevant
- [] I am providing new code and test(s) for it

Fixes #
nit picking fixes