### PR TITLE
fix(mdraid): allow UUID comparison for more than one UUID

### DIFF
--- a/modules.d/90mdraid/mdraid_start.sh
+++ b/modules.d/90mdraid/mdraid_start.sh
@@ -54,7 +54,7 @@ _md_force_run() {
             _UUID=$(str_replace "$_UUID" ":" "")
 
             # check if we should handle this device
-            strstr " $_MD_UUID " " $_UUID " || continue
+            strstr "$_MD_UUID" "$_UUID" || continue
 
             _md_start "${_md}"
         done


### PR DESCRIPTION
If the system provides more than one UUID, the __MD_UUID_ var contains a [line break](https://github.com/dracutdevs/dracut/blob/master/modules.d/99base/dracut-lib.sh#L315) after each UUID. Therefore the [strstr](https://github.com/dracutdevs/dracut/blob/master/modules.d/99base/dracut-lib.sh#L31)
function could not find any UUID, caused by the additional spaces provided to the function.

Furthermore this could lead to a boot interruption, because the start of a degraded raid1 won't be executed. So, manual
interaction is necessary.

**Scenario**:
System with two raid1 (md0+md1) partitions. One disk fails and system tries to boot:

- udev discovers raid partitions and starts to assemble them [incrementally](https://github.com/dracutdevs/dracut/blob/master/modules.d/90mdraid/65-md-incremental-imsm.rules#L42)
- both raid partitions stay degraded because second disk is missing
- rd.retry timeout kicks in and [executes](https://github.com/dracutdevs/dracut/blob/master/modules.d/90mdraid/65-md-incremental-imsm.rules#L34) /sbin/mdraid_start
- [comparison](https://github.com/dracutdevs/dracut/blob/master/modules.d/90mdraid/mdraid_start.sh#L57) of existing UUIDs fails
- dracut timeouts and falls into emergency shell

**Simplified bugfix output**:
```
#!/bin/bash

strstr() { [[ $1 == *"$2"* ]]; }

UUID=$(printf '%s\n' AAA BBB)
TEST="BBB"

strstr " $UUID " " $TEST " || echo bug
strstr "$UUID" "$TEST" && echo fix

#########################################

++ printf '%s\n' AAA BBB
+ UUID='AAA
BBB'
+ TEST=BBB
+ strstr ' AAA
BBB ' ' BBB '
+ [[  AAA
BBB  == *\ \B\B\B\ * ]]
+ echo bug
bug
+ strstr 'AAA
BBB' BBB
+ [[ AAA
BBB == *\B\B\B* ]]
+ echo fix
fix
```

## Changes

Removed additional spaces from input of comparison function.
[Manpage](https://github.com/dracutdevs/dracut/blob/master/man/dracut.cmdline.7.asc#md-raid
) about _rd.md.uuid_ ("This parameter can be specified multiple times.") is true again ;)

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it