### PR TITLE
fix(network-manager): write DHCP filename option to dhcpopts file

### DIFF
--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -56,6 +56,7 @@ kf_parse() {
 dhcpopts_create() {
     kf_parse root-path new_root_path < "$1"
     kf_parse next-server new_next_server < "$1"
+    kf_parse dhcp-bootfile filename < "$1"
 }
 
 for _i in /sys/class/net/*; do


### PR DESCRIPTION
Anaconda parses the 'filename' variable [1] set in /tmp/net.$netif.dhcpopts to determine the name of the kickstart file to use.

[1] https://github.com/rhinstaller/anaconda/blob/anaconda-35.21-1/dracut/fetch-kickstart-net.sh#L31-L34
