### PR TITLE
feat(crypt): check if fido2 module is needed in hostonly mode

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -24,6 +24,9 @@ depends() {
         if grep -q "tpm2-device=" "$dracutsysrootdir"/etc/crypttab; then
             deps+=" tpm2-tss"
         fi
+        if grep -q -e "fido2-device=" -e "fido2-cid=" "$dracutsysrootdir"/etc/crypttab; then
+            deps+=" fido2"
+        fi
     fi
     echo "$deps"
     return 0


### PR DESCRIPTION
In hostonly mode, include the fido2 module if any encrypted volumes are configured in `/etc/crypttab` to be decrypted using a FIDO2 device.

More info on the [crypttab man page](https://www.freedesktop.org/software/systemd/man/crypttab.html#fido2-device=).

PR created following https://github.com/dracutdevs/dracut/pull/1641#issuecomment-977598222

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it