### PR TITLE
tr fix

### DIFF
--- a/modules.d/91crypt-gpg/module-setup.sh
+++ b/modules.d/91crypt-gpg/module-setup.sh
@@ -3,7 +3,7 @@
 # GPG support is optional
 # called by dracut
 check() {
-    require_binaries gpg || return 1
+    require_binaries gpg tr || return 1
 
     if sc_requested; then
         if ! sc_supported; then
@@ -23,7 +23,7 @@ depends() {
 
 # called by dracut
 install() {
-    inst_multiple gpg
+    inst_multiple gpg tr
     inst "$moddir/crypt-gpg-lib.sh" "/lib/dracut-crypt-gpg-lib.sh"
 
     if sc_requested; then

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -15,7 +15,7 @@ depends() {
 install() {
     inst_multiple mount mknod mkdir sleep chroot chown \
         sed ls flock cp mv dmesg rm ln rmmod mkfifo umount readlink setsid \
-        modprobe chmod
+        modprobe chmod tr
 
     inst_multiple -o findmnt less kmod
 


### PR DESCRIPTION
There are two modules that forget to install `tr`: base and crypt-gpg. In base is used everywhere to parse the kernel command line parameters. If this is not pulled explicitly there are situations where the root disk parsing will fail because of the missing `tr`.

## Changes
adds `tr` to inst_multiple in base and crypt-gpg

## Checklist
- [ x ] I have tested it locally
- [ n/a ] I have reviewed and updated any documentation if relevant
- [ x ] I am providing new code and test(s) for it

Fixes #
