### PR TITLE
fix(fips.sh): repsect rd.fips.skipkernel

### DIFF
--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -113,58 +113,61 @@ do_fips() {
 
     KERNEL=$(uname -r)
 
-    fips_info "Checking integrity of kernel"
-    if [ -e "/run/initramfs/live/vmlinuz0" ]; then
-        do_rhevh_check /run/initramfs/live/vmlinuz0 || return 1
-    elif [ -e "/run/initramfs/live/isolinux/vmlinuz0" ]; then
-        do_rhevh_check /run/initramfs/live/isolinux/vmlinuz0 || return 1
-    elif [ -e "/run/install/repo/images/pxeboot/vmlinuz" ]; then
-        # This is a boot.iso with the .hmac inside the install.img
-        do_rhevh_check /run/install/repo/images/pxeboot/vmlinuz || return 1
-    else
-        BOOT_IMAGE="$(getarg BOOT_IMAGE)"
+    if ! getarg rd.fips.skipkernel > /dev/null; then
 
-        # On s390x, BOOT_IMAGE isn't a path but an integer representing the
-        # entry number selected. Let's try the root of /boot first, and
-        # otherwise fallback to trying to parse the BLS entries if it's a
-        # BLS-based system.
-        if [ "$(uname -m)" = s390x ]; then
-            if [ -e "/boot/vmlinuz-${KERNEL}" ]; then
-                BOOT_IMAGE="vmlinuz-${KERNEL}"
-            elif [ -d /boot/loader/entries ]; then
-                bls=$(find /boot/loader/entries -name '*.conf' | sort -rV | sed -n "$((BOOT_IMAGE + 1))p")
-                if [ -e "${bls}" ]; then
-                    BOOT_IMAGE=$(grep ^linux "${bls}" | cut -d' ' -f2)
+        fips_info "Checking integrity of kernel"
+        if [ -e "/run/initramfs/live/vmlinuz0" ]; then
+            do_rhevh_check /run/initramfs/live/vmlinuz0 || return 1
+        elif [ -e "/run/initramfs/live/isolinux/vmlinuz0" ]; then
+            do_rhevh_check /run/initramfs/live/isolinux/vmlinuz0 || return 1
+        elif [ -e "/run/install/repo/images/pxeboot/vmlinuz" ]; then
+            # This is a boot.iso with the .hmac inside the install.img
+            do_rhevh_check /run/install/repo/images/pxeboot/vmlinuz || return 1
+        else
+            BOOT_IMAGE="$(getarg BOOT_IMAGE)"
+
+            # On s390x, BOOT_IMAGE isn't a path but an integer representing the
+            # entry number selected. Let's try the root of /boot first, and
+            # otherwise fallback to trying to parse the BLS entries if it's a
+            # BLS-based system.
+            if [ "$(uname -m)" = s390x ]; then
+                if [ -e "/boot/vmlinuz-${KERNEL}" ]; then
+                    BOOT_IMAGE="vmlinuz-${KERNEL}"
+                elif [ -d /boot/loader/entries ]; then
+                    bls=$(find /boot/loader/entries -name '*.conf' | sort -rV | sed -n "$((BOOT_IMAGE + 1))p")
+                    if [ -e "${bls}" ]; then
+                        BOOT_IMAGE=$(grep ^linux "${bls}" | cut -d' ' -f2)
+                    fi
                 fi
             fi
-        fi
 
-        # Trim off any leading GRUB boot device (e.g. ($root) )
-        BOOT_IMAGE="$(echo "${BOOT_IMAGE}" | sed 's/^(.*)//')"
+            # Trim off any leading GRUB boot device (e.g. ($root) )
+            BOOT_IMAGE="$(echo "${BOOT_IMAGE}" | sed 's/^(.*)//')"
 
-        BOOT_IMAGE_NAME="${BOOT_IMAGE##*/}"
-        BOOT_IMAGE_PATH="${BOOT_IMAGE%${BOOT_IMAGE_NAME}}"
+            BOOT_IMAGE_NAME="${BOOT_IMAGE##*/}"
+            BOOT_IMAGE_PATH="${BOOT_IMAGE%${BOOT_IMAGE_NAME}}"
 
-        if [ -z "$BOOT_IMAGE_NAME" ]; then
-            BOOT_IMAGE_NAME="vmlinuz-${KERNEL}"
-        elif ! [ -e "/boot/${BOOT_IMAGE_PATH}/${BOOT_IMAGE_NAME}" ]; then
-            #if /boot is not a separate partition BOOT_IMAGE might start with /boot
-            BOOT_IMAGE_PATH=${BOOT_IMAGE_PATH#"/boot"}
-            #on some achitectures BOOT_IMAGE does not contain path to kernel
-            #so if we can't find anything, let's treat it in the same way as if it was empty
-            if ! [ -e "/boot/${BOOT_IMAGE_PATH}/${BOOT_IMAGE_NAME}" ]; then
+            if [ -z "$BOOT_IMAGE_NAME" ]; then
                 BOOT_IMAGE_NAME="vmlinuz-${KERNEL}"
-                BOOT_IMAGE_PATH=""
+            elif ! [ -e "/boot/${BOOT_IMAGE_PATH}/${BOOT_IMAGE_NAME}" ]; then
+                #if /boot is not a separate partition BOOT_IMAGE might start with /boot
+                BOOT_IMAGE_PATH=${BOOT_IMAGE_PATH#"/boot"}
+                #on some achitectures BOOT_IMAGE does not contain path to kernel
+                #so if we can't find anything, let's treat it in the same way as if it was empty
+                if ! [ -e "/boot/${BOOT_IMAGE_PATH}/${BOOT_IMAGE_NAME}" ]; then
+                    BOOT_IMAGE_NAME="vmlinuz-${KERNEL}"
+                    BOOT_IMAGE_PATH=""
+                fi
             fi
-        fi
 
-        BOOT_IMAGE_HMAC="/boot/${BOOT_IMAGE_PATH}/.${BOOT_IMAGE_NAME}.hmac"
-        if ! [ -e "${BOOT_IMAGE_HMAC}" ]; then
-            warn "${BOOT_IMAGE_HMAC} does not exist"
-            return 1
-        fi
+            BOOT_IMAGE_HMAC="/boot/${BOOT_IMAGE_PATH}/.${BOOT_IMAGE_NAME}.hmac"
+            if ! [ -e "${BOOT_IMAGE_HMAC}" ]; then
+                warn "${BOOT_IMAGE_HMAC} does not exist"
+                return 1
+            fi
 
-        (cd "${BOOT_IMAGE_HMAC%/*}" && sha512hmac -c "${BOOT_IMAGE_HMAC}") || return 1
+            (cd "${BOOT_IMAGE_HMAC%/*}" && sha512hmac -c "${BOOT_IMAGE_HMAC}") || return 1
+        fi
     fi
 
     fips_info "All initrd crypto checks done"


### PR DESCRIPTION
Support for this flag was broken in 4257798f8ad8570e6918ca9b819ffa254d4316ff

This pull request changes...

## Changes

## Checklist
- [*] I have tested it locally
- [*] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
