### PR TITLE
fix(dracut-initramfs-restore.sh): check if SELINUXTYPE is set

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -76,7 +76,7 @@ fi
 
 if [ -e /etc/selinux/config -a -x /usr/sbin/setfiles ]; then
     . /etc/selinux/config
-    /usr/sbin/setfiles -v -r /run/initramfs /etc/selinux/"${SELINUXTYPE}"/contexts/files/file_contexts /run/initramfs > /dev/null
+    [ -n "${SELINUXTYPE}" ] && /usr/sbin/setfiles -v -r /run/initramfs /etc/selinux/"${SELINUXTYPE}"/contexts/files/file_contexts /run/initramfs > /dev/null
 fi
 
 exit 0


### PR DESCRIPTION
It can happen that SELINUXTYPE is not set, e.g., in Fedora/RHEL
installation images /etc/selinux/config is an empty file. That means
that setfiles fails, which makes dracut-initramfs-restore fail too
because it uses "set -x", which means that dracut-shutdown.service
fails. But, after commit 7ab1d00227cad6f1b86ba01fdc766769faebb031, a
failure of dracut-shutdown.service means that the final switch back into
initrd is skipped. Let's just add an additional sanity check to
workaround that.

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it