### PR TITLE
dracut.usage: Fix dracut.cmdline reference from section 5 to 7

### DIFF
--- a/man/dracut.usage.asc
+++ b/man/dracut.usage.asc
@@ -103,7 +103,7 @@ The kernel command line can also be provided by the dhcp server with the
 root-path option. See <<NetworkBoot>>.
 
 For a full reference of all kernel command line parameters,
-see *dracut.cmdline*(5).
+see *dracut.cmdline*(7).
 
 To get a quick start for the suitable kernel command line on your system,
 use the __--print-cmdline__ option:


### PR DESCRIPTION
Signed-off-by: Morten Linderud <morten@linderud.pw>
