### PR TITLE
fix(network): wrong test of wicked unit

### DIFF
--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -17,7 +17,7 @@ depends() {
     done
 
     if [ -z "$network_handler" ]; then
-        if [[ -x $dracutsysrootdir$systemdsystemunitdir/wicked.service ]]; then
+        if [[ -e $dracutsysrootdir$systemdsystemunitdir/wicked.service ]]; then
             network_handler="network-wicked"
         elif [[ -x $dracutsysrootdir/usr/libexec/nm-initrd-generator ]] || [[ -x $dracutsysrootdir/usr/lib/nm-initrd-generator ]]; then
             network_handler="network-manager"


### PR DESCRIPTION
The test for the wicked service is never met because it does not have execute permission.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
