### PR TITLE
fix(dmsquash-live): iso-scan requires rmdir

### DIFF
--- a/modules.d/90dmsquash-live/module-setup.sh
+++ b/modules.d/90dmsquash-live/module-setup.sh
@@ -22,7 +22,7 @@ installkernel() {
 
 # called by dracut
 install() {
-    inst_multiple umount dmsetup blkid dd losetup blockdev find
+    inst_multiple umount dmsetup blkid dd losetup blockdev find rmdir
     inst_multiple -o checkisomd5
     inst_hook cmdline 30 "$moddir/parse-dmsquash-live.sh"
     inst_hook cmdline 31 "$moddir/parse-iso-scan.sh"


### PR DESCRIPTION
/sbin/iso-scan: line 36: "rmdir: command not found" messages are flooding the console (and potentially preventing to see more important errors).

Make sure rmdir is installed for the module.

## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
