### PR TITLE
fix(cms): reload NetworkManager connections

### DIFF
--- a/modules.d/35network-manager/nm-lib.sh
+++ b/modules.d/35network-manager/nm-lib.sh
@@ -28,3 +28,7 @@ nm_generate_connections() {
         done
     fi
 }
+
+nm_reload_connections() {
+    [ -n "$DRACUT_SYSTEMD" ] && systemctl is-active nm-initrd.service && nmcli connection reload
+}

--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -19,7 +19,7 @@ depends() {
     if [ -z "$network_handler" ]; then
         if [[ -x $dracutsysrootdir$systemdsystemunitdir/wicked.service ]]; then
             network_handler="network-wicked"
-        elif [[ -x $dracutsysrootdir/usr/libexec/nm-initrd-generator ]]; then
+        elif [[ -x $dracutsysrootdir/usr/libexec/nm-initrd-generator ]] || [[ -x $dracutsysrootdir/usr/lib/nm-initrd-generator ]]; then
             network_handler="network-manager"
         elif [[ -x $dracutsysrootdir$systemdutildir/systemd-networkd ]]; then
             network_handler="systemd-networkd"

--- a/modules.d/80cms/cmsifup.sh
+++ b/modules.d/80cms/cmsifup.sh
@@ -34,7 +34,7 @@ fi
 IFACES="$IFACES $DEVICE"
 echo "$IFACES" >> /tmp/net.ifaces
 
-if [ -x /usr/libexec/nm-initrd-generator ]; then
+if [ -x /usr/libexec/nm-initrd-generator ] || [ -x /usr/lib/nm-initrd-generator ]; then
     type nm_generate_connections > /dev/null 2>&1 || . /lib/nm-lib.sh
     nm_generate_connections
 else

--- a/modules.d/80cms/cmsifup.sh
+++ b/modules.d/80cms/cmsifup.sh
@@ -37,6 +37,7 @@ echo "$IFACES" >> /tmp/net.ifaces
 if [ -x /usr/libexec/nm-initrd-generator ] || [ -x /usr/lib/nm-initrd-generator ]; then
     type nm_generate_connections > /dev/null 2>&1 || . /lib/nm-lib.sh
     nm_generate_connections
+    nm_reload_connections
 else
     exec ifup "$DEVICE"
 fi


### PR DESCRIPTION
When NetworkManager is running as systemd service, it's not enough to write connection files; the module should also tell NetworkManager to reload the connections from disk so that any new connection can be auto-activated.

https://bugzilla.redhat.com/show_bug.cgi?id=1975929

