### PR TITLE
fix(s390_rules): make collect optional

### DIFF
--- a/modules.d/95dasd_rules/module-setup.sh
+++ b/modules.d/95dasd_rules/module-setup.sh
@@ -26,7 +26,6 @@ check() {
     local found=0
     local bdev
     [ "$_arch" = "s390" -o "$_arch" = "s390x" ] || return 1
-    require_binaries /usr/lib/udev/collect || return 1
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         for bdev in /sys/block/*; do
@@ -50,7 +49,6 @@ depends() {
 
 # called by dracut
 install() {
-    inst_multiple /usr/lib/udev/collect
     inst_hook cmdline 30 "$moddir/parse-dasd.sh"
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _dasd

--- a/modules.d/95qeth_rules/module-setup.sh
+++ b/modules.d/95qeth_rules/module-setup.sh
@@ -5,7 +5,6 @@ check() {
     local _arch=${DRACUT_ARCH:-$(uname -m)}
     local _online=0
     [ "$_arch" = "s390" -o "$_arch" = "s390x" ] || return 1
-    require_binaries /usr/lib/udev/collect || return 1
     dracut_module_included network || return 1
 
     [[ $hostonly ]] && {
@@ -56,5 +55,4 @@ install() {
         [ -n "$id" ] && inst_rules_qeth "$id"
     done
 
-    inst_simple /usr/lib/udev/collect
 }

--- a/modules.d/95zfcp_rules/module-setup.sh
+++ b/modules.d/95zfcp_rules/module-setup.sh
@@ -45,7 +45,6 @@ check() {
     local _arch=${DRACUT_ARCH:-$(uname -m)}
     local _ccw
     [ "$_arch" = "s390" -o "$_arch" = "s390x" ] || return 1
-    require_binaries /usr/lib/udev/collect || return 1
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         found=0
@@ -66,7 +65,6 @@ depends() {
 
 # called by dracut
 install() {
-    inst_multiple /usr/lib/udev/collect
     inst_hook cmdline 30 "$moddir/parse-zfcp.sh"
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _zfcp


### PR DESCRIPTION
/usr/lib/udev/collect has been removed from systemd v246, so make it optional in the udev rules

This pull request changes...

dependency of s390 udev rules on collect

## Changes

## Checklist
- [X ] I have tested it locally
- [X ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
