### PR TITLE
feat: add aarch64 uefi support

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1362,7 +1362,7 @@ if [[ ! $print_cmdline ]]; then
                 ;;
             aarch64)
                 EFI_MACHINE_TYPE_NAME=aa64
-                 # aarch64 kernels are uncompressed and thus larger, so we need a bigger gap between vma sections
+                # aarch64 kernels are uncompressed and thus larger, so we need a bigger gap between vma sections
                 EFI_SECTION_VMA_INITRD=0x4000000
                 ;;
             *)


### PR DESCRIPTION
binutils 2.38 added support for aarch64 efi binaries to objcopy, so it is now possible to create combined efi images for aarch64 as well.
This PR adds support for this to dracut.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1629
