### PR TITLE
fix(dracut.sh): check if kernel has zstd support

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2378,13 +2378,12 @@ case $compress in
         ;;
     zstd)
         compress="$DRACUT_COMPRESS_ZSTD -15 -q -T0"
+        if ! check_kernel_config CONFIG_RD_ZSTD; then
+            dwarn "dracut: kernel has no zstd support compiled in, skipping image compression."
+            compress="cat"
+        fi
         ;;
 esac
-
-if [[ $compress == $DRACUT_COMPRESS_ZSTD* ]] && ! check_kernel_config CONFIG_RD_ZSTD; then
-    dwarn "dracut: kernel has no zstd support compiled in."
-    compress="cat"
-fi
 
 if ! (
     umask 077


### PR DESCRIPTION
This pull request changes... in compression logic

## Changes

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes commit https://github.com/dracutdevs/dracut/commit/591118c56da2bfcea060e3b7671bc87b23c0e44a

In my opinion something went wrong in PR review process:
- why introduce external check for zstd in-kernel support
- why zstd support in kernel must be checked now? Why nobody bother for gz/bzip2/lz4/others by following this logic? Does zstd is some kind of special one ?

