### PR TITLE
fix(base): do not quote $initargs for switch_root

### DIFF
--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -387,7 +387,8 @@ if [ -f /etc/capsdrop ]; then
         }
 else
     unset RD_DEBUG
-    exec "$SWITCH_ROOT" "$NEWROOT" "$INIT" "$initargs" || {
+    # shellcheck disable=SC2086
+    exec "$SWITCH_ROOT" "$NEWROOT" "$INIT" $initargs || {
         warn "Something went very badly wrong in the initramfs.  Please "
         warn "file a bug against dracut."
         emergency_shell


### PR DESCRIPTION
We want word splitting to occur so that the arguments are passed
separately, and we don't end up passing an empty string if no arguments
are specified.

Bug: https://bugs.gentoo.org/803548
Fixes: 2fabaaa62dcfd31e593ca45e1374e55adae29d6b