### PR TITLE
feat(dm-integrity): add module for systemd-integritysetup

### DIFF
--- a/modules.d/01systemd-integritysetup/module-setup.sh
+++ b/modules.d/01systemd-integritysetup/module-setup.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Prerequisite check(s) for module.
+check() {
+
+    # If the binary(s) requirements are not fulfilled the module can't be installed.
+    require_binaries \
+        "$systemdutildir"/systemd-integritysetup \
+        "$systemdutildir"/system-generators/systemd-integritysetup-generator \
+        || return 1
+
+    # Return 255 to only include the module, if another module requires it.
+    return 255
+
+}
+
+# Module dependency requirements.
+depends() {
+
+    # This module has external dependency on other module(s).
+    echo systemd dm
+    # Return 0 to include the dependent module(s) in the initramfs.
+    return 0
+
+}
+
+installkernel() {
+    instmods dm-integrity
+}
+
+# Install the required file(s) and directories for the module in the initramfs.
+install() {
+
+    inst_multiple -o \
+        "$systemdutildir"/systemd-integritysetup \
+        "$systemdutildir"/system-generators/systemd-integritysetup-generator \
+        "$systemdsystemunitdir"/integritysetup-pre.target \
+        "$systemdsystemunitdir"/integritysetup.target \
+        "$systemdsystemunitdir"/sysinit.target.wants/integritysetup.target
+
+    # Install the hosts local user configurations if enabled.
+    if [[ $hostonly ]]; then
+        inst_multiple -H -o \
+            /etc/integritytab \
+            "$systemdsystemconfdir"/integritysetup.target \
+            "$systemdsystemconfdir/integritysetup.target.wants/*.target" \
+            "$systemdsystemconfdir"/integritysetup-pre.target \
+            "$systemdsystemconfdir/integritysetup-pre.target.wants/*.target" \
+            "$systemdsystemconfdir"/sysinit.target.wants/integritysetup.target \
+            "$systemdsystemconfdir/sysinit.target.wants/integritysetup.target.wants/*.target"
+    fi
+
+    # Install required libraries.
+    _arch=${DRACUT_ARCH:-$(uname -m)}
+    inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*"
+
+}

--- a/pkgbuild/dracut.spec
+++ b/pkgbuild/dracut.spec
@@ -328,6 +328,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/modules.d/01systemd-coredump
 %{dracutlibdir}/modules.d/01systemd-hostnamed
 %{dracutlibdir}/modules.d/01systemd-initrd
+%{dracutlibdir}/modules.d/01systemd-integritysetup
 %{dracutlibdir}/modules.d/01systemd-journald
 %{dracutlibdir}/modules.d/01systemd-ldconfig
 %{dracutlibdir}/modules.d/01systemd-modules-load


### PR DESCRIPTION
Adds module support for [systemd-integritysetup](https://github.com/systemd/systemd/pull/20902) which utilizes [dm-integrity](https://www.kernel.org/doc/html/latest/admin-guide/device-mapper/dm-integrity.html).

## Changes

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


