### PR TITLE
multipath fixes

### DIFF
--- a/modules.d/90multipath/multipathd.service
+++ b/modules.d/90multipath/multipathd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Device-Mapper Multipath Device Controller
-Before=iscsi.service iscsid.service lvm2-activation-early.service
+Before=lvm2-activation-early.service
 Before=local-fs-pre.target blk-availability.service shutdown.target
 Wants=systemd-udevd-kernel.socket
 After=systemd-udevd-kernel.socket

--- a/modules.d/90multipath/multipathd.service
+++ b/modules.d/90multipath/multipathd.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=Device-Mapper Multipath Device Controller
 Before=iscsi.service iscsid.service lvm2-activation-early.service
-Wants=systemd-udev-trigger.service systemd-udev-settle.service local-fs-pre.target
-After=systemd-udev-trigger.service systemd-udev-settle.service
+Wants=local-fs-pre.target
 Before=local-fs-pre.target
+Wants=systemd-udevd-kernel.socket
+After=systemd-udevd-kernel.socket
 Before=initrd-cleanup.service
 DefaultDependencies=no
 Conflicts=shutdown.target

--- a/modules.d/90multipath/multipathd.service
+++ b/modules.d/90multipath/multipathd.service
@@ -1,10 +1,10 @@
 [Unit]
 Description=Device-Mapper Multipath Device Controller
 Before=iscsi.service iscsid.service lvm2-activation-early.service
-Wants=local-fs-pre.target
-Before=local-fs-pre.target
+Before=local-fs-pre.target blk-availability.service shutdown.target
 Wants=systemd-udevd-kernel.socket
 After=systemd-udevd-kernel.socket
+After=multipathd.socket systemd-remount-fs.service
 Before=initrd-cleanup.service
 DefaultDependencies=no
 Conflicts=shutdown.target
@@ -13,13 +13,16 @@ ConditionKernelCommandLine=!nompath
 ConditionKernelCommandLine=!rd.multipath=0
 ConditionKernelCommandLine=!rd_NO_MULTIPATH
 ConditionKernelCommandLine=!multipath=off
+ConditionVirtualization=!container
 
 [Service]
 Type=notify
 NotifyAccess=main
 ExecStartPre=-/sbin/modprobe dm-multipath
-ExecStart=/sbin/multipathd -s -d
+ExecStart=/sbin/multipathd -d -s
 ExecReload=/sbin/multipathd reconfigure
+TasksMax=infinity
 
 [Install]
 WantedBy=sysinit.target
+Also=multipathd.socket


### PR DESCRIPTION
## Changes

Fix some issues in multipathd.service, and eliminate the differences
wrt the unit file shipped with multipath-tools upstream. The ultimate
goal is to be able drop the service unit file from dracut and use the
one from upstream. I have sent a patch series to the dm-devel mailing
list today ("[PATCH 0/4] multipathd: service unit fixes").

Also, despite the recent changes in upstream multipath-tools,
we still get warnings about systemd-udev-settle.service, this time
for multipathd-configure.service. It would be nice to get rid of them,
too. This patch set avoids installing that unit file if mpathconf isn't
available.

@bmarzins, you're invited to push a fix for multipathd-configure.service
to this branch. I expect that simply dropping the dependencies on
systemd-udevd-settle.service will suffice. I won't attempt to make
these fixes myself, as I'm not familiar enough with mpathconf-based
multipath setup.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

