### PR TITLE
Add missing libraries

### DIFF
--- a/modules.d/91fido2/module-setup.sh
+++ b/modules.d/91fido2/module-setup.sh
@@ -23,6 +23,7 @@ install() {
     inst_libdir_file \
         {"tls/$_arch/",tls/,"$_arch/",}"libfido2.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"/cryptsetup/libcryptsetup-token-systemd-fido2.so" \
         {"tls/$_arch/",tls/,"$_arch/",}"libcbor.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libhidapi-hidraw.so.*"
 }

--- a/modules.d/91tpm2-tss/module-setup.sh
+++ b/modules.d/91tpm2-tss/module-setup.sh
@@ -52,7 +52,7 @@ install() {
         {"tls/$_arch/",tls/,"$_arch/",}"libtss2-tcti-swtpm.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libtss2-tctildr.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup-token-systemd-tpm2.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"/cryptsetup/libcryptsetup-token-systemd-tpm2.so" \
         {"tls/$_arch/",tls/,"$_arch/",}"libcurl.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libjson-c.so.*"
 

--- a/modules.d/91tpm2-tss/module-setup.sh
+++ b/modules.d/91tpm2-tss/module-setup.sh
@@ -52,6 +52,7 @@ install() {
         {"tls/$_arch/",tls/,"$_arch/",}"libtss2-tcti-swtpm.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libtss2-tctildr.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup-token-systemd-tpm2.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libcurl.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libjson-c.so.*"
 


### PR DESCRIPTION
This adds the missing libraries libcryptsetup-token-systemd-fido2.so libcryptsetup-token-systemd-tpm2.so to their module fixes #1676 

TODO create a new p11-kit module.

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
