### PR TITLE
allow to disable running nm-initrd-generator when rd.nm-initrd-generator=0

### DIFF
--- a/modules.d/35network-manager/nm-lib.sh
+++ b/modules.d/35network-manager/nm-lib.sh
@@ -4,14 +4,16 @@ type getcmdline > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 nm_generate_connections() {
     rm -f /run/NetworkManager/system-connections/*
-    if [ -x /usr/libexec/nm-initrd-generator ]; then
-        # shellcheck disable=SC2046
-        /usr/libexec/nm-initrd-generator -- $(getcmdline)
-    elif [ -x /usr/lib/nm-initrd-generator ]; then
-        # shellcheck disable=SC2046
-        /usr/lib/nm-initrd-generator -- $(getcmdline)
-    else
-        derror "nm-initrd-generator not found"
+    if getargbool 1 rd.nm-initrd-generator; then
+        if [ -x /usr/libexec/nm-initrd-generator ]; then
+            # shellcheck disable=SC2046
+            /usr/libexec/nm-initrd-generator -- $(getcmdline)
+        elif [ -x /usr/lib/nm-initrd-generator ]; then
+            # shellcheck disable=SC2046
+            /usr/lib/nm-initrd-generator -- $(getcmdline)
+        else
+            derror "nm-initrd-generator not found"
+        fi
     fi
 
     if getargbool 0 rd.neednet; then


### PR DESCRIPTION
With `rd.nm-initrd-generator=0` kexec-tools can copy the network configurations files in
/etc/NetworkManager/system-connections/ or /etc/sysconfig/network-scripts/ifcfg
to the kdump initramfs directly. Thus it would be much easier for kexec-tools
to set up network to dump vmcore to a remote fs.
## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
