### PR TITLE
fix(install): restore musl support

### DIFF
--- a/src/install/util.c
+++ b/src/install/util.c
@@ -24,17 +24,15 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/types.h>
+#include <sys/syscall.h>
 
 #include "util.h"
 
-#if __GLIBC_PREREQ(2, 30) == 0
-#include <sys/syscall.h>
 #ifndef SYS_gettid
 #error "SYS_gettid unavailable on this system"
 #endif
 
 #define gettid()    ((pid_t) syscall(SYS_gettid))
-#endif /*__GLIBC_PREREQ */
 
 size_t page_size(void)
 {


### PR DESCRIPTION
__GLIBC_PREREQ is only defined in glibc. This change reverts
the recent change from ef0f848a67fdd0a0dab135acbd1cd7fa0179a95c.
The portability of the code outweights the benefits of the
earlier change.

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
