### PR TITLE
fix(iscsi): Remove unneeded iscsi NOP-disable code

### DIFF
--- a/modules.d/95iscsi/iscsiroot.sh
+++ b/modules.d/95iscsi/iscsiroot.sh
@@ -82,15 +82,6 @@ handle_firmware() {
         if [ $_res -ne 0 ]; then
             warn "iscsiadm: Log-in to iscsi target failed"
         else
-            # get a list of connected targets
-            tgts=$(cat /sys/firmware/ibft/target*/target-name | sort -u)
-            # disable NOPs for each FW target
-            for tgt in ${tgts}; do
-                iscsiadm -m node -T "${tgt}" \
-                    --op update \
-                    --name 'node.conn[0].timeo.noop_out_interval' --value 0 \
-                    --name 'node.conn[0].timeo.noop_out_timeout' --value 0
-            done
             need_shutdown
         fi
     fi


### PR DESCRIPTION
Commit 7374943ae3d06 ("fix(iscsi): add support for the new iscsiadm
"no-wait" (-W) command") added some code to try to disable iscsi's
NOPs, since they are considered "bad" for an iscsi root disc,
but that code doesn't work because the session is already established
at this point. Open-iscsi will change so that it automatically
disables NOPs for the root disc, so this code can just go away.

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
