### PR TITLE
fix(dracut): be more robust when using 'set -u'

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -878,7 +878,7 @@ unset GREP_OPTIONS
 export DRACUT_LOG_LEVEL=warning
 [[ $debug ]] && {
     export DRACUT_LOG_LEVEL=debug
-    export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
+    export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]-}): '
     set -x
 }
 

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -392,7 +392,7 @@ setdebug() {
             if getargbool 0 rd.debug -d -y rdinitdebug -d -y rdnetdebug; then
                 RD_DEBUG=yes
                 [ -n "$BASH" ] \
-                    && export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
+                    && export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]-}): '
             fi
         fi
         export RD_DEBUG


### PR DESCRIPTION
From bash manpage, `FUNCNAME` exists only inside functions. When in debug mode, make sure to use an empty default value as `FUNCNAME[0]` when outside of functions.

With bash4 this wasn't an issue, but is with bash5 with hardening option **set -u** used, as shown in the example below:

Incorrect:
~~~
$ bash -u -c 'echo -n ${FUNCNAME[0]}'
bash: line 1: FUNCNAME[0]: unbound variable
$
~~~

Correct:
~~~
$ bash -u -c 'echo -n ${FUNCNAME[0]-}'
$
~~~

This hardening enables sourcing `dracut-lib.sh` from external utilities executing in the initramfs such as `clevis-luks-askpass`, which uses hardening option **set -u** internally (see [Clevis PR 340](https://github.com/latchset/clevis/pull/340))

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [N/A] I have reviewed and updated any documentation if relevant
- [N/A] I am providing new code and test(s) for it
