### PR TITLE
feat(fido2): introducing the fido2 module

### DIFF
--- a/modules.d/91fido2/module-setup.sh
+++ b/modules.d/91fido2/module-setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Prerequisite check(s) for module.
+check() {
+    # Return 255 to only include the module, if another module requires it.
+    return 255
+}
+
+# Module dependency requirements.
+depends() {
+    # This module has external dependency on other module(s).
+    echo systemd-udevd
+    # Return 0 to include the dependent module(s) in the initramfs.
+    return 0
+}
+
+# Install the required file(s) and directories for the module in the initramfs.
+install() {
+    # Install required libraries.
+    _arch=${DRACUT_ARCH:-$(uname -m)}
+    inst_libdir_file \
+        {"tls/$_arch/",tls/,"$_arch/",}"libfido2.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libcbor.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libhidapi-hidraw.so.*"
+}

--- a/pkgbuild/dracut.spec
+++ b/pkgbuild/dracut.spec
@@ -372,6 +372,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/modules.d/90qemu
 %{dracutlibdir}/modules.d/91crypt-gpg
 %{dracutlibdir}/modules.d/91crypt-loop
+%{dracutlibdir}/modules.d/91fido2
 %{dracutlibdir}/modules.d/91tpm2-tss
 %{dracutlibdir}/modules.d/95debug
 %{dracutlibdir}/modules.d/95fstab-sys


### PR DESCRIPTION
From systemd v248, the systemd-cryptsetup component allows to unlock encrypted storage using FIDO2 security tokens.

This module adds to the initramfs image the dependencies required to unlock an encrypted root filesystem, which are basically the [libfido2](https://github.com/Yubico/libfido2) library and its missing dependencies.
It also needs the `60-fido-id.rules` and the `fido_id` program added by the systemd-udevd module.

More info on the [systemd-cryptenroll](https://www.freedesktop.org/software/systemd/man/systemd-cryptenroll.html#--fido2-device=PATH) and [crypttab](https://www.freedesktop.org/software/systemd/man/crypttab.html#fido2-device=) man pages.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it