### PR TITLE
refactor(base): remove `str_replace` from `dracut-lib.sh`

### DIFF
--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -103,26 +103,6 @@ vinfo() {
     done
 }
 
-# replaces all occurrences of 'search' in 'str' with 'replacement'
-#
-# str_replace str search replacement
-#
-# example:
-# str_replace '  one two  three  ' ' ' '_'
-str_replace() {
-    local in="$1"
-    local s="$2"
-    local r="$3"
-    local out=''
-
-    while strstr "${in}" "$s"; do
-        chop="${in%%"$s"*}"
-        out="${out}${chop}$r"
-        in="${in#*"$s"}"
-    done
-    echo "${out}${in}"
-}
-
 killall_proc_mountpoint() {
     local _pid
     local _killed=0


### PR DESCRIPTION
remove duplicate implementation of `str_replace` to follow-up
commit 148e420be5b5809aa8d5033f47477573bbbf3e60

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
