### PR TITLE
fix(bluetooth): make $dbussystem/bluetooth.conf optional

### DIFF
--- a/modules.d/62bluetooth/module-setup.sh
+++ b/modules.d/62bluetooth/module-setup.sh
@@ -55,7 +55,7 @@ install() {
     shopt -q -s nullglob globstar
     local -a var_lib_files
 
-    inst_multiple \
+    inst_multiple -o \
         "$dbussystem"/bluetooth.conf \
         "${systemdsystemunitdir}/bluetooth.target" \
         "${systemdsystemunitdir}/bluetooth.service" \


### PR DESCRIPTION
Do not display an error message if the `$dbussystem/bluetooth.conf` file don't exist.
This line was added in commit https://github.com/dracutdevs/dracut/commit/34b1dd2e26c343e9000094db01a7985b6851adf1 to include the missing `/usr/share/dbus-1/system.d/bluetooth.conf` in Arch Linux, but not all Linux distributions ship this file (e.g.: Fedora, SUSE...).

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it