### PR TITLE
fix(resume): check for presence of /sys/power/resume

### DIFF
--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -13,7 +13,7 @@ check() {
     # Only support resume if hibernation is currently on
     # and no swap is mounted on a net device
     [[ $hostonly ]] || [[ $mount_needs ]] && {
-        swap_on_netdevice || [[ "$(cat /sys/power/resume)" == "0:0" ]] && return 255
+        swap_on_netdevice || [[ -f /sys/power/resume && "$(cat /sys/power/resume)" == "0:0" ]] && return 255
     }
 
     return 0


### PR DESCRIPTION
On platforms where the kernel is built without suspend/resume support we
see "cat: /sys/power/resume: No such file or directory" message when
creating an initrd image. Check for the presence of /sys/power/resume
first before reading it.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [N/A] I am providing new code and test(s) for it
