### PR TITLE
fix(kernel-modules): add mailbox drivers for arm

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -80,6 +80,7 @@ installkernel() {
                 "=drivers/hwmon" \
                 "=drivers/hwspinlock" \
                 "=drivers/i2c/busses" \
+                "=drivers/mailbox" \
                 "=drivers/memory" \
                 "=drivers/mfd" \
                 "=drivers/mmc/core" \


### PR DESCRIPTION
Mailbox drivers might be needed by some of the devices used in the
initrd. For example, on the Raspberry Pi 4, the MMC 'sdhci-iproc' driver
depends on 'bcm2835-mailbox'.

Signed-off-by: Adrien Thierry <athierry@redhat.com>

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
