### PR TITLE
fix(dmsquash-live): permanent overlay on the same drive as LiveCD .iso

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -129,7 +129,14 @@ do_live_overlay() {
     # need to know where to look for the overlay
     if [ -z "$setup" -a -n "$devspec" -a -n "$pathspec" -a -n "$overlay" ]; then
         mkdir -m 0755 -p /run/initramfs/overlayfs
-        mount -n -t auto "$devspec" /run/initramfs/overlayfs || :
+        if ismounted "$devspec"; then
+            devmnt=$(findmnt -e -v -n -o 'TARGET' --source "$devspec")
+            # We need $devspec writable for overlay storage
+            mount -o remount,rw "$devspec"
+            mount --bind "$devmnt" /run/initramfs/overlayfs
+        else
+            mount -n -t auto "$devspec" /run/initramfs/overlayfs || :
+        fi
         if [ -f /run/initramfs/overlayfs$pathspec -a -w /run/initramfs/overlayfs$pathspec ]; then
             OVERLAY_LOOPDEV=$(losetup -f --show ${readonly_overlay:+-r} /run/initramfs/overlayfs$pathspec)
             over=$OVERLAY_LOOPDEV


### PR DESCRIPTION
An example kernel command line arguments for this configuration
iso-scan/filename=distro.iso root=live:CDLABEL=ISO
rd.live.image rd.live.overlay=/dev/sda:/overlay.img

iso-scan would mount /dev/sda first and keep it mounted. The change
allows detecting if the permanent overlay drive is already mounted.
It also ensures that the mount is writable, as permanent overlay
requires writable storage.

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
