### PR TITLE
ci: change default compression option for SUSE

### DIFF
--- a/dracut.conf.d/suse.conf.example
+++ b/dracut.conf.d/suse.conf.example
@@ -7,7 +7,7 @@
 hostonly="yes"
 hostonly_cmdline="yes"
 
-compress="xz -0 --check=crc32 --memlimit-compress=50%"
+compress="zstd"
 
 i18n_vars="/etc/sysconfig/language:RC_LANG-LANG,RC_LC_ALL-LC_ALL /etc/sysconfig/console:CONSOLE_UNICODEMAP-FONT_UNIMAP,CONSOLE_FONT-FONT,CONSOLE_SCREENMAP-FONT_MAP /etc/sysconfig/keyboard:KEYTABLE-KEYMAP"
 omit_drivers+=" i2o_scsi "

--- a/dracut.sh
+++ b/dracut.sh
@@ -2381,6 +2381,11 @@ case $compress in
         ;;
 esac
 
+if [[ $compress == $DRACUT_COMPRESS_ZSTD* ]] && ! check_kernel_config CONFIG_RD_ZSTD; then
+    dwarn "dracut: kernel has no zstd support compiled in."
+    compress="cat"
+fi
+
 if ! (
     umask 077
     cd "$initdir"


### PR DESCRIPTION
This pull request changes the default compression option for SUSE to zstd, due to an internal company decision.
It also checks whether the target kernel has zstd support compiled in; otherwise, it does not compress the initramfs image.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
