### PR TITLE
fix(01fips/module-setup.sh): remove root build requirements.

### DIFF
--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -70,16 +70,4 @@ install() {
     inst_multiple sha512hmac rmmod insmod mount uname umount grep sed cut find sort
 
     inst_simple /etc/system-fips
-    [ -c "${initdir}"/dev/random ] || mknod "${initdir}"/dev/random c 1 8 \
-        || {
-            dfatal "Cannot create /dev/random"
-            dfatal "To create an initramfs with fips support, dracut has to run as root"
-            return 1
-        }
-    [ -c "${initdir}"/dev/urandom ] || mknod "${initdir}"/dev/urandom c 1 9 \
-        || {
-            dfatal "Cannot create /dev/random"
-            dfatal "To create an initramfs with fips support, dracut has to run as root"
-            return 1
-        }
 }


### PR DESCRIPTION
Since /dev/ is mounted as devtmpfs early in the boot process,
the fips modules does not need to statically populate devices in it.
As such, there is no need to run as root when building with the fips modules

This pull request changes...

## Changes

## Checklist
- [*] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
