### PR TITLE
Add documentation for rd.luks.key.tout

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -453,6 +453,11 @@ it, e.g. `rd.luks.name=cccc=mykeys`, otherwise it gets closed
 when not needed anymore.
 ===============================
 
+**rd.luks.key.tout=0**::
+    specify how many times dracut will try to read the keys specified in in
+    rd.luk.key. This gives a chance to the removable device containing the key
+    to initialise.
+
 MD RAID
 ~~~~~~~
 **rd.md=0**::


### PR DESCRIPTION
## Changes

This adds `rd.luks.key.tout` description to `dracut.cmdline` man page.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #