### PR TITLE
feat(shutdown): explicitly link reboot, halt and poweroff to systemctl

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -137,7 +137,7 @@ install() {
         journalctl systemctl \
         echo swapoff \
         kmod insmod rmmod modprobe modinfo depmod lsmod \
-        mount umount reboot poweroff \
+        mount umount \
         systemd-run systemd-escape \
         systemd-cgls systemd-tmpfiles \
         systemd-ask-password systemd-tty-ask-password-agent \

--- a/modules.d/99shutdown/module-setup.sh
+++ b/modules.d/99shutdown/module-setup.sh
@@ -14,7 +14,16 @@ depends() {
 # called by dracut
 install() {
     local _d
-    inst_multiple umount poweroff reboot halt losetup stat sleep timeout
+    local _systemctl
+    inst_multiple umount losetup stat sleep timeout
+    _systemctl=$(find_binary systemctl 2> /dev/null)
+    if dracut_module_included "systemd" && [ -n "$_systemctl" ]; then
+        ln_r "$_systemctl" "/sbin/reboot"
+        ln_r "$_systemctl" "/sbin/halt"
+        ln_r "$_systemctl" "/sbin/poweroff"
+    else
+        inst_multiple reboot halt poweroff
+    fi
     inst_multiple -o kexec
     inst "$moddir/shutdown.sh" "$prefix/shutdown"
     [ -e "${initdir}/lib" ] || mkdir -m 0755 -p "${initdir}"/lib


### PR DESCRIPTION
If the running system is using systemd, it provides commands `reboot`, `halt` and `poweroff` via `systemctl` verbs.

Some distributions (SUSE, Debian, Arch,...) ship the legacy SysV `reboot`, `halt` and `poweroff` commands as links to `systemctl` in a separate package, causing the need to add an additional dependency in their dracut installation package, which will be avoided by this PR.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
