### PR TITLE
fix(network-manager): include nm-daemon-helper binary

### DIFF
--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -31,6 +31,7 @@ install() {
 
     inst NetworkManager
     inst_multiple -o /usr/{lib,libexec}/nm-initrd-generator
+    inst_multiple -o /usr/{lib,libexec}/nm-daemon-helper
     inst_multiple -o teamd dhclient
     inst_hook cmdline 99 "$moddir/nm-config.sh"
     if dracut_module_included "systemd"; then


### PR DESCRIPTION
Since version 1.32, NetworkManager launches a tiny external helper to determine the hostname via reverse DNS resolution through glibc's nss-dns. Include the binary.

- [x] I have tested it locally by rebuilding the initrd and letting NM resolve the hostname via the helper
