### PR TITLE
Fix shell options leaking from the 10i18n module.

### DIFF
--- a/modules.d/10i18n/module-setup.sh
+++ b/modules.d/10i18n/module-setup.sh
@@ -30,11 +30,7 @@ install() {
     I18N_CONF="/etc/locale.conf"
     VCONFIG_CONF="/etc/vconsole.conf"
 
-    findkeymap() {
-        # shellcheck disable=SC2064
-        trap "$(shopt -p nullglob globstar)" RETURN
-        shopt -q -s nullglob globstar
-
+    _findkeymap() {
         local -a MAPS
         local MAPNAME
         local INCLUDES
@@ -66,10 +62,19 @@ install() {
             for INCL in "${INCLUDES[@]}"; do
                 for FN in "$dracutsysrootdir""${kbddir}"/keymaps/**/"$INCL"*; do
                     [[ -f $FN ]] || continue
-                    [[ -v KEYMAPS["$FN"] ]] || findkeymap "$FN"
+                    [[ -v KEYMAPS["$FN"] ]] || _findkeymap "$FN"
                 done
             done
         done
+    }
+
+    # Wrapper around the recursive _findkeymap making sure the shell
+    # options are restored correctly
+    findkeymap() {
+        # shellcheck disable=SC2064
+        trap "$(shopt -p nullglob globstar)" RETURN
+        shopt -q -s nullglob globstar
+        _findkeymap "$@"
     }
 
     # Function gathers variables from distributed files among the tree, maps to


### PR DESCRIPTION
The findkeymap function in the `10i18n/module-setup.sh` manipulates the shell  options and relies on restoring them using the trap. However, as the function might be called recursively, each recursive invocation changes the signal handler to its
own. As the recursion is entered with shell options already modified, the changed trap handler is replaced with restoration to the modified shell options, not the original ones. This patch wraps the findkeymap function so that the shellopts are manipulated and restored outside the recursion.

## Changes
- wrap the recursive `findkeymap` function with a wrapper in which the shell options are manipulated and restored correctly

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it