### PR TITLE
fix(base): do not require chroot inside initramfs

### DIFF
--- a/modules.d/95debug/module-setup.sh
+++ b/modules.d/95debug/module-setup.sh
@@ -14,7 +14,7 @@ depends() {
 # called by dracut
 install() {
     inst_multiple -o ls ps grep more cat rm strace free showmount df du lsblk \
-        ping netstat rpcinfo vi scp ping6 ssh find \
+        ping netstat rpcinfo vi scp ping6 ssh find chroot \
         tcpdump cp dd less hostname mkdir systemd-analyze \
         fsck fsck.ext2 fsck.ext4 fsck.ext3 fsck.ext4dev fsck.f2fs fsck.vfat e2fsck
 

--- a/modules.d/98selinux/module-setup.sh
+++ b/modules.d/98selinux/module-setup.sh
@@ -13,5 +13,5 @@ depends() {
 # called by dracut
 install() {
     inst_hook pre-pivot 50 "$moddir/selinux-loadpolicy.sh"
-    inst_multiple setenforce
+    inst_multiple setenforce chroot
 }

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -13,7 +13,7 @@ depends() {
 
 # called by dracut
 install() {
-    inst_multiple mount mknod mkdir sleep chroot chown \
+    inst_multiple mount mknod mkdir sleep chown \
         sed ls flock cp mv dmesg rm ln rmmod mkfifo umount readlink setsid \
         modprobe chmod tr
 


### PR DESCRIPTION
dracut can be invoked inside a chroot, but inside
the generated initramfs the chroot binary is not required.

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
