### PR TITLE
fix(plymouth): hide dpkg-architecture stderr messages

### DIFF
--- a/modules.d/50plymouth/module-setup.sh
+++ b/modules.d/50plymouth/module-setup.sh
@@ -3,7 +3,9 @@
 pkglib_dir() {
     local _dirs="/usr/lib/plymouth /usr/libexec/plymouth/"
     if find_binary dpkg-architecture &> /dev/null; then
-        _dirs+=" /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/plymouth"
+        local _arch
+        _arch=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2> /dev/null)
+        [ -n "$_arch" ] && _dirs+=" /usr/lib/$_arch/plymouth"
     fi
     for _dir in $_dirs; do
         if [ -x "$dracutsysrootdir""$_dir"/plymouth-populate-initrd ]; then


### PR DESCRIPTION
`dpkg-architecture` prints warnings and errors to stderr. If the system does not have gcc installed, it issues a warning:
```
dpkg-architecture: warning: cannot determine CC system type, falling back to default (native compilation)
```
This fix checks only the value of the queried variable.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it