### PR TITLE
fix(network-wicked): multiple path corrections

### DIFF
--- a/modules.d/35network-wicked/module-setup.sh
+++ b/modules.d/35network-wicked/module-setup.sh
@@ -33,15 +33,23 @@ install() {
 
     inst_dir /etc/wicked/extensions
     inst_dir /usr/share/wicked/schema
-    inst_dir /usr/lib/wicked/bin
+    if [ -d /usr/lib/wicked/bin ]; then
+        inst_dir /usr/lib/wicked/bin
+        inst_multiple "/usr/lib/wicked/bin/*"
+    elif [ -d /usr/libexec/wicked/bin ]; then
+        inst_dir /usr/libexec/wicked/bin
+        inst_multiple "/usr/libexec/wicked/bin/*"
+    fi
     inst_dir /var/lib/wicked
 
     inst_multiple "/etc/wicked/*.xml"
     inst_multiple "/etc/wicked/extensions/*"
-    inst_multiple "/etc/dbus-1/system.d/org.opensuse.Network*"
+    if [ -f /etc/dbus-1/system.d/org.opensuse.Network.conf ]; then
+        inst_multiple "/etc/dbus-1/system.d/org.opensuse.Network*"
+    elif [ -f /usr/share/dbus-1/system.d/org.opensuse.Network.conf ]; then
+        inst_multiple "/usr/share/dbus-1/system.d/org.opensuse.Network*"
+    fi
     inst_multiple "/usr/share/wicked/schema/*"
-    inst_multiple "/usr/lib/wicked/bin/*"
-    inst_multiple "/usr/libexec/wicked/bin/*"
     inst_multiple "/usr/sbin/wicked*"
 
     wicked_units=(


### PR DESCRIPTION
Since [wicked-0.6.67](https://github.com/openSUSE/wicked/blob/version-0.6.67/wicked.spec.in#L117), its dbus configuration files can be installed in /etc or /usr/share, what was breaking this module in openSUSE Tumbleweed.

Also, check if it's using `libexec` or `lib` instead of displaying always an error.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
