### PR TITLE
fix(base): Fix installing dracut-util

### DIFF
--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -19,7 +19,7 @@ install() {
 
     inst_multiple -o findmnt less kmod
 
-    inst_binary "${dracutsysrootdir}${dracutbasedir}/dracut-util" "/usr/bin/dracut-util"
+    inst_binary "${dracutbasedir}/dracut-util" "/usr/bin/dracut-util"
 
     ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
     ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"


### PR DESCRIPTION
inst_binary uses ${dracutsysrootdir} internally to find the source
file.

Signed-off-by: Zoltán Böszörményi <zboszor@gmail.com>

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #

The generated initramfs printed errors during boot because `dracut-util` was missing behind `dracut-getarg` and `dracut-getargs`.