### PR TITLE
S390 rules fix inst rules arguments

### DIFF
--- a/modules.d/95dasd_rules/module-setup.sh
+++ b/modules.d/95dasd_rules/module-setup.sh
@@ -56,10 +56,10 @@ install() {
         [[ $_dasd ]] && printf "%s\n" "$_dasd" >> "${initdir}/etc/cmdline.d/95dasd.conf"
     fi
     if [[ $hostonly ]]; then
-        inst_rules_wildcard 51-dasd-*.rules
-        inst_rules_wildcard 41-s390x-dasd-*.rules
+        inst_rules_wildcard "51-dasd-*.rules"
+        inst_rules_wildcard "41-dasd-*.rules"
         mark_hostonly /etc/udev/rules.d/51-dasd-*.rules
-        mark_hostonly /etc/udev/rules.d/41-s390x-dasd-*.rules
+        mark_hostonly /etc/udev/rules.d/41-dasd-*.rules
     fi
     inst_rules 59-dasd.rules
 }

--- a/modules.d/95zfcp_rules/module-setup.sh
+++ b/modules.d/95zfcp_rules/module-setup.sh
@@ -74,7 +74,7 @@ install() {
         done
     fi
     if [[ $hostonly ]]; then
-        inst_rules_wildcard 51-zfcp-*.rules
-        inst_rules_wildcard 41-s390x-zfcp-*.rules
+        inst_rules_wildcard "51-zfcp-*.rules"
+        inst_rules_wildcard "41-zfcp-*.rules"
     fi
 }


### PR DESCRIPTION
Arguments to the inst_rules_wildcard function need quoting
rules naming *-s390x-* was obsolete and broken

## Checklist
- [ X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
