### PR TITLE
fix(squash): apply FIPS and libpthread workaround

### DIFF
--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -52,6 +52,12 @@ installpost() {
         done
     else
         DRACUT_RESOLVE_DEPS=1 inst_multiple sh mount modprobe mkdir switch_root grep umount
+
+        # libpthread workaround: pthread_cancel wants to dlopen libgcc_s.so
+        inst_libdir_file -o "libgcc_s.so*"
+
+        # FIPS workaround for Fedora/RHEL: libcrypto needs libssl when FIPS is enabled
+        [[ $DRACUT_FIPS_MODE ]] && inst_libdir_file -o "libssl.so*"
     fi
 
     hostonly="" instmods "loop" "squashfs" "overlay"


### PR DESCRIPTION
There are some workarounds in dracut.sh for FIPS/libpthread covering
some hidden lib dependency issues. These workarounds didn't take effect
for the squash loader since the squash loader is installed
independently. So apply these workarounds again.

Also skip the lib detection code, since these extra installed libs
are small, and squash loader contents are dropped after switch root,
won't be an issue to be always installed. And this makes the code
cleaner.

Signed-off-by: Kairui Song <kasong@redhat.com>

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
