### PR TITLE
fix(cpio): write zeros instead of seek for padding and alignment

### DIFF
--- a/src/dracut-cpio/src/main.rs
+++ b/src/dracut-cpio/src/main.rs
@@ -255,7 +255,10 @@ impl ArchiveState {
             self.off += fname.len() as u64;
             // +1 as padding starts after fname nulterm
             let seeklen = 1 + archive_padlen(self.off + 1, 4);
-            writer.seek(io::SeekFrom::Current(seeklen as i64))?;
+            {
+                let z = vec![0u8; seeklen.try_into().unwrap()];
+                writer.write_all(&z)?;
+            }
             self.off += seeklen;
         }
         *mapped_ino = Some((*hl).mapped_ino);
@@ -469,7 +472,10 @@ fn archive_path<W: Seek + Write>(
         let padding_len = archive_padlen(state.off + seek_len as u64, 4);
         seek_len += padding_len as i64;
     }
-    writer.seek(io::SeekFrom::Current(seek_len))?;
+    {
+        let z = vec![0u8; seek_len.try_into().unwrap()];
+        writer.write_all(&z)?;
+    }
     state.off += seek_len as u64;
 
     // io::copy() can reflink: https://github.com/rust-lang/rust/pull/75272 \o/


### PR DESCRIPTION
This is a workaround for GRUB2's Btrfs implementation, which doesn't
correctly handle gaps between extents.

A fix has already been proposed upstream via
https://lists.gnu.org/archive/html/grub-devel/2021-10/msg00206.html

Given that this bug is severe, it makes sense to include this minimal
workaround.

Signed-off-by: David Disseldorp <ddiss@suse.de>

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

## Fixes

https://bugzilla.opensuse.org/show_bug.cgi?id=1190982