### PR TITLE
Add zfs detection

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -780,6 +780,14 @@ btrfs_devs() {
         done
 }
 
+zfs_devs() {
+    local _mp="$1"
+    zpool list -H -v -P "${_mp%%/*}" | awk -F$'\t' '$2 ~ /^\// {print $2}' \
+        | while read -r _dev; do
+            realpath "${_dev}"
+        done
+}
+
 iface_for_remote_addr() {
     # shellcheck disable=SC2046
     set -- $(ip -o route get to "$1")

--- a/modules.d/95rootfs-block/module-setup.sh
+++ b/modules.d/95rootfs-block/module-setup.sh
@@ -44,6 +44,11 @@ cmdline_rootfs() {
         printf " root=%s" "$(shorten_persistent_dev "$(get_persistent_dev "$_dev")")"
     fi
     _fstype="$(find_mp_fstype /)"
+    if [[ ${_fstype} == "zfs" ]]; then
+        local _root_ds
+        _root_ds="$(findmnt -n -o SOURCE /)"
+        printf " root=zfs:%s" "${_root_ds// /+}"
+    fi
     _flags="$(find_mp_fsopts /)"
     if [ -n "$_fstype" ]; then
         printf " rootfstype=%s" "$_fstype"


### PR DESCRIPTION
zfs detection is currently done by the zfs dracut module installed by
downstream, resulting in a lot of duplicated code. This commit puts zfs
detection into the core dracut logic, allowing for detection of zfs
partitions to be done at the same time as all others. It also allows for
dracut to correctly create a `root=` cmdline parameter for zfs.

Signed-off-by: Savyasachee Jha <hi@savyasacheejha.com>

This pull request changes...

## Changes

- Adds a `zfs_devs` function analogous to `btrfs_devs` in `dracut-functions.sh`
- Adds detection of zfs devices using function in the above point
- If the rootfs is on a zfs partition, then allows for setting a `root=zfs:<zfs dataset>` cmdline parameter

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
Nothing