### PR TITLE
[RFC] Dracut module args support for dracut cmdline

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -478,7 +478,15 @@ while :; do
 done
 
 # get output file name and kernel version from command line arguments
+dracut_modules_args=()
 while (($# > 0)); do
+    module_args_regex="^\w+\.\w+=(\S|\t|\ )+$"
+    [[ "$1" =~ $module_args_regex ]] && {
+        dracut_modules_args+=("$1")
+        shift
+        continue
+    }
+
     case ${1%%=*} in
         ++include)
             shift 2
@@ -497,6 +505,24 @@ while (($# > 0)); do
     esac
     shift
 done
+
+# parsing dracut cmdline like module.arg=value
+module_get_arg() {
+    local _module=$1
+    local _argument=$2
+    local _v
+    for ((i=0;i<${#dracut_modules_args[@]};i++)); do
+        local _mod_arg_val=${dracut_modules_args[$i]}
+        local _mod=${_mod_arg_val%%.*}
+        local _arg_val=${_mod_arg_val#*.}
+        local _arg=${_arg_val%%=*}
+        local _val=${_arg_val#*=}
+        if [[ $_module == $_mod ]] && [[ $_argument == $_arg ]]; then
+            _v=$_val
+        fi
+    done
+    echo $_v
+}
 
 # extract input image file provided with rebuild option to get previous parameters, if any
 if [[ $append_args_l == "yes" ]]; then

--- a/dracut.sh
+++ b/dracut.sh
@@ -864,6 +864,13 @@ while (($# > 0)); do
     shift
 done
 
+for ((i=0;i<${#dracut_modules_args[@]};i++)); do
+    mod_arg_val=${dracut_modules_args[$i]}
+    mod_arg=${mod_arg_val%%=*}
+    val=${mod_arg_val#*=}
+    PARMS_TO_STORE+=" $mod_arg='$val'"
+done
+
 [[ $sysroot_l ]] && dracutsysrootdir="$sysroot_l"
 
 if [[ $regenerate_all == "yes" ]]; then

--- a/dracut.sh
+++ b/dracut.sh
@@ -2323,11 +2323,11 @@ if dracut_module_included "squash"; then
     dinfo "*** Squashing the files inside the initramfs ***"
     declare squash_compress_arg
     # shellcheck disable=SC2086
-    if [[ $compress ]]; then
-        if ! mksquashfs /dev/null "$DRACUT_TMPDIR"/.squash-test.img -no-progress -comp $compress &> /dev/null; then
-            dwarn "mksquashfs doesn't support compressor '$compress', failing back to default compressor."
+    if [[ $squash_comp ]]; then
+        if ! mksquashfs /dev/null "$DRACUT_TMPDIR"/.squash-test.img -no-progress -comp $squash_comp &> /dev/null; then
+            dwarn "mksquashfs doesn't support compressor '$squash_comp', failing back to default compressor."
         else
-            squash_compress_arg="$compress"
+            squash_compress_arg="$squash_comp"
         fi
     fi
 

--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -10,6 +10,7 @@ check() {
         fi
     done
 
+    squash_comp=$(module_get_arg $_mod comp)
     return 255
 }
 


### PR DESCRIPTION
This patch set:
1) allows dracut cmdline pass arguments to specific dracut modules as mod.arg="val".
2) decouple compressors for dracut and dracut-squash. With the patch set, the dracut-squash module can receive customized compressor by squash.comp="zstd"
3) It's a RFC patch set, which didn't update the usage docs, in case of further comments and modifications. 

@daveyoung @ryncsn 

## Changes
[PATCH 1/3] Dracut module args support for dracut cmdline
[PATCH 2/3] Allows lsinitrd to show module args
[PATCH 3/3] Decouple the compressor for dracut and dracut-squash

## Checklist
- [Y] I have tested it locally
- [N] I have reviewed and updated any documentation if relevant
- [N] I am providing new code and test(s) for it

Fixes #