### PR TITLE
udev-rules: make sure the hwdb with ifname renaming rules is around

### DIFF
--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -97,4 +97,16 @@ install() {
 
     inst_libdir_file "libnss_files*"
 
+    if [[ $hostonly ]]; then
+        inst_multiple -o "${udevdir}"/hwdb.bin
+        inst_multiple -H -o "${udevconfdir}"/hwdb.bin
+    else
+        inst_dir "${udevdir}"/hwdb.d
+        inst_simple "${udevdir}"/hwdb.d/20-net-ifname.hwdb
+        systemd-hwdb --usr --root="${initdir}" update
+    fi
+
+    # Remove any installed hwdb files, now that we're sure
+    # to have the binary database in place
+    rm -fr -- "${initdir}${udevdir}"/hwdb.d
 }


### PR DESCRIPTION
## Changes

The stable network interface naming relies on hwdb. In one particular
case actually: the Dell "idrac" interface.

The systemd-udevd module actually already includes the hwdb for hostonly
images, but we need it to work for non-hostonly images as well as those
that don't utilize the systemd-udevd module as well.

Let's make udev-rules also pull in the binary hwdb for hostonly builds.
On Fedora 35 this adds 2M compressed, 11M uncompressed. That is quite
some extra fat, but it's consistent with what systemd-udevd does.

For non-hostonly ones, pull in only what we know we need in binary form.
The extra space consumed is negligible (300B uncompressed).

## Checklist
- [ x ] I have tested it locally
- [ x ] I have reviewed and updated any documentation if relevant
- [ :( ] I am providing new code and test(s) for it