### PR TITLE
fix(98dracut-systemd): fix service dependencies

### DIFF
--- a/modules.d/98dracut-systemd/dracut-shutdown.service
+++ b/modules.d/98dracut-systemd/dracut-shutdown.service
@@ -7,8 +7,6 @@ Description=Restore /run/initramfs on shutdown
 Documentation=man:dracut-shutdown.service(8)
 After=local-fs.target boot.mount boot.automount
 Wants=local-fs.target
-Conflicts=shutdown.target umount.target
-DefaultDependencies=no
 ConditionPathExists=!/run/initramfs/bin/sh
 OnFailure=dracut-shutdown-onfailure.service
 


### PR DESCRIPTION
This pull request fixes dependencies of `dracut-systemd.service`. `dracut-systemd.service` is not an early boot service, therefore it should not use `DefaultDependencies=no`. This automatically fixes the service's ordering dependencies, as in its current state it is missing `Before=shutdown.target umount.target`.

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it