### PR TITLE
fix(network-manager): wait for the actual connection

### DIFF
--- a/modules.d/35network-manager/nm-wait-online-initrd.service
+++ b/modules.d/35network-manager/nm-wait-online-initrd.service
@@ -8,7 +8,7 @@ ConditionPathExists=/run/NetworkManager/initrd/neednet
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/nm-online -s -q -t 3600
+ExecStart=/usr/bin/nm-online -q -t 3600
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
Wait for the actual connection instead of daemon startup.
This fixes dmsquash-live failures.

Signed-off-by: Zoltán Böszörményi <zboszor@gmail.com>

This pull request changes the ExecStart= line for nm-wait-online-initrd.service, option -s has to be removed from nm-online.
I am using  dmsquash-live combined with network-manager under Yocto 3.4 to remote boot devices.
Since NM pulls up the network interface asynchronously and nm-wait-online-initrd.service (nm-online -s) didn't wait for the interface to actually get an IP address, it made the success or failure for dmsquash-live to pull the live rootfs image timing sensitive.

Opinion needed: can we just remove option "-s" as in the commit or should this module provide two different wait-online services and install one or the other into the initramfs if dmsquash-live is also used?

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
