### PR TITLE
Fix inconsistent variable use in 40network

### DIFF
--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -295,7 +295,7 @@ ibft_to_cmdline() {
                 # skip not assigned ip adresses
                 [ "$ip" = "0.0.0.0" ] && continue
                 [ -e "${iface}"/gateway ] && read -r gw < "${iface}"/gateway
-                [ "$gateway" = "0.0.0.0" ] && unset gateway
+                [ "$gw" = "0.0.0.0" ] && unset gw
                 [ -e "${iface}"/subnet-mask ] && read -r mask < "${iface}"/subnet-mask
                 [ -e "${iface}"/prefix-len ] && read -r prefix < "${iface}"/prefix-len
                 [ -e "${iface}"/primary-dns ] && read -r dns1 < "${iface}"/primary-dns


### PR DESCRIPTION
## Changes

- fix(40network): consistent use of "$gw" for gateway

## Checklist
- [x ] I have tested it locally

Fixes #
