### PR TITLE
fix(udev-rules): add cdrom udev rules by default

### DIFF
--- a/modules.d/90dmsquash-live/module-setup.sh
+++ b/modules.d/90dmsquash-live/module-setup.sh
@@ -35,7 +35,5 @@ install() {
         inst_script "$moddir/dmsquash-generator.sh" "$systemdutildir"/system-generators/dracut-dmsquash-generator
         inst_simple "$moddir/checkisomd5@.service" "/etc/systemd/system/checkisomd5@.service"
     fi
-    # should probably just be generally included
-    inst_rules 60-cdrom_id.rules
     dracut_need_initqueue
 }

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -35,6 +35,7 @@ install() {
         58-scsi-sg3_symlink.rules \
         59-scsi-sg3_utils.rules \
         60-block.rules \
+        60-cdrom_id.rules \
         60-pcmcia.rules \
         60-persistent-storage.rules \
         61-persistent-storage-edd.rules \


### PR DESCRIPTION
Include cdrom udev rules by default, even if
systemd-udevd or dmsquash-live dracut modules
are not installed.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
