### PR TITLE
[RFC/WIP] dmsquash-live: add support for iso-scan.ram kernel parameter

### DIFF
--- a/modules.d/90dmsquash-live/iso-scan.sh
+++ b/modules.d/90dmsquash-live/iso-scan.sh
@@ -8,6 +8,8 @@ isofile=$1
 
 [ -z "$isofile" ] && exit 1
 
+copytoram=$2
+
 ismounted "/run/initramfs/isoscan" && exit 0
 
 mkdir -p "/run/initramfs/isoscan"
@@ -21,7 +23,15 @@ do_iso_scan() {
         : > /tmp/isoscan-"${_name}"
         mount -t auto -o ro "$dev" "/run/initramfs/isoscan" || continue
         if [ -f "/run/initramfs/isoscan/$isofile" ]; then
-            losetup -f "/run/initramfs/isoscan/$isofile"
+            if [ -n "$copytoram" ]; then
+                mount -o remount,size=100% /run
+                cp "/run/initramfs/isoscan/$isofile" "/run/initramfs/scan.iso"
+                losetup -f "/run/initramfs/scan.iso"
+                umount "/run/initramfs/isoscan"
+                rmdir "/run/initramfs/isoscan"
+            else
+                losetup -f "/run/initramfs/isoscan/$isofile"
+            fi
             ln -s "$dev" /run/initramfs/isoscandev
             rm -f -- "$job"
             exit 0

--- a/modules.d/90dmsquash-live/parse-iso-scan.sh
+++ b/modules.d/90dmsquash-live/parse-iso-scan.sh
@@ -3,7 +3,8 @@
 # root=live:backingdev
 
 isofile=$(getarg iso-scan/filename)
+copytoram=$(getarg iso-scan.ram)
 
 if [ -n "$isofile" ]; then
-    /sbin/initqueue --settled --unique /sbin/iso-scan "$isofile"
+    /sbin/initqueue --settled --unique /sbin/iso-scan "$isofile" "$copytoram"
 fi


### PR DESCRIPTION
iso-scan.ram copy the ISO to RAM allowing in place reinstalls
without pulling install source from the network

An exemple in place kickstart reinstall using kexec:
```
echo ks.cfg | cpio -H newc -o >> initrd.img
kexec -l vmlinuz --initrd=initrd.img --command-line="ks=file:/ks.cfg \
iso-scan/filename=/AlmaLinux-8.5-x86_64-dvd.iso \
iso-scan.ram=yes \
inst.repo=hd:LABEL=AlmaLinux-8-5-x86_64-dvd"
kexec -e
```

This pull request changes...

## Changes
Allow to load ISO in RAM

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
