### PR TITLE
refactor(base): use blockdev@<devname>.target instead of <devname>.device

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -78,6 +78,7 @@ install() {
         "$systemdsystemunitdir"/timers.target \
         "$systemdsystemunitdir"/paths.target \
         "$systemdsystemunitdir"/umount.target \
+        "$systemdsystemunitdir"/blockdev@.target \
         \
         "$systemdsystemunitdir"/sys-kernel-config.mount \
         \

--- a/modules.d/98dracut-systemd/rootfs-generator.sh
+++ b/modules.d/98dracut-systemd/rootfs-generator.sh
@@ -28,9 +28,9 @@ EOF
     fi
 
     _name=$(dev_unit_name "$1")
-    if ! [ -L "$GENERATOR_DIR"/initrd.target.wants/"${_name}".device ]; then
+    if ! [ -L "$GENERATOR_DIR"/initrd.target.wants/blockdev@"${_name}".target ]; then
         [ -d "$GENERATOR_DIR"/initrd.target.wants ] || mkdir -p "$GENERATOR_DIR"/initrd.target.wants
-        ln -s ../"${_name}".device "$GENERATOR_DIR"/initrd.target.wants/"${_name}".device
+        ln -s ../../../../lib/systemd/system/blockdev@.target "$GENERATOR_DIR"/initrd.target.wants/blockdev@"${_name}".target
     fi
 
     if ! [ -f "$GENERATOR_DIR"/"${_name}".device.d/timeout.conf ]; then

--- a/modules.d/99base/dracut-dev-lib.sh
+++ b/modules.d/99base/dracut-dev-lib.sh
@@ -72,10 +72,10 @@ set_systemd_timeout_for_dev() {
     _timeout=${_timeout:-0}
 
     _name=$(dev_unit_name "$1")
-    if ! [ -L "${PREFIX}/etc/systemd/system/initrd.target.wants/${_name}.device" ]; then
+    if ! [ -L "${PREFIX}/etc/systemd/system/initrd.target.wants/blockdev@${_name}.target" ]; then
         [ -d "${PREFIX}"/etc/systemd/system/initrd.target.wants ] || mkdir -p "${PREFIX}"/etc/systemd/system/initrd.target.wants
-        ln -s ../"${_name}".device "${PREFIX}/etc/systemd/system/initrd.target.wants/${_name}.device"
-        type mark_hostonly > /dev/null 2>&1 && mark_hostonly /etc/systemd/system/initrd.target.wants/"${_name}".device
+        ln -s ../../../../lib/systemd/system/blockdev@.target "${PREFIX}/etc/systemd/system/initrd.target.wants/blockdev@${_name}.target"
+        type mark_hostonly > /dev/null 2>&1 && mark_hostonly "${PREFIX}/etc/systemd/system/initrd.target.wants/blockdev@${_name}.target"
         _needreload=1
     fi
 
@@ -132,7 +132,7 @@ cancel_wait_for_dev() {
     rm -f -- "$hookdir/emergency/80-${_name}.sh"
     if [ -n "$DRACUT_SYSTEMD" ]; then
         _name=$(dev_unit_name "$1")
-        rm -f -- "${PREFIX}/etc/systemd/system/initrd.target.wants/${_name}.device"
+        rm -f -- "${PREFIX}/etc/systemd/system/initrd.target.wants/blockdev@${_name}.target"
         rm -f -- "${PREFIX}/etc/systemd/system/${_name}.device.d/timeout.conf"
         /sbin/initqueue --onetime --unique --name daemon-reload systemctl daemon-reload
     fi


### PR DESCRIPTION
The blockdev@<devname>.target is a unit made for ordering block devices
for systemd services. It seems to be the canonical way of doing this as
given in the man page systemd.special. This PR aims to get dracut to
use the same target unit throughout in base, as well as in the
dracut-systemd module.

Signed-off-by: Savyasachee Jha <hi@savyasacheejha.com>

This pull request changes...

## Changes
All instances of `initrd.target.wants/<devname>.device` replaced with `initrd.target.wants/blockdev@<devname>.target`. I have tested this locally and seen no breakage in booting.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
Nothing