### PR TITLE
Improve logic for selecting initramfs compression

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1294,23 +1294,6 @@ if [[ $no_kernel != yes ]] && [[ -d $srcmods ]]; then
         else
             dwarn "$srcmods/modules.dep is missing. Did you run depmod?"
         fi
-    elif ! (command -v gzip &> /dev/null && command -v xz &> /dev/null); then
-        read -r _mod < "$srcmods"/modules.dep
-        _mod=${_mod%%:*}
-        if [[ -f $srcmods/"$_mod" ]]; then
-            # Check, if kernel modules are compressed, and if we can uncompress them
-            case "$_mod" in
-                *.ko.gz) kcompress=gzip ;;
-                *.ko.xz) kcompress=xz ;;
-                *.ko.zst) kcompress=zstd ;;
-            esac
-            if [[ $kcompress ]]; then
-                if ! command -v "$kcompress" &> /dev/null; then
-                    dfatal "Kernel modules are compressed with $kcompress, but $kcompress is not available."
-                    exit 1
-                fi
-            fi
-        fi
     fi
 fi
 

--- a/dracut.sh
+++ b/dracut.sh
@@ -2350,6 +2350,13 @@ if [[ $create_early_cpio == yes ]]; then
     fi
 fi
 
+if [[ $compress && $compress != cat ]]; then
+    if ! command -v "${compress%% *}" &> /dev/null; then
+        derror "dracut: cannot execute compression command '$compress', falling back to default"
+        compress=
+    fi
+fi
+
 if ! [[ $compress ]]; then
     # check all known compressors, if none specified
     for i in $DRACUT_COMPRESS_PIGZ $DRACUT_COMPRESS_GZIP $DRACUT_COMPRESS_LZ4 $DRACUT_COMPRESS_LZOP $DRACUT_COMPRESS_ZSTD $DRACUT_COMPRESS_LZMA $DRACUT_COMPRESS_XZ $DRACUT_COMPRESS_LBZIP2 $DRACUT_COMPRESS_BZIP2 $DRACUT_COMPRESS_CAT; do

--- a/dracut.sh
+++ b/dracut.sh
@@ -2358,7 +2358,9 @@ if ! [[ $compress ]]; then
         break
     done
     if [[ $compress == cat ]]; then
-        printf "%s\n" "dracut: no compression tool available. Initramfs image is going to be big." >&2
+        dwarn "dracut: no compression tool available. Initramfs image is going to be big."
+    else
+        dinfo "dracut: using auto-determined compression method '$compress'"
     fi
 fi
 


### PR DESCRIPTION
## Changes

Handle missing compression tools, or otherwise lack of support
for the configured compression method, more gracefully. It's normally not necessary to bail out if e.g. *xz* is not installed.

## Checklist
- [x] I have tested it locally
- [x ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

