### PR TITLE
feat(mdraid): enable passing environment variables to mdadm

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -475,6 +475,10 @@ MD RAID
     only activate the raid sets with the given UUID. This parameter can be
     specified multiple times.
 
+**rd.md.env=**__ENVVAR=VALUE__::
+    set environment variable ENVVAR before calling mdadm. This parameter can be
+    specified multiple times.
+
 DM RAID
 ~~~~~~~
 **rd.dm=0**::

--- a/modules.d/90mdraid/mdadm-wrapper.sh
+++ b/modules.d/90mdraid/mdadm-wrapper.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# Wrapper used to set environment variables in mdadm environment
+#
+
+. /lib/dracut-lib.sh
+
+for envvar in $(getargs rd.md.env=); do
+    splitsep '=' "$envvar" key value
+    eval export "$key='${value}'"
+done
+exec /sbin/mdadm.real "${@:-}"

--- a/modules.d/90mdraid/module-setup.sh
+++ b/modules.d/90mdraid/module-setup.sh
@@ -69,7 +69,8 @@ install() {
     inst_multiple cat expr
     inst_multiple -o mdmon
     inst "$(command -v partx)" /sbin/partx
-    inst "$(command -v mdadm)" /sbin/mdadm
+    inst "$(command -v mdadm)" /sbin/mdadm.real
+    inst "$moddir/mdadm-wrapper.sh" "/sbin/mdadm"
 
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _raidconf


### PR DESCRIPTION
This feature is useful for testing, e.g. when testing IMSM without having the required hardware.

With the patch, to test IMSM without the hardware, it's enough to add
the following to kernel command line parameters:
~~~
rd.md.env=IMSM_NO_PLATFORM=1
~~~

## Changes

New `rd.md.env` parameter (multi-valued) to pass environment variables to `mdadm` binary.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [??] I am providing new code and test(s) for it (I don't know how to test this)
