### PR TITLE
fix(dracut.sh): require root to run hostonly mode

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1079,6 +1079,10 @@ fi
 
 [[ $hostonly == yes ]] && hostonly="-h"
 [[ $hostonly != "-h" ]] && unset hostonly
+if [[ $hostonly ]] && [[ $EUID != 0 ]]; then
+    printf "%s\n" "dracut: hostonly mode must be run as root! Please use 'sudo'." >&2
+    exit 1
+fi
 
 case $hostonly_mode in
     '')


### PR DESCRIPTION
The base module install function (modules.d/99base/module-setup.sh) cannot read /etc/shadow in hostonly mode if the user is not root ([line here](https://github.com/dracutdevs/dracut/blob/master/modules.d/99base/module-setup.sh#L38)), but dracut allows to create the initramfs anyway. This causes that it is not possible to log in to the emergency shell with the newly created initramfs.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
