### PR TITLE
fix(vi): vi binary is missing

### DIFF
--- a/dracut.conf.d/fedora.conf.example
+++ b/dracut.conf.d/fedora.conf.example
@@ -8,7 +8,7 @@ i18n_install_all="yes"
 
 stdloglvl=3
 sysloglvl=5
-install_optional_items+=" vi /etc/virc ps grep cat rm "
+install_optional_items+=" vi /usr/libexec/vi /etc/virc ps grep cat rm "
 prefix="/"
 environment=/usr/lib/environment.d
 environmentconfdir=/etc/environment.d


### PR DESCRIPTION
This pull request changes...

## Changes
/usr/bin/vi is just a wrapper shell script to run /usr/libexec/vi which is the vi binary. 
/usr/bin/vi is available in initrd.img, but /usr/libexec/vi is missing.
As as result, vi command never works.
This PR is to add /usr/libexec/vi.

## Checklist
- [Y] I have tested it locally
- [N] I have reviewed and updated any documentation if relevant
- [N] I am providing new code and test(s) for it

Fixes #
