### PR TITLE
test: don't use `-cpu max` in GH Actions

### DIFF
--- a/test/run-qemu
+++ b/test/run-qemu
@@ -3,13 +3,14 @@
 # We prefer kvm, kqemu, userspace in that order.
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
+QEMU_CPU="${QEMU_CPU:-max}"
 
-[[ -x /usr/bin/qemu ]] && BIN=/usr/bin/qemu && ARGS=(-cpu max)
+[[ -x /usr/bin/qemu ]] && BIN=/usr/bin/qemu && ARGS=(-cpu "$QEMU_CPU")
 (lsmod | grep -q '^kqemu ') && BIN=/usr/bin/qemu && ARGS=(-kernel-kqemu -cpu host)
 [[ -c /dev/kvm && -x /usr/bin/kvm ]] && BIN=/usr/bin/kvm && ARGS=(-cpu host)
 [[ -c /dev/kvm && -x /usr/bin/qemu-kvm ]] && BIN=/usr/bin/qemu-kvm && ARGS=(-cpu host)
 [[ -c /dev/kvm && -x /usr/libexec/qemu-kvm ]] && BIN=/usr/libexec/qemu-kvm && ARGS=(-cpu host)
-[[ -x /usr/bin/qemu-system-$(uname -m) ]] && BIN=/usr/bin/qemu-system-$(uname -m) && ARGS=(-cpu max)
+[[ -x /usr/bin/qemu-system-$(uname -m) ]] && BIN=/usr/bin/qemu-system-$(uname -m) && ARGS=(-cpu "$QEMU_CPU")
 [[ -c /dev/kvm && -x /usr/bin/qemu-system-$(uname -m) ]] && BIN=/usr/bin/qemu-system-$(uname -m) && ARGS=(-enable-kvm -cpu host)
 
 [[ $BIN ]] || {

--- a/tools/test-github.sh
+++ b/tools/test-github.sh
@@ -41,6 +41,7 @@ else
             cd /lib/modules
             ls -1 | tail -1
         )" \
+        QEMU_CPU="IvyBridge-v2" \
         DRACUT_NO_XATTR=1 \
         TEST_RUN_ID="$RUN_ID" \
         ${TESTS:+TESTS="$TESTS"} \


### PR DESCRIPTION
There appears to be an issue with newer QEMU versions (spotted with Arch
Linux and C9S containers) which causes the respective GH Actions to hang
when booting a QEMU VM in combination with the `-cpu max` parameter.

During (a particularly painful) debugging session I once managed to get
some output from such "frozen" machine (using `earlycon` and
`earlyprintk` kernel cmdline options), and in that particular case the
VM died with a trap caused by an invalid opcode.

I couldn't reproduce this locally, only in GH Actions environment with
Arch Linux and C9S containers. Also, so far I haven't found out which
specific CPUID flag causes this, but using the `IvyBridge-v2` feature
set seems to mitigate the issue.

---

I came across this when configuring our downstream dracut CI for C9S,
but it applies to Arch Linux as well (see the cancelled Arch jobs in recent
PRs).

Ideally it would be great to just disable the particular CPUID flag, but debugging
this is quite painful.
