### PR TITLE
fix(dmsquash-live): overlayfs on a block device root

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -210,8 +210,6 @@ do_live_overlay() {
             fi
         fi
         if [ -n "$overlayfs" ]; then
-            mkdir -m 0755 -p /run/overlayfs
-            mkdir -m 0755 -p /run/ovlwork
             if [ -n "$readonly_overlay" ] && ! [ -h /run/overlayfs-r ]; then
                 info "No persistent overlay found."
                 unset -v readonly_overlay
@@ -368,7 +366,14 @@ fi
 ROOTFLAGS="$(getarg rootflags)"
 
 if [ -n "$overlayfs" ]; then
-    mkdir -m 0755 -p /run/rootfsbase
+    if [ -n "$FSIMG" ]; then
+        mkdir -m 0755 -p /run/rootfsbase
+        mount -r $FSIMG /run/rootfsbase
+    else
+        ln -sf /run/initramfs/live /run/rootfsbase
+    fi
+    mkdir -m 0755 -p /run/overlayfs
+    mkdir -m 0755 -p /run/ovlwork
     if [ -n "$reset_overlay" ] && [ -h /run/overlayfs ]; then
         ovlfs=$(readlink /run/overlayfs)
         info "Resetting the OverlayFS overlay directory."
@@ -379,7 +384,6 @@ if [ -n "$overlayfs" ]; then
     else
         ovlfs=lowerdir=/run/rootfsbase
     fi
-    mount -r $FSIMG /run/rootfsbase
     if [ -z "$DRACUT_SYSTEMD" ]; then
         printf 'mount -t overlay LiveOS_rootfs -o%s,%s %s\n' "$ROOTFLAGS" \
             "$ovlfs",upperdir=/run/overlayfs,workdir=/run/ovlwork \


### PR DESCRIPTION
An example kernel command line option for this configuration
root=/dev/sda1 ro rd.live.image rd.live.overlay.overlayfs=1

The change checks if $FSIMG is empty and adds a symlink from
/run/rootfsbase to /run/initramfs/live and changes the place
of the creation of the required mount point directories.

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
