### PR TITLE
fix(base): do not change the provided UUID

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -6,11 +6,6 @@ set -e
 [ -e /run/initramfs/bin/sh ] && exit 0
 [ -e /run/initramfs/.need_shutdown ] || exit 0
 
-# SIGTERM signal is received upon forced shutdown: ignore the signal
-# We want to remain alive to be able to trap unpacking errors to avoid
-# switching root to an incompletely unpacked initramfs
-trap 'echo "Received SIGTERM signal, ignoring!" >&2' TERM
-
 KERNEL_VERSION="$(uname -r)"
 
 [[ $dracutbasedir ]] || dracutbasedir=/usr/lib/dracut

--- a/modules.d/80cms/module-setup.sh
+++ b/modules.d/80cms/module-setup.sh
@@ -27,7 +27,7 @@ install() {
     inst_script "$moddir/cmsifup.sh" /sbin/cmsifup
     # shellcheck disable=SC2046
     inst_multiple /etc/cmsfs-fuse/filetypes.conf /etc/udev/rules.d/99-fuse.rules /etc/fuse.conf \
-        cmsfs-fuse fusermount bash insmod rmmod cat normalize_dasd_arg sed \
+        cmsfs-fuse fusermount ulockmgr_server bash insmod rmmod cat normalize_dasd_arg sed \
         $(rpm -ql s390utils-base) awk getopt
 
     inst_libdir_file "gconv/*"

--- a/modules.d/90dmsquash-live-ntfs/module-setup.sh
+++ b/modules.d/90dmsquash-live-ntfs/module-setup.sh
@@ -13,7 +13,7 @@ depends() {
 }
 
 install() {
-    inst_multiple fusermount mount.fuse ntfs-3g
+    inst_multiple fusermount ulockmgr_server mount.fuse ntfs-3g
     dracut_need_initqueue
 }
 

--- a/modules.d/95dasd_rules/module-setup.sh
+++ b/modules.d/95dasd_rules/module-setup.sh
@@ -26,6 +26,7 @@ check() {
     local found=0
     local bdev
     [ "$_arch" = "s390" -o "$_arch" = "s390x" ] || return 1
+    require_binaries /usr/lib/udev/collect || return 1
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         for bdev in /sys/block/*; do
@@ -49,6 +50,7 @@ depends() {
 
 # called by dracut
 install() {
+    inst_multiple /usr/lib/udev/collect
     inst_hook cmdline 30 "$moddir/parse-dasd.sh"
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _dasd

--- a/modules.d/95qeth_rules/module-setup.sh
+++ b/modules.d/95qeth_rules/module-setup.sh
@@ -5,6 +5,7 @@ check() {
     local _arch=${DRACUT_ARCH:-$(uname -m)}
     local _online=0
     [ "$_arch" = "s390" -o "$_arch" = "s390x" ] || return 1
+    require_binaries /usr/lib/udev/collect || return 1
     dracut_module_included network || return 1
 
     [[ $hostonly ]] && {
@@ -55,4 +56,5 @@ install() {
         [ -n "$id" ] && inst_rules_qeth "$id"
     done
 
+    inst_simple /usr/lib/udev/collect
 }

--- a/modules.d/95zfcp_rules/module-setup.sh
+++ b/modules.d/95zfcp_rules/module-setup.sh
@@ -45,6 +45,7 @@ check() {
     local _arch=${DRACUT_ARCH:-$(uname -m)}
     local _ccw
     [ "$_arch" = "s390" -o "$_arch" = "s390x" ] || return 1
+    require_binaries /usr/lib/udev/collect || return 1
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         found=0
@@ -65,6 +66,7 @@ depends() {
 
 # called by dracut
 install() {
+    inst_multiple /usr/lib/udev/collect
     inst_hook cmdline 30 "$moddir/parse-zfcp.sh"
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _zfcp

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -594,10 +594,10 @@ label_uuid_to_dev() {
             echo "/dev/disk/by-partlabel/$(echo "${_dev#PARTLABEL=}" | sed 's,/,\\x2f,g;s, ,\\x20,g')"
             ;;
         UUID=*)
-            echo "/dev/disk/by-uuid/$(echo "${_dev#UUID=}")"
+            echo "/dev/disk/by-uuid/$(echo "${_dev#UUID=}" | tr "[:upper:]" "[:lower:]")"
             ;;
         PARTUUID=*)
-            echo "/dev/disk/by-partuuid/$(echo "${_dev#PARTUUID=}")"
+            echo "/dev/disk/by-partuuid/$(echo "${_dev#PARTUUID=}" | tr "[:upper:]" "[:lower:]")"
             ;;
     esac
 }

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -594,10 +594,10 @@ label_uuid_to_dev() {
             echo "/dev/disk/by-partlabel/$(echo "${_dev#PARTLABEL=}" | sed 's,/,\\x2f,g;s, ,\\x20,g')"
             ;;
         UUID=*)
-            echo "/dev/disk/by-uuid/$(echo "${_dev#UUID=}" | tr "[:upper:]" "[:lower:]")"
+            echo "/dev/disk/by-uuid/$(echo "${_dev#UUID=}")"
             ;;
         PARTUUID=*)
-            echo "/dev/disk/by-partuuid/$(echo "${_dev#PARTUUID=}" | tr "[:upper:]" "[:lower:]")"
+            echo "/dev/disk/by-partuuid/$(echo "${_dev#PARTUUID=}")"
             ;;
     esac
 }

--- a/test/run-qemu
+++ b/test/run-qemu
@@ -3,14 +3,13 @@
 # We prefer kvm, kqemu, userspace in that order.
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
-QEMU_CPU="${QEMU_CPU:-max}"
 
-[[ -x /usr/bin/qemu ]] && BIN=/usr/bin/qemu && ARGS=(-cpu "$QEMU_CPU")
+[[ -x /usr/bin/qemu ]] && BIN=/usr/bin/qemu && ARGS=(-cpu max)
 (lsmod | grep -q '^kqemu ') && BIN=/usr/bin/qemu && ARGS=(-kernel-kqemu -cpu host)
 [[ -c /dev/kvm && -x /usr/bin/kvm ]] && BIN=/usr/bin/kvm && ARGS=(-cpu host)
 [[ -c /dev/kvm && -x /usr/bin/qemu-kvm ]] && BIN=/usr/bin/qemu-kvm && ARGS=(-cpu host)
 [[ -c /dev/kvm && -x /usr/libexec/qemu-kvm ]] && BIN=/usr/libexec/qemu-kvm && ARGS=(-cpu host)
-[[ -x /usr/bin/qemu-system-$(uname -m) ]] && BIN=/usr/bin/qemu-system-$(uname -m) && ARGS=(-cpu "$QEMU_CPU")
+[[ -x /usr/bin/qemu-system-$(uname -m) ]] && BIN=/usr/bin/qemu-system-$(uname -m) && ARGS=(-cpu max)
 [[ -c /dev/kvm && -x /usr/bin/qemu-system-$(uname -m) ]] && BIN=/usr/bin/qemu-system-$(uname -m) && ARGS=(-enable-kvm -cpu host)
 
 [[ $BIN ]] || {

--- a/tools/test-github.sh
+++ b/tools/test-github.sh
@@ -41,7 +41,6 @@ else
             cd /lib/modules
             ls -1 | tail -1
         )" \
-        QEMU_CPU="IvyBridge-v2" \
         DRACUT_NO_XATTR=1 \
         TEST_RUN_ID="$RUN_ID" \
         ${TESTS:+TESTS="$TESTS"} \


### PR DESCRIPTION
This was introduced by
https://github.com/dracutdevs/dracut/commit/d3532978de04c78f53664dad7b37705a49a7ee54
Bugzilla:
https://bugzilla.redhat.com/show_bug.cgi?id=2012496

This pull request changes...

## Changes
During boot dracut parses the provided UUID to lower case and thus starts an endless loop wating for the devise to appear. The device is actually mapped correctly by the kernel (which doesn't tweak the UUID) but because we are waiting for a name with lower charachters the expeted device never appers which drops us at the emergency shell leaving the system unbootable.
This happens especially on nfts/fat filesystems because technically those don't have a UUID but searial numbers which are used by the linux tools as UUID.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
https://github.com/dracutdevs/dracut/issues/1635
