### PR TITLE
fix(systemd-sysusers): use split systemd sysuser configs

### DIFF
--- a/modules.d/01systemd-coredump/module-setup.sh
+++ b/modules.d/01systemd-coredump/module-setup.sh
@@ -37,6 +37,7 @@ install() {
         "$systemdsystemunitdir"/systemd-coredump.socket \
         "$systemdsystemunitdir"/systemd-coredump@.service \
         "$systemdsystemunitdir"/sockets.target.wants/systemd-coredump.socket \
+        "$sysusers"/systemd-coredump.conf \
         coredumpctl
 
     # Install the hosts local user configurations if enabled.
@@ -48,6 +49,7 @@ install() {
             "$systemdsystemconfdir/systemd-coredump.socket.d/*.conf" \
             "$systemdsystemconfdir"/systemd-coredump@.service \
             "$systemdsystemconfdir/systemd-coredump@.service.d/*.conf" \
-            "$systemdsystemconfdir"/sockets.target.wants/systemd-coredump.socket
+            "$systemdsystemconfdir"/sockets.target.wants/systemd-coredump.socket \
+            "$sysusersconfdir"/systemd-coredump.conf
     fi
 }

--- a/modules.d/01systemd-journald/module-setup.sh
+++ b/modules.d/01systemd-journald/module-setup.sh
@@ -47,6 +47,7 @@ install() {
         "$systemdsystemunitdir"/sockets.target.wants/systemd-journald.socket \
         "$systemdsystemunitdir"/sockets.target.wants/systemd-journald-audit.socket \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-journald.service \
+        "$sysusers"/systemd-journal.conf \
         journalctl
 
     # Install library file(s)
@@ -66,7 +67,8 @@ install() {
             "$systemdsystemconfdir"/systemd-journal-flush.service \
             "$systemdsystemconfdir/systemd-journal-flush.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-journal-catalog-update.service \
-            "$systemdsystemconfdir/systemd-journal-catalog-update.service.d/*.conf"
+            "$systemdsystemconfdir/systemd-journal-catalog-update.service.d/*.conf" \
+            "$sysusersconfdir"/systemd-journal.conf
     fi
 
 }

--- a/modules.d/01systemd-networkd/module-setup.sh
+++ b/modules.d/01systemd-networkd/module-setup.sh
@@ -50,6 +50,7 @@ install() {
         "$systemdsystemunitdir"/systemd-network-generator.service \
         "$systemdsystemunitdir"/systemd-networkd-wait-online.service \
         "$systemdsystemunitdir"/systemd-network-generator.service \
+        "$sysusers"/systemd-network.conf \
         networkctl ip
 
     # Enable systemd type units
@@ -74,6 +75,7 @@ install() {
             "$systemdsystemconfdir"/systemd-network-generator.service \
             "$systemdsystemconfdir/systemd-network-generator.service/*.conf" \
             "$systemdsystemconfdir"/systemd-networkd-wait-online.service \
-            "$systemdsystemconfdir/systemd-networkd-wait-online.service/*.conf"
+            "$systemdsystemconfdir/systemd-networkd-wait-online.service/*.conf" \
+            "$sysusersconfdir"/systemd-network.conf
     fi
 }

--- a/modules.d/01systemd-resolved/module-setup.sh
+++ b/modules.d/01systemd-resolved/module-setup.sh
@@ -40,6 +40,7 @@ install() {
         "$systemdutildir"/systemd-resolved \
         "$systemdsystemunitdir"/systemd-resolved.service \
         "$systemdsystemunitdir/systemd-resolved.service.d/*.conf" \
+        "$sysusers"/systemd-resolve.conf \
         resolvectl
 
     # Enable systemd type unit(s)
@@ -51,6 +52,7 @@ install() {
             "$systemdutilconfdir"/resolved.conf \
             "$systemdutilconfdir/resolved.conf.d/*.conf" \
             "$systemdsystemconfdir"/systemd-resolved.service \
-            "$systemdsystemconfdir/systemd-resolved.service/*.conf"
+            "$systemdsystemconfdir/systemd-resolved.service/*.conf" \
+            "$sysusersconfdir"/systemd-resolve.conf
     fi
 }

--- a/modules.d/01systemd-timesyncd/module-setup.sh
+++ b/modules.d/01systemd-timesyncd/module-setup.sh
@@ -42,7 +42,8 @@ install() {
         "$systemdsystemunitdir"/systemd-timesyncd.service \
         "$systemdsystemunitdir/systemd-timesyncd.service.d/*.conf" \
         "$systemdsystemunitdir"/systemd-time-wait-sync.service \
-        "$systemdsystemunitdir/systemd-time-wait-sync.service.d/*.conf"
+        "$systemdsystemunitdir/systemd-time-wait-sync.service.d/*.conf" \
+        "$sysusers"/systemd-timesync.conf
 
     # Enable systemd type unit(s)
     for i in \
@@ -60,6 +61,7 @@ install() {
             "$systemdsystemconfdir"/systemd-timesyncd.service \
             "$systemdsystemconfdir/systemd-timesyncd.service.d/*.conf" \
             "$systemdsystemunitdir"/systemd-time-wait-sync.service \
-            "$systemdsystemunitdir/systemd-time-wait-sync.service.d/*.conf"
+            "$systemdsystemunitdir/systemd-time-wait-sync.service.d/*.conf" \
+            "$sysusersconfdir"/systemd-timesync.conf
     fi
 }


### PR DESCRIPTION
Fixes the regression introduced by https://github.com/systemd/systemd/pull/20056
As discussed in #1656 and #1657

## Changes
Include the new sysusers.d files to allow compatability with future systemd releases. Otherwise the users would be missing inside the initrd.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
