### PR TITLE
fix(multipath): drop ExecStop= setting from service unit

### DIFF
--- a/modules.d/90multipath/multipathd.service
+++ b/modules.d/90multipath/multipathd.service
@@ -14,11 +14,11 @@ ConditionKernelCommandLine=!rd_NO_MULTIPATH
 ConditionKernelCommandLine=!multipath=off
 
 [Service]
-Type=simple
+Type=notify
+NotifyAccess=main
 ExecStartPre=-/sbin/modprobe dm-multipath
 ExecStart=/sbin/multipathd -s -d
 ExecReload=/sbin/multipathd reconfigure
-ExecStop=/sbin/multipathd shutdown
 
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
This removes the `ExecStop=` field from multipath.service.
Some CI runs do rarely encounter a failure related to this
service in initrd, which seems to be stemming from a socket
I/O race between the client and the server on shutdown.
It looks like the client (`multipathd shutdown`) can lose the race,
hit an I/O error, and cause the whole unit to fail (even if the server
managed to shutdown properly already).

Notably, the upstream unit does not have such stop command
as the daemon can already perform a graceful exit through
its signal handler.

As such, this commit re-aligns the two units by dropping the
custom stop-command, thus avoiding any of the existing
races.

Refs:
 * https://github.com/coreos/fedora-coreos-tracker/issues/803
 * https://github.com/opensvc/multipath-tools/blob/0.8.7/multipathd/multipathd.service