### PR TITLE
fix(systemd-resolved): add systemd-resolve user

### DIFF
--- a/modules.d/01systemd-resolved/module-setup.sh
+++ b/modules.d/01systemd-resolved/module-setup.sh
@@ -42,6 +42,15 @@ install() {
         "$systemdsystemunitdir/systemd-resolved.service.d/*.conf" \
         resolvectl
 
+    # install systemd-resolve user/group
+    {
+        grep '^systemd-resolve:' "$dracutsysrootdir"/etc/passwd 2> /dev/null
+    } >> "$initdir/etc/passwd"
+
+    {
+        grep '^systemd-resolve:' "$dracutsysrootdir"/etc/group 2> /dev/null
+    } >> "$initdir/etc/group"
+
     # Enable systemd type unit(s)
     $SYSTEMCTL -q --root "$initdir" enable systemd-resolved.service
 


### PR DESCRIPTION
This pull request adds the `systemd-resolve` user to initramfs when using the `systemd-resolved` module.

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1656 
