### PR TITLE
fix(network-manager): skip non-directories in /sys/class/net

### DIFF
--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -60,6 +60,7 @@ dhcpopts_create() {
 }
 
 for _i in /sys/class/net/*; do
+    [ -d "$_i" ] || continue
     state="/run/NetworkManager/devices/$(cat "$_i"/ifindex)"
     grep -q '^connection-uuid=' "$state" 2> /dev/null || continue
     ifname="${_i##*/}"


### PR DESCRIPTION
There can be files in this directory, eg "bonding_masters" if a
network bond is in use.

Fixes #1604
