### PR TITLE
fix(bluetooth): dbus configuration path fixes

### DIFF
--- a/modules.d/62bluetooth/module-setup.sh
+++ b/modules.d/62bluetooth/module-setup.sh
@@ -56,6 +56,7 @@ install() {
     local -a var_lib_files
 
     inst_multiple \
+        "$dbussystem"/bluetooth.conf \
         "${systemdsystemunitdir}/bluetooth.target" \
         "${systemdsystemunitdir}/bluetooth.service" \
         bluetoothctl
@@ -69,7 +70,7 @@ install() {
 
         inst_multiple \
             /etc/bluetooth/main.conf \
-            /etc/dbus-1/system.d/bluetooth.conf \
+            "$dbussystemconfdir"/bluetooth.conf \
             "${var_lib_files[@]#"$dracutsysrootdir"}"
     fi
 


### PR DESCRIPTION
Add a missing /usr/share path ( fixes #1627 )
Use variable instead of hard path

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
