### PR TITLE
fix(dracut-systemd): systemd-gpt-auto-generator should not run when root is unset

### DIFF
--- a/modules.d/98dracut-systemd/dracut-cmdline.sh
+++ b/modules.d/98dracut-systemd/dracut-cmdline.sh
@@ -52,10 +52,12 @@ source_hook cmdline
 case "${root#block:}${root_unset}" in
     LABEL=* | UUID=* | PARTUUID=* | PARTLABEL=*)
         root="block:$(label_uuid_to_dev "${root#block:}")"
+        rm /usr/lib/systemd/system-generators/systemd-gpt-auto-generator
         rootok=1
         ;;
     /dev/*)
         root="block:${root#block:}"
+        rm /usr/lib/systemd/system-generators/systemd-gpt-auto-generator
         rootok=1
         ;;
     UNSET | gpt-auto | tmpfs)


### PR DESCRIPTION
systemd-gpt-auto generator runs when `root=<device>` is not set on the
kernel cmdline. It doesn't work even if `root=<device>` is set by dracut
in the stored command line. For systemd-gpt-auto-generator to not run,
one either needs to explicitly set a `root=` parameter or set
`rd.systemd.gpt_auto=0` on the kernel cmdline.

Since we do not have control over the command line passed to the kernel,
the easiest way to bypass this is to delete the generator when the root
parameter is set.

Fixes #1709

Signed-off-by: Savyasachee Jha <hi@savyasacheejha.com>

This pull request changes...

## Changes
Deletes `systemd-auto-gpt-generator` at runtime if the `root=` parameter is set.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

It has been (extensively) tested on Fedora 35 running systemd 249 (v249.9-1.fc35) and dracut v55.

Fixes #1709 
