### PR TITLE
Minor fixes on `95suspend` and `99base`

### DIFF
--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -50,7 +50,7 @@ install() {
     fi
 
     # Optional uswsusp support
-    for _bin in /usr/sbin/resume /usr/lib/suspend/resume /usr/lib/uswsusp/resume; do
+    for _bin in /usr/sbin/resume /usr/lib/suspend/resume /usr/lib64/suspend/resume /usr/lib/uswsusp/resume /usr/lib64/uswsusp/resume; do
         [[ -x $dracutsysrootdir${_bin} ]] && {
             inst "${_bin}" /usr/sbin/resume
             [[ $hostonly ]] && [[ -f $dracutsysrootdir/etc/suspend.conf ]] && inst -H /etc/suspend.conf

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -599,6 +599,9 @@ label_uuid_to_dev() {
         PARTUUID=*)
             echo "/dev/disk/by-partuuid/$(echo "${_dev#PARTUUID=}" | tr "[:upper:]" "[:lower:]")"
             ;;
+        *)
+            echo "$_dev"
+            ;;
     esac
 }
 


### PR DESCRIPTION
This pull request fixes `95suspend` module and a function from `99base`, so resumes from hibernation using https://github.com/bircoph/suspend work in Gentoo.

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
- `95suspend` module setup now also searches for /usr/lib64/suspend/resume and /usr/lib64/uswsusp/resume , which are relevant on distros like Gentoo.
- `label_uuid_to_dev` now returns the unaltered input when it does not match any of the alternate ways to designate a device. Previously, the function was returning nothing, leading to potential failures in several places.
