### PR TITLE
fix(man): default value of rd.retry was increased to 180 seconds

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -151,7 +151,7 @@ Misc
 
 **rd.retry=**__<seconds>__::
     specify how long dracut should retry the initqueue to configure devices.
-    The default is 30 seconds. After 2/3 of the time, degraded raids are force
+    The default is 180 seconds. After 2/3 of the time, degraded raids are force
     started. If you have hardware, which takes a very long time to announce its
     drives, you might want to extend this value.
 


### PR DESCRIPTION
The [man page](https://github.com/dracutdevs/dracut/blob/master/man/dracut.cmdline.7.asc#misc) still states the old value of `rd.retry` of _30 seconds_, which does not reflect the [current situation](https://github.com/dracutdevs/dracut/blob/master/modules.d/99base/init.sh#L163) ([introduced here](https://github.com/dracutdevs/dracut/commit/517d27a75f678d4c295cbb07687453950b55df5a)) of _180 seconds_.

## Changes

Update man page of `rd.retry` to 180 seconds.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
