### PR TITLE
ci: remove Fedora 33 container

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -28,7 +28,6 @@ jobs:
             fail-fast: false
             matrix:
                 config:
-                    - { dockerfile: 'Dockerfile-Fedora-33',         tag: 'fedora:33' }
                     - { dockerfile: 'Dockerfile-Fedora-latest',     tag: 'fedora:latest' }
                     - { dockerfile: 'Dockerfile-Fedora-rawhide',    tag: 'fedora:rawhide' }
                     - { dockerfile: 'Dockerfile-OpenSuse-latest',   tag: 'opensuse:latest' }


### PR DESCRIPTION
Fedora 33 is scheduled to reach end-of-life (EOL) on 2021-11-30.
No new dracut releases should be ending up in that Fedora release at this point.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
