### PR TITLE
fix(dracut-initramfs-restore.sh): unpack uncompressed initrd as last option

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -51,13 +51,13 @@ fi
 
 cd /run/initramfs
 
-if $SKIP "$IMG" | cpio -id --no-absolute-filenames --quiet > /dev/null \
-    || $SKIP "$IMG" | zcat | cpio -id --no-absolute-filenames --quiet > /dev/null \
+if $SKIP "$IMG" | zcat | cpio -id --no-absolute-filenames --quiet > /dev/null \
     || $SKIP "$IMG" | bzcat | cpio -id --no-absolute-filenames --quiet > /dev/null \
     || $SKIP "$IMG" | xzcat | cpio -id --no-absolute-filenames --quiet > /dev/null \
     || $SKIP "$IMG" | lz4 -d -c | cpio -id --no-absolute-filenames --quiet > /dev/null \
     || $SKIP "$IMG" | lzop -d -c | cpio -id --no-absolute-filenames --quiet > /dev/null \
-    || $SKIP "$IMG" | zstd -d -c | cpio -id --no-absolute-filenames --quiet > /dev/null; then
+    || $SKIP "$IMG" | zstd -d -c | cpio -id --no-absolute-filenames --quiet > /dev/null \
+    || $SKIP "$IMG" | cpio -id --no-absolute-filenames --quiet > /dev/null; then
     rm -f -- .need_shutdown
 else
     # something failed, so we clean up


### PR DESCRIPTION
Attempting to unpack the initrd assuming it is uncompressed when it is can delay the shutdown process by several seconds. This must be the last check.

While the current "try and failure" code is not optimal (maybe it would be nice to parse the header like lsinitrd does), the amount of time added by the decompression checks is small.

The following log is an example of the time spent to unpack a zstd compressed initrd before adding this fix.

```
[ 3190.829557] systemd[1]: Stopped Getty on tty6.
[ 3190.830648] dracut-initramfs-restore[23469]: cpio: Malformed number �㿼QI;�
[ 3190.837816] dracut-initramfs-restore[23469]: cpio: Malformed number 㿼QI;�
[ 3190.841632] dracut-initramfs-restore[23469]: cpio: Malformed number ��QI;��
[ 3190.842517] dracut-initramfs-restore[23469]: cpio: Malformed number �QI;���
[ 3190.846640] dracut-initramfs-restore[23469]: cpio: Malformed number QI;��ǋ
...
[ 3272.201456] dracut-initramfs-restore[23469]: cpio: Malformed number ��p�D�D
[ 3272.202138] dracut-initramfs-restore[23469]: cpio: Malformed number ��p�D�D�
[ 3272.202806] dracut-initramfs-restore[23469]: cpio: Malformed number �p�D�D��
[ 3272.203476] dracut-initramfs-restore[23469]: cpio: warning: skipped 106138 bytes of junk
[ 3272.204296] dracut-initramfs-restore[23469]: cpio: warning: archive header has reverse byte-order
[ 3272.205151] dracut-initramfs-restore[23469]: cpio: 2)���9;T%f{a����!c���'0ۻ$�i�5�&�,�Pi���3���䲝{/4�S��/����T�z u��_)�K��Ώ^)���B]�?@Wĵ�9�R+B: unknown file type
[ 3272.206586] dracut-initramfs-restore[23469]: cpio: premature end of file
[ 3272.207820] dracut-initramfs-restore[23831]: gzip: stdin: not in gzip format
[ 3272.208546] dracut-initramfs-restore[23832]: cpio: premature end of archive
[ 3272.209291] dracut-initramfs-restore[23830]: ERROR: src/skipcpio/skipcpio.c:191:main(): fwrite
[ 3272.210158] dracut-initramfs-restore[23834]: bzcat: (stdin) is not a bzip2 file.
[ 3272.210915] dracut-initramfs-restore[23835]: cpio: premature end of archive
[ 3272.211628] dracut-initramfs-restore[23833]: ERROR: src/skipcpio/skipcpio.c:191:main(): fwrite
[ 3272.212550] dracut-initramfs-restore[23837]: xzcat: (stdin): File format not recognized
[ 3272.213356] dracut-initramfs-restore[23838]: cpio: premature end of archive
[ 3272.214083] dracut-initramfs-restore[23836]: ERROR: src/skipcpio/skipcpio.c:191:main(): fwrite
[ 3272.214944] dracut-initramfs-restore[23840]: /usr/lib/dracut/dracut-initramfs-restore: line 58: lz4: command not found
[ 3272.216032] dracut-initramfs-restore[23841]: cpio: premature end of archive
[ 3272.216748] dracut-initramfs-restore[23839]: ERROR: src/skipcpio/skipcpio.c:191:main(): fwrite
[ 3272.217610] dracut-initramfs-restore[23843]: /usr/lib/dracut/dracut-initramfs-restore: line 59: lzop: command not found
[ 3272.218679] dracut-initramfs-restore[23844]: cpio: premature end of archive
[ 3272.219395] dracut-initramfs-restore[23842]: ERROR: src/skipcpio/skipcpio.c:191:main(): fwrite
[ 3272.319083][    T1] dracut Warning: Killing all remaining processes
[ 3272.455993][    T1] dracut Warning: Unmounted /oldroot.
[ 3272.514229][T23944] reboot: Restarting system
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it