### PR TITLE
fix: make the base module dependency explicit

### DIFF
--- a/modules.d/95rootfs-block/module-setup.sh
+++ b/modules.d/95rootfs-block/module-setup.sh
@@ -7,7 +7,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo fs-lib
+    echo base fs-lib
 }
 
 cmdline_journal() {


### PR DESCRIPTION
When dracut is called with the "--modules" argument, the base
module needs to be specificed by the caller. Dracut already has
a well functioning dependency management system that could be used
to not make base module special.

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
