### PR TITLE
fix(tpm2-tss): add tss user and group

### DIFF
--- a/modules.d/91tpm2-tss/module-setup.sh
+++ b/modules.d/91tpm2-tss/module-setup.sh
@@ -55,4 +55,8 @@ install() {
         {"tls/$_arch/",tls/,"$_arch/",}"libcurl.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libjson-c.so.*"
 
+    # Add user and group for tpm2-tss
+    grep '^tss:' "$dracutsysrootdir"/etc/passwd 2> /dev/null >> "$initdir/etc/passwd"
+    grep '^tss:' "$dracutsysrootdir"/etc/group 2> /dev/null >> "$initdir/etc/group"
+
 }


### PR DESCRIPTION
The `tss` user and group are required by `60-tpm-udev.rules`

```
# tpm devices can only be accessed by the tss user but the tss
# group members can access tpmrm devices
KERNEL=="tpm[0-9]*", TAG+="systemd", MODE="0660", OWNER="tss"
KERNEL=="tpmrm[0-9]*", TAG+="systemd", MODE="0660", OWNER="tss", GROUP="tss"
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1700
