### PR TITLE
fix(dmsquash-live-ntfs,cms): fuse3 no longer requires ulockmgr_server

### DIFF
--- a/modules.d/80cms/module-setup.sh
+++ b/modules.d/80cms/module-setup.sh
@@ -27,7 +27,7 @@ install() {
     inst_script "$moddir/cmsifup.sh" /sbin/cmsifup
     # shellcheck disable=SC2046
     inst_multiple /etc/cmsfs-fuse/filetypes.conf /etc/udev/rules.d/99-fuse.rules /etc/fuse.conf \
-        cmsfs-fuse fusermount ulockmgr_server bash insmod rmmod cat normalize_dasd_arg sed \
+        cmsfs-fuse fusermount bash insmod rmmod cat normalize_dasd_arg sed \
         $(rpm -ql s390utils-base) awk getopt
 
     inst_libdir_file "gconv/*"

--- a/modules.d/90dmsquash-live-ntfs/module-setup.sh
+++ b/modules.d/90dmsquash-live-ntfs/module-setup.sh
@@ -13,7 +13,7 @@ depends() {
 }
 
 install() {
-    inst_multiple fusermount ulockmgr_server mount.fuse ntfs-3g
+    inst_multiple fusermount mount.fuse ntfs-3g
     dracut_need_initqueue
 }
 


### PR DESCRIPTION
fuse3 no longer includes ulockmgr_server.
https://github.com/libfuse/libfuse/blob/master/ChangeLog.rst#libfuse-300-2016-12-08

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
