### PR TITLE
fix(dracut.sh): apply microcode updates properly in debian

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2168,6 +2168,7 @@ if [[ $early_microcode == yes ]]; then
                     _src=$(get_ucode_file)
                     [[ $_src ]] || break
                     [[ -r $_fwdir/$_fw/$_src ]] || _src="${_src}.early"
+                    [[ -r $_fwdir/$_fw/$_src ]] || _src="${_src/early/initramfs}"
                     [[ -r $_fwdir/$_fw/$_src ]] || break
                 fi
 


### PR DESCRIPTION
Instead of `<microcode>.early`, Debian has some microcode files with names
of the sort `<microcode>.initramfs`.

This pull request changes...

## Changes

Allows dracut to pull in microcode data of the form <microcode>.initramfs, which seems to be the convention in debian.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
