### PR TITLE
fix(qeth_rules): check the existence of /sys/devices/qeth/*/online beforehand

### DIFF
--- a/modules.d/95qeth_rules/module-setup.sh
+++ b/modules.d/95qeth_rules/module-setup.sh
@@ -10,6 +10,7 @@ check() {
 
     [[ $hostonly ]] && {
         for i in /sys/devices/qeth/*/online; do
+            [ ! -f "$i" ] && continue
             read -r _online < "$i"
             [ "$_online" -eq 1 ] && return 0
         done


### PR DESCRIPTION
On s390x KVM machines, the follow errors occurred,
```
    $ kdumpctl rebuild
    kdump: Rebuilding /boot/initramfs-4.18.0-321.el8.s390xkdump.img
    /usr/lib/dracut/modules.d/95qeth_rules/module-setup.sh: line 13: /sys/devices/qeth/*/online: No such file or directory
    /usr/lib/dracut/modules.d/95qeth_rules/module-setup.sh: line 13: /sys/devices/qeth/*/online: No such file or directory
```

because s390x KVM uses virtual devices and /sys/devices/qeth/*/online
doesn't exist. Eliminate this error by checking the existence
beforehand.


## Changes


## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
