### PR TITLE
fix(img-lib): install rmdir

### DIFF
--- a/modules.d/99img-lib/module-setup.sh
+++ b/modules.d/99img-lib/module-setup.sh
@@ -14,7 +14,7 @@ depends() {
 
 # called by dracut
 install() {
-    inst_multiple tar gzip dd echo tr
+    inst_multiple tar gzip dd echo tr rmdir
     # TODO: make this conditional on a cmdline flag / config option
     inst_multiple -o cpio xz bzip2 zstd
     inst_simple "$moddir/img-lib.sh" "/lib/img-lib.sh"


### PR DESCRIPTION
rmdir is used in some modules but not properly installed (e.g. img-lib module).
It would make it easier to ration about the dependencies and would save
a bit of intramfs space to just use rm instead.

This pull request changes...

## Changes

## Checklist
- [ X ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
