### PR TITLE
fix(memstrack): drop bash runtime requirement

### DIFF
--- a/modules.d/99memstrack/memstrack-start.sh
+++ b/modules.d/99memstrack/memstrack-start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Mount kernel debug fs so debug tools can work.
 # memdebug=4 and memdebug=5 requires debug fs to be mounted.
 # And there is no need to umount it.
@@ -20,8 +20,6 @@ is_debugfs_ready() {
 }
 
 prepare_debugfs() {
-    local trace_base
-
     trace_base=$(get_trace_base)
     # old debugfs interface case.
     if ! [ -d "$trace_base/tracing" ]; then
@@ -44,10 +42,10 @@ fi
 if [ -n "$DEBUG_MEM_LEVEL" ]; then
     if [ "$DEBUG_MEM_LEVEL" -ge 5 ]; then
         echo "memstrack - will report kernel module memory usage summary and top allocation stack"
-        memstrack --report module_summary,module_top --notui --throttle 80 -o /.memstrack &
+        nohup memstrack --report module_summary,module_top --notui --throttle 80 -o /.memstrack > /dev/null &
     elif [ "$DEBUG_MEM_LEVEL" -ge 4 ]; then
         echo "memstrack - will report memory usage summary"
-        memstrack --report module_summary --notui --throttle 80 -o /.memstrack &
+        nohup memstrack --report module_summary --notui --throttle 80 -o /.memstrack > /dev/null &
     else
         exit 0
     fi
@@ -61,9 +59,7 @@ if [ $RET -ne 0 ]; then
     exit $RET
 fi
 
+echo $PID > /run/memstrack.pid
+
 # Wait a second for memstrack to setup everything, avoid missing any event
 sleep 1
-
-echo $PID > /run/memstrack.pid
-# bash specific - non posix
-disown

--- a/modules.d/99memstrack/memstrack.service
+++ b/modules.d/99memstrack/memstrack.service
@@ -7,7 +7,7 @@ ConditionKernelCommandLine=|rd.memdebug=4
 ConditionKernelCommandLine=|rd.memdebug=5
 
 [Service]
-Type=simple
+Type=forking
 ExecStart=/bin/memstrack-start
 PIDFile=/run/memstrack.pid
 StandardInput=null

--- a/modules.d/99memstrack/module-setup.sh
+++ b/modules.d/99memstrack/module-setup.sh
@@ -11,12 +11,12 @@ check() {
 }
 
 depends() {
-    echo systemd bash
+    echo systemd
     return 0
 }
 
 install() {
-    inst_multiple pgrep pkill
+    inst_multiple pgrep pkill nohup
     inst "/bin/memstrack" "/bin/memstrack"
 
     inst "$moddir/memstrack-start.sh" "/bin/memstrack-start"


### PR DESCRIPTION
This makes the scripts POSIX compatible and bash is no longer needed.

## Changes

Use nohup instead of disown, and let systemd track the service properly.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it