### PR TITLE
fix(dracut.sh): drop restorecon call

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2558,8 +2558,6 @@ else
     fi
 fi
 
-command -v restorecon &> /dev/null && restorecon -- "$outfile"
-
 btrfs_uuid() {
     btrfs filesystem show "$1" | sed -n '1s/^.*uuid: //p'
 }


### PR DESCRIPTION
This pull request drops `restorecon` call from dracut.sh, as AFAICT there is no need for it. `cp` already applies appropriate label on the target file (unless `--preserve=context` is used).

## Changes
- drop `restorecon` call

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it