### PR TITLE
fix: make the base module dependency explicit

### DIFF
--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -7,6 +7,7 @@ check() {
 
 # called by dracut
 depends() {
+    echo base
     return 0
 }
 

--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -10,6 +10,7 @@ check() {
 
 # called by dracut
 depends() {
+    echo base
     return 0
 }
 

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -10,7 +10,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo dbus bash
+    echo base dbus bash
     return 0
 }
 

--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -27,7 +27,7 @@ depends() {
             network_handler="network-legacy"
         fi
     fi
-    echo "kernel-network-modules $network_handler"
+    echo "base kernel-network-modules $network_handler"
     return 0
 }
 

--- a/modules.d/45url-lib/module-setup.sh
+++ b/modules.d/45url-lib/module-setup.sh
@@ -9,7 +9,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo network
+    echo base network
     return 0
 }
 

--- a/modules.d/80cms/module-setup.sh
+++ b/modules.d/80cms/module-setup.sh
@@ -11,7 +11,7 @@ check() {
 depends() {
     arch=${DRACUT_ARCH:-$(uname -m)}
     [ "$arch" = "s390" -o "$arch" = "s390x" ] || return 1
-    echo znet zfcp dasd dasd_mod bash
+    echo base znet zfcp dasd dasd_mod bash
     return 0
 }
 

--- a/modules.d/90btrfs/module-setup.sh
+++ b/modules.d/90btrfs/module-setup.sh
@@ -18,7 +18,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo udev-rules
+    echo base udev-rules
     return 0
 }
 

--- a/modules.d/90livenet/module-setup.sh
+++ b/modules.d/90livenet/module-setup.sh
@@ -8,7 +8,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo network url-lib dmsquash-live img-lib bash
+    echo base network url-lib dmsquash-live img-lib bash
     return 0
 }
 

--- a/modules.d/95cifs/module-setup.sh
+++ b/modules.d/95cifs/module-setup.sh
@@ -18,7 +18,7 @@ check() {
 # called by dracut
 depends() {
     # We depend on network modules being loaded
-    echo network
+    echo base network
 }
 
 # called by dracut

--- a/modules.d/95fcoe-uefi/module-setup.sh
+++ b/modules.d/95fcoe-uefi/module-setup.sh
@@ -17,7 +17,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo fcoe uefi-lib bash
+    echo base fcoe uefi-lib bash
     return 0
 }
 

--- a/modules.d/95fstab-sys/module-setup.sh
+++ b/modules.d/95fstab-sys/module-setup.sh
@@ -7,7 +7,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo fs-lib
+    echo base fs-lib
 }
 
 # called by dracut

--- a/modules.d/95nfs/module-setup.sh
+++ b/modules.d/95nfs/module-setup.sh
@@ -33,7 +33,7 @@ check() {
 # called by dracut
 depends() {
     # We depend on network modules being loaded
-    echo network
+    echo base network
 }
 
 # called by dracut

--- a/modules.d/95rootfs-block/module-setup.sh
+++ b/modules.d/95rootfs-block/module-setup.sh
@@ -7,7 +7,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo fs-lib
+    echo base fs-lib
 }
 
 cmdline_journal() {

--- a/modules.d/95virtfs/module-setup.sh
+++ b/modules.d/95virtfs/module-setup.sh
@@ -16,6 +16,7 @@ check() {
 
 # called by dracut
 depends() {
+    echo base
     return 0
 }
 

--- a/modules.d/98dracut-systemd/module-setup.sh
+++ b/modules.d/98dracut-systemd/module-setup.sh
@@ -9,7 +9,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo "systemd-initrd"
+    echo "base systemd-initrd"
     return 0
 }
 

--- a/modules.d/98syslog/module-setup.sh
+++ b/modules.d/98syslog/module-setup.sh
@@ -8,6 +8,7 @@ check() {
 
 # called by dracut
 depends() {
+    echo base
     return 0
 }
 

--- a/modules.d/98usrmount/module-setup.sh
+++ b/modules.d/98usrmount/module-setup.sh
@@ -8,7 +8,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo 'fs-lib'
+    echo 'base fs-lib'
 }
 
 # called by dracut

--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -297,8 +297,6 @@ done
 udevadm control --exit
 udevadm info --cleanup-db
 
-debug_off # Turn off debugging for this section
-
 # unexport some vars
 export_n root rflags fstype netroot NEWROOT
 unset CMDLINE
@@ -338,7 +336,6 @@ if getarg init= > /dev/null; then
     done
     unset CLINE
 else
-    debug_off # Turn off debugging for this section
     set -- "$CLINE"
     for x in "$@"; do
         case "$x" in

--- a/modules.d/99fs-lib/module-setup.sh
+++ b/modules.d/99fs-lib/module-setup.sh
@@ -7,6 +7,7 @@ check() {
 
 # called by dracut
 depends() {
+    echo base
     return 0
 }
 

--- a/modules.d/99memstrack/module-setup.sh
+++ b/modules.d/99memstrack/module-setup.sh
@@ -11,7 +11,7 @@ check() {
 }
 
 depends() {
-    echo systemd bash
+    echo base systemd bash
     return 0
 }
 


### PR DESCRIPTION
When dracut is called with the "--modules" argument, the base
module needs to be specificed by the caller. Dracut already has
a well functioning dependency mamanegemtn system that could be used
to not make base module special.

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
