### PR TITLE
fix(systemd-sysusers): override systemd-sysusers.service

### DIFF
--- a/modules.d/01systemd-sysusers/module-setup.sh
+++ b/modules.d/01systemd-sysusers/module-setup.sh
@@ -24,6 +24,8 @@ depends() {
 # Install the required file(s) and directories for the module in the initramfs.
 install() {
 
+    inst_simple "$moddir/sysusers-dracut.conf" "$systemdsystemunitdir/systemd-sysusers.service.d/sysusers-dracut.conf"
+
     inst_multiple -o \
         "$sysusers"/basic.conf \
         "$sysusers"/systemd.conf \

--- a/modules.d/01systemd-sysusers/sysusers-dracut.conf
+++ b/modules.d/01systemd-sysusers/sysusers-dracut.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionNeedsUpdate=


### PR DESCRIPTION
Fixes a regression with systemd not running units with ConditionNeedsUpdate set in initrds

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1656 
