### PR TITLE
fix(systemd-sysusers): add required dependency after the split of systemd sysuser configs

### DIFF
--- a/modules.d/01systemd-coredump/module-setup.sh
+++ b/modules.d/01systemd-coredump/module-setup.sh
@@ -20,7 +20,7 @@ check() {
 depends() {
 
     # This module has external dependency on the systemd module.
-    echo systemd-journald systemd-sysctl
+    echo systemd-journald systemd-sysctl systemd-sysusers
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 

--- a/modules.d/01systemd-timesyncd/module-setup.sh
+++ b/modules.d/01systemd-timesyncd/module-setup.sh
@@ -20,7 +20,7 @@ check() {
 depends() {
 
     # This module has external dependency on other module(s).
-    echo dbus systemd-timedated
+    echo dbus systemd-sysusers systemd-timedated
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 


### PR DESCRIPTION
This pull requests adds the required `systemd-sysusers` dependency to `systemd-coredump` and `systemd-timesyncd` after the split of systemd sysuser configs (https://github.com/dracutdevs/dracut/commit/fec93bb22181f80056b40231fca36c422248ade0), 

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
