### PR TITLE
fix(dracut.sh): do not ignore invalid config file or dir path

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -888,20 +888,26 @@ export DRACUT_LOG_LEVEL=warning
 [[ $dracutbasedir ]] || dracutbasedir="$dracutsysrootdir"/usr/lib/dracut
 
 # if we were not passed a config file, try the default one
-if [[ ! -f $conffile ]]; then
+if [[ -z $conffile ]]; then
     if [[ $allowlocal ]]; then
         conffile="$dracutbasedir/dracut.conf"
     else
         conffile="$dracutsysrootdir/etc/dracut.conf"
     fi
+elif [[ ! -f $conffile ]]; then
+    printf "%s\n" "dracut: Configuration file '$conffile' not found." >&2
+    exit 1
 fi
 
-if [[ ! -d $confdir ]]; then
+if [[ -z $confdir ]]; then
     if [[ $allowlocal ]]; then
         confdir="$dracutbasedir/dracut.conf.d"
     else
         confdir="$dracutsysrootdir/etc/dracut.conf.d"
     fi
+elif [[ ! -d $confdir ]]; then
+    printf "%s\n" "dracut: Configuration directory '$confdir' not found." >&2
+    exit 1
 fi
 
 # source our config file


### PR DESCRIPTION
Invalid config file/directory path should not be silently ignored.

Fixes issue #1136

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1136