### PR TITLE
fix(90kernel-modules): add isp1760 USB controller

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -96,6 +96,7 @@ installkernel() {
                 "=drivers/usb/dwc2" \
                 "=drivers/usb/dwc3" \
                 "=drivers/usb/host" \
+                "=drivers/usb/isp1760" \
                 "=drivers/usb/misc" \
                 "=drivers/usb/musb" \
                 "=drivers/usb/phy" \


### PR DESCRIPTION
Like the dwc/chipidea controllers the isp1760 can act in either
host or gadget mode so it ends up in it's own directory. Add this
driver into the initrd as it's part of some arm platforms and
is needed to be able to boot off USB storage.

Fixes issue #1619

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1619
