### PR TITLE
fix(dracut-shutdown): add cleanup handler on failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,7 @@ ifneq ($(enable_documentation),no)
 endif
 	if [ -n "$(systemdsystemunitdir)" ]; then \
 		mkdir -p $(DESTDIR)$(systemdsystemunitdir); \
+		ln -srf $(DESTDIR)$(pkglibdir)/modules.d/98dracut-systemd/dracut-shutdown-onfailure.service $(DESTDIR)$(systemdsystemunitdir)/dracut-shutdown-onfailure.service; \
 		ln -srf $(DESTDIR)$(pkglibdir)/modules.d/98dracut-systemd/dracut-shutdown.service $(DESTDIR)$(systemdsystemunitdir)/dracut-shutdown.service; \
 		mkdir -p $(DESTDIR)$(systemdsystemunitdir)/sysinit.target.wants; \
 		ln -s ../dracut-shutdown.service \

--- a/modules.d/98dracut-systemd/dracut-shutdown-onfailure.service
+++ b/modules.d/98dracut-systemd/dracut-shutdown-onfailure.service
@@ -1,0 +1,13 @@
+#  This file is part of dracut.
+#
+# See dracut.bootup(7) for details
+
+[Unit]
+Description=Service executing upon dracut-shutdown failure to perform cleanup
+Documentation=man:dracut-shutdown.service(8)
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStart=-/bin/rm /run/initramfs/shutdown
+StandardError=null

--- a/modules.d/98dracut-systemd/dracut-shutdown.service
+++ b/modules.d/98dracut-systemd/dracut-shutdown.service
@@ -10,6 +10,7 @@ Wants=local-fs.target
 Conflicts=shutdown.target umount.target
 DefaultDependencies=no
 ConditionPathExists=!/run/initramfs/bin/sh
+OnFailure=dracut-shutdown-onfailure.service
 
 [Service]
 RemainAfterExit=yes

--- a/modules.d/98dracut-systemd/dracut-shutdown.service.8.asc
+++ b/modules.d/98dracut-systemd/dracut-shutdown.service.8.asc
@@ -40,6 +40,9 @@ by injecting "rd.break=pre-shutdown rd.shell" or "rd.break=shutdown rd.shell".
 # touch /run/initramfs/.need_shutdown
 ----
 
+In case the unpack of the initramfs fails, dracut-shutdown-onfailure.service
+executes to make sure switch root doesn't happen, since it would result in
+switching to an incomplete initramfs.
 
 AUTHORS
 -------

--- a/pkgbuild/dracut.spec
+++ b/pkgbuild/dracut.spec
@@ -415,6 +415,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %dir %{_sharedstatedir}/initramfs
 %if %{defined _unitdir}
 %{_unitdir}/dracut-shutdown.service
+%{_unitdir}/dracut-shutdown-onfailure.service
 %{_unitdir}/sysinit.target.wants/dracut-shutdown.service
 %{_unitdir}/dracut-cmdline.service
 %{_unitdir}/dracut-initqueue.service


### PR DESCRIPTION
It may happen that `dracut-shutdown.service` fails, for example on timeout due to very low bandwidth.
In such case, for hardening purposes, a new `dracut-shutdown-onfailure.service` unit doing `dracut-shutdown.service` cleanup needs to execute to make sure switching root to an incomplete initramfs won't occur later.

See also [RHBZ #1924587](https://bugzilla.redhat.com/show_bug.cgi?id=1924587).

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
