### PR TITLE
improve lvm module

### DIFF
--- a/modules.d/90lvm/64-lvm.rules
+++ b/modules.d/90lvm/64-lvm.rules
@@ -6,6 +6,14 @@
 
 SUBSYSTEM!="block", GOTO="lvm_end"
 ACTION!="add|change", GOTO="lvm_end"
+
+# If the md device is active (indicated by array_state), then set the flag
+# LVM_MD_PV_ACTIVATED=1 indicating that the md device for the PV is ready
+# to be used.  The lvm udev rule running in root will check that this flag
+# is set before it will process the md device (it wants to avoid
+# processing an md device that exists but is not yet ready to be used.)
+KERNEL=="md[0-9]*", ACTION=="change", ENV{ID_FS_TYPE}=="LVM2_member", ENV{LVM_MD_PV_ACTIVATED}!="1", TEST=="md/array_state", ENV{LVM_MD_PV_ACTIVATED}="1"
+
 # Also don't process disks that are slated to be a multipath device
 ENV{DM_MULTIPATH_DEVICE_PATH}=="1", GOTO="lvm_end"
 KERNEL=="dm-[0-9]*", ACTION=="add", GOTO="lvm_end"

--- a/modules.d/90lvm/64-lvm.rules
+++ b/modules.d/90lvm/64-lvm.rules
@@ -15,7 +15,7 @@ PROGRAM=="/bin/sh -c 'for i in $sys/$devpath/holders/dm-[0-9]*; do [ -e $$i ] &&
     GOTO="lvm_end"
 
 RUN+="/sbin/initqueue --settled --onetime --unique /sbin/lvm_scan"
-RUN+="/sbin/initqueue --timeout --name 51-lvm_scan --onetime --unique /sbin/lvm_scan --partial"
+RUN+="/sbin/initqueue --timeout --name 51-lvm_scan --onetime --unique /sbin/lvm_scan --activationmode degraded"
 RUN+="/bin/sh -c '>/tmp/.lvm_scan-%k;'"
 
 LABEL="lvm_end"

--- a/modules.d/90lvm/lvm_scan.sh
+++ b/modules.d/90lvm/lvm_scan.sh
@@ -28,10 +28,7 @@ if [ ! -e /etc/lvm/lvm.conf ]; then
         echo '"r/.*/" ]'
         echo '}'
 
-        # establish LVM locking
         echo 'global {'
-        echo '    locking_type = 4'
-        echo '    use_lvmetad = 0'
         echo '}'
     } > /etc/lvm/lvm.conf
     lvmwritten=1

--- a/modules.d/90lvm/module-setup.sh
+++ b/modules.d/90lvm/module-setup.sh
@@ -61,10 +61,6 @@ install() {
     if [[ $hostonly ]] || [[ $lvmconf == "yes" ]]; then
         if [[ -f $dracutsysrootdir/etc/lvm/lvm.conf ]]; then
             inst_simple -H /etc/lvm/lvm.conf
-            # FIXME: near-term hack to establish read-only locking;
-            # use command-line lvm.conf editor once it is available
-            sed -i -e 's/\(^[[:space:]]*\)locking_type[[:space:]]*=[[:space:]]*[[:digit:]]/\1locking_type = 4/' "${initdir}/etc/lvm/lvm.conf"
-            sed -i -e 's/\(^[[:space:]]*\)use_lvmetad[[:space:]]*=[[:space:]]*[[:digit:]]/\1use_lvmetad = 0/' "${initdir}/etc/lvm/lvm.conf"
         fi
 
         export LVM_SUPPRESS_FD_WARNINGS=1
@@ -80,16 +76,6 @@ install() {
             fi
         fi
         unset LVM_SUPPRESS_FD_WARNINGS
-    fi
-
-    if ! [[ -e ${initdir}/etc/lvm/lvm.conf ]]; then
-        mkdir -p "${initdir}/etc/lvm"
-        {
-            echo 'global {'
-            echo 'locking_type = 4'
-            echo 'use_lvmetad = 0'
-            echo '}'
-        } > "${initdir}/etc/lvm/lvm.conf"
     fi
 
     inst_rules 11-dm-lvm.rules 69-dm-lvm-metad.rules

--- a/modules.d/90lvm/module-setup.sh
+++ b/modules.d/90lvm/module-setup.sh
@@ -78,20 +78,7 @@ install() {
         unset LVM_SUPPRESS_FD_WARNINGS
     fi
 
-    inst_rules 11-dm-lvm.rules 69-dm-lvm-metad.rules
-
-    # Do not run lvmetad update via pvscan in udev rule  - lvmetad is not running yet in dracut!
-    if [[ -f ${initdir}/lib/udev/rules.d/69-dm-lvm-metad.rules ]]; then
-        if grep -q SYSTEMD_WANTS "${initdir}"/lib/udev/rules.d/69-dm-lvm-metad.rules; then
-            sed -i -e 's/^ENV{SYSTEMD_ALIAS}=.*/# No LVM pvscan in dracut - lvmetad is not running yet/' \
-                "${initdir}"/lib/udev/rules.d/69-dm-lvm-metad.rules
-            sed -i -e 's/^ENV{ID_MODEL}=.*//' "${initdir}"/lib/udev/rules.d/69-dm-lvm-metad.rules
-            sed -i -e 's/^ENV{SYSTEMD_WANTS}+\?=.*//' "${initdir}"/lib/udev/rules.d/69-dm-lvm-metad.rules
-        else
-            sed -i -e 's/.*lvm pvscan.*/# No LVM pvscan for in dracut - lvmetad is not running yet/' \
-                "${initdir}"/lib/udev/rules.d/69-dm-lvm-metad.rules
-        fi
-    fi
+    inst_rules 11-dm-lvm.rules
 
     # Gentoo ebuild for LVM2 prior to 2.02.63-r1 doesn't install above rules
     # files, but provides the one below:


### PR DESCRIPTION
## Changes

This series makes various updates to the lvm module:
- removes support for the unused lvm snapshot management feature
- removes automated editing of deprecated lvm.conf lvmetad settings
- removes an unused udev rule
- replaces the use of --partial with --activationmode degraded
- removes checks for using options that have existed for many years
- uses the filter generated by dracut when lvm.conf has no filter set
- only attempts to activate an LV when the LV is seen on devices

## Checklist
- [x ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
