### PR TITLE
fix(usrmount): do not empty _dev variable

### DIFF
--- a/modules.d/98usrmount/mount-usr.sh
+++ b/modules.d/98usrmount/mount-usr.sh
@@ -55,7 +55,12 @@ mount_usr() {
     while read -r _dev _mp _fs _opts _freq _passno || [ -n "$_dev" ]; do
         [ "${_dev%%#*}" != "$_dev" ] && continue
         if [ "$_mp" = "/usr" ]; then
-            _dev="$(label_uuid_to_dev "$_dev")"
+            case "$_dev" in
+                LABEL=* | UUID=* | PARTUUID=* | PARTLABEL=*)
+                    _dev="$(label_uuid_to_dev "$_dev")"
+                    ;;
+                *) ;;
+            esac
 
             if strstr "$_opts" "subvol=" \
                 && [ "${root#block:}" -ef "$_dev" ] \


### PR DESCRIPTION
Currently $_dev is always overridden with the value returned by
label_uuid_to_dev(). This results in an empty value if $_dev is a
device path. Fix this by calling label_uuid_to_dev() conditionally.

Bug: https://bugs.gentoo.org/807971

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes d3532978de04c78f53664dad7b37705a49a7ee54
