### PR TITLE
fix(install): segfault on popen error

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -550,6 +550,10 @@ static int resolve_deps(const char *src)
         ret = 0;
 
         fptr = popen(cmd, "r");
+        if (fptr == NULL) {
+                log_error("Error '%s' initiating pipe stream from '%s'", strerror(errno), cmd);
+                exit(EXIT_FAILURE);
+        }
 
         while (!feof(fptr)) {
                 char *p;


### PR DESCRIPTION
Now dracut-install writes message like
`dracut-install: Error 'Cannot allocate memory' initiating pipe stream from 'ldd /bin/sh4 2>&1'`
instead of segmentation fault