### PR TITLE
fix(squash): remove tailing '/' when installing ld.so.conf.d

### DIFF
--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -31,7 +31,7 @@ installpost() {
     # initdir also needs ld.so.* to make ld.so work
     inst /etc/ld.so.cache
     inst /etc/ld.so.conf
-    inst_dir /etc/ld.so.conf.d/
+    inst_dir /etc/ld.so.conf.d
 
     # Create mount points for squash loader
     mkdir -p "$initdir"/squash/


### PR DESCRIPTION
## Changes

This tailing '/' will result in following error:

dracut-install: ERROR: installing '/etc/ld.so.conf.d/'
dracut: FAILED: /usr/lib/dracut/dracut-install -D /var/tmp/dracut.kEFQLs/initramfs -d /etc/ld.so.conf.d/

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it