### PR TITLE
feat(crypt): check if tpm2-tss module is needed in hostonly mode

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -18,7 +18,14 @@ check() {
 
 # called by dracut
 depends() {
-    echo dm rootfs-block
+    local deps
+    deps="dm rootfs-block"
+    if [[ $hostonly && -f "$dracutsysrootdir"/etc/crypttab ]]; then
+        if grep -q "tpm2-device=" "$dracutsysrootdir"/etc/crypttab; then
+            deps+=" tpm2-tss"
+        fi
+    fi
+    echo "$deps"
     return 0
 }
 


### PR DESCRIPTION
In hostonly mode, include the tpm2-tss module if any encrypted volumes are configured in `/etc/crypttab` to be decrypted using the TPM2 device (`tpm2-device=` option).

More info on the [crypttab man page](https://www.freedesktop.org/software/systemd/man/crypttab.html#tpm2-device=).

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it