### PR TITLE
fix(dracut-initramfs-restore.sh): add missing compression options

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -51,13 +51,13 @@ fi
 
 cd /run/initramfs
 
-if $SKIP "$IMG" | zcat | cpio -id --no-absolute-filenames --quiet > /dev/null; then
-    rm -f -- .need_shutdown
-elif $SKIP "$IMG" | xzcat | cpio -id --no-absolute-filenames --quiet > /dev/null; then
-    rm -f -- .need_shutdown
-elif $SKIP "$IMG" | lz4 -d -c | cpio -id --no-absolute-filenames --quiet > /dev/null; then
-    rm -f -- .need_shutdown
-elif $SKIP "$IMG" | zstd -d -c | cpio -id --no-absolute-filenames --quiet > /dev/null; then
+if $SKIP "$IMG" | cpio -id --no-absolute-filenames --quiet > /dev/null \
+    || $SKIP "$IMG" | zcat | cpio -id --no-absolute-filenames --quiet > /dev/null \
+    || $SKIP "$IMG" | bzcat | cpio -id --no-absolute-filenames --quiet > /dev/null \
+    || $SKIP "$IMG" | xzcat | cpio -id --no-absolute-filenames --quiet > /dev/null \
+    || $SKIP "$IMG" | lz4 -d -c | cpio -id --no-absolute-filenames --quiet > /dev/null \
+    || $SKIP "$IMG" | lzop -d -c | cpio -id --no-absolute-filenames --quiet > /dev/null \
+    || $SKIP "$IMG" | zstd -d -c | cpio -id --no-absolute-filenames --quiet > /dev/null; then
     rm -f -- .need_shutdown
 else
     # something failed, so we clean up


### PR DESCRIPTION
The unpack fails if the initrd is not compressed or compressed with bzip2 or LZO.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1463
