### PR TITLE
fix(systemd-journald): remove duplicate entry in inst_multiple

### DIFF
--- a/modules.d/01systemd-journald/module-setup.sh
+++ b/modules.d/01systemd-journald/module-setup.sh
@@ -45,7 +45,6 @@ install() {
         "$systemdsystemunitdir"/sockets.target.wants/systemd-journald-audit.socket \
         "$systemdsystemunitdir"/sockets.target.wants/systemd-journald-dev-log.socket \
         "$systemdsystemunitdir"/sockets.target.wants/systemd-journald.socket \
-        "$systemdsystemunitdir"/sockets.target.wants/systemd-journald-audit.socket \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-journald.service \
         "$sysusers"/systemd-journal.conf \
         journalctl


### PR DESCRIPTION
This pull request removes a duplicate entry in the inst_multiple call (lines 45 and 48 are equal):

https://github.com/dracutdevs/dracut/blob/631d5f72a223288aa1f48bb8e8d0313e75947400/modules.d/01systemd-journald/module-setup.sh#L45-L48

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
