### PR TITLE
fix(bluetooth): make hostonly configuration files optional

### DIFF
--- a/modules.d/62bluetooth/module-setup.sh
+++ b/modules.d/62bluetooth/module-setup.sh
@@ -67,7 +67,7 @@ install() {
     if [[ $hostonly ]]; then
         var_lib_files=("$dracutsysrootdir"/var/lib/bluetooth/**)
 
-        inst_multiple \
+        inst_multiple -o \
             /etc/bluetooth/main.conf \
             /etc/dbus-1/system.d/bluetooth.conf \
             "${var_lib_files[@]#"$dracutsysrootdir"}"


### PR DESCRIPTION
Do not fail if any of the expected configuration files don't exist.

Upstream bluez explicitly asked distributions to not ship a `main.conf`, so that the compiled-in system-wide defaults for bluez are used, unless the user explicitly configures something else.

For example, SUSE ships the template under `/usr/share/doc/packages/bluez/main.conf`, if the user wants to configure system-wide settings, he can copy it to `/etc/bluetooth` and edit it.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
