### PR TITLE
fix(dmsquash-live): do not install systemd files when systemd is not enabled

### DIFF
--- a/modules.d/90dmsquash-live/module-setup.sh
+++ b/modules.d/90dmsquash-live/module-setup.sh
@@ -31,9 +31,11 @@ install() {
     inst_hook pre-pivot 20 "$moddir/apply-live-updates.sh"
     inst_script "$moddir/dmsquash-live-root.sh" "/sbin/dmsquash-live-root"
     inst_script "$moddir/iso-scan.sh" "/sbin/iso-scan"
-    inst_script "$moddir/dmsquash-generator.sh" "$systemdutildir"/system-generators/dracut-dmsquash-generator
+    if dracut_module_included "systemd-initrd"; then
+        inst_script "$moddir/dmsquash-generator.sh" "$systemdutildir"/system-generators/dracut-dmsquash-generator
+        inst_simple "$moddir/checkisomd5@.service" "/etc/systemd/system/checkisomd5@.service"
+    fi
     # should probably just be generally included
     inst_rules 60-cdrom_id.rules
-    inst_simple "$moddir/checkisomd5@.service" "/etc/systemd/system/checkisomd5@.service"
     dracut_need_initqueue
 }


### PR DESCRIPTION
Systemd is an optional module for the dmsquash-live module. This scenario
is properly handled for other modules (for example livenet module) but not for
dmsquash-live module.

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
