### PR TITLE
feat(connman): introduce connman support module

### DIFF
--- a/modules.d/35connman/cm-config.sh
+++ b/modules.d/35connman/cm-config.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+type cm_generate_connections > /dev/null 2>&1 || . /lib/cm-lib.sh
+
+if [ -n "$netroot" ] || [ -e /tmp/net.ifaces ]; then
+    echo rd.neednet >> /etc/cmdline.d/connman.conf
+fi
+
+if getargbool 0 rd.debug -d -y rdinitdebug -d -y rdnetdebug; then
+    if [ -n "$DRACUT_SYSTEMD" ]; then
+        # Enable tty output if a usable console is found
+        # shellcheck disable=SC2217
+        if [ -w /dev/console ] && (echo < /dev/console) > /dev/null 2> /dev/null; then
+            mkdir -p /run/systemd/system/cm-initrd.service.d
+            cat << EOF > /run/systemd/system/cm-initrd.service.d/tty-output.conf
+[Service]
+StandardOutput=tty
+EOF
+            systemctl --no-block daemon-reload
+        fi
+    fi
+fi
+
+cm_generate_connections

--- a/modules.d/35connman/cm-initrd.service
+++ b/modules.d/35connman/cm-initrd.service
@@ -1,0 +1,24 @@
+[Unit]
+DefaultDependencies=no
+Wants=systemd-udev-trigger.service
+After=systemd-udev-trigger.service
+After=dracut-cmdline.service
+Wants=network.target
+Before=network.target
+RequiresMountsFor=/var/lib/connman
+After=dbus.service
+ConditionPathExists=/run/connman/initrd/neednet
+
+[Service]
+Type=dbus
+BusName=net.connman
+Restart=on-failure
+ExecStart=/usr/sbin/connmand -n
+StandardOutput=null
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_SYS_TIME CAP_SYS_MODULE CAP_SYS_ADMIN
+ProtectHome=true
+ProtectSystem=full
+
+[Install]
+WantedBy=initrd.target
+Also=cm-wait-online-initrd.service

--- a/modules.d/35connman/cm-lib.sh
+++ b/modules.d/35connman/cm-lib.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+type getcmdline > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+cm_generate_connections() {
+    if getargbool 0 rd.neednet; then
+        mkdir -p "$hookdir"/initqueue/finished
+        echo '[ -f /tmp/cm.done ]' > "$hookdir"/initqueue/finished/cm.sh
+        mkdir -p /run/connman/initrd
+        : > /run/connman/initrd/neednet # activate ConnMan services
+    fi
+}

--- a/modules.d/35connman/cm-run.sh
+++ b/modules.d/35connman/cm-run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+type source_hook > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if [ -e /tmp/cm.done ]; then
+    return
+fi
+
+while read -r _serv; do
+    ifname=$(connmanctl services "$_serv" | grep Interface= | sed 's/^.*Interface=\([^,]*\).*$/\1/')
+    source_hook initqueue/online "$ifname"
+    /sbin/netroot "$ifname"
+done < <(connmanctl services | grep -oE '[^ ]+$')
+
+: > /tmp/cm.done

--- a/modules.d/35connman/cm-wait-online-initrd.service
+++ b/modules.d/35connman/cm-wait-online-initrd.service
@@ -1,0 +1,16 @@
+[Unit]
+DefaultDependencies=no
+Requires=cm-initrd.service
+After=cm-initrd.service
+Before=network-online.target
+Before=dracut-initqueue.service
+ConditionPathExists=/run/connman/initrd/neednet
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/connmand-wait-online
+RemainAfterExit=yes
+
+[Install]
+WantedBy=initrd.target
+WantedBy=network-online.target

--- a/modules.d/35connman/module-setup.sh
+++ b/modules.d/35connman/module-setup.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+    require_binaries sed grep connmand connmanctl connmand-wait-online || return 1
+
+    # do not add this module by default
+    return 255
+}
+
+# called by dracut
+depends() {
+    echo dbus systemd bash
+    return 0
+}
+
+# called by dracut
+installkernel() {
+    return 0
+}
+
+# called by dracut
+install() {
+    # We don't need `ip` but having it is *really* useful for people debugging
+    # in an emergency shell.
+    inst_multiple ip sed grep
+
+    inst connmand
+    inst connmanctl
+    inst connmand-wait-online
+    inst "$dbussystem"/connman.conf
+    [[ $hostonly ]] && [[ -f $dracutsysrootdir/etc/connman/main.conf ]] && inst /etc/connman/main.conf
+    inst_dir /usr/lib/connman/plugins
+    inst_dir /var/lib/connman
+
+    inst_hook cmdline 99 "$moddir/cm-config.sh"
+
+    inst_simple "$moddir"/cm-initrd.service "$systemdsystemunitdir"/cm-initrd.service
+    inst_simple "$moddir"/cm-wait-online-initrd.service "$systemdsystemunitdir"/cm-wait-online-initrd.service
+
+    $SYSTEMCTL -q --root "$initdir" enable cm-initrd.service
+
+    inst_hook initqueue/settled 99 "$moddir/cm-run.sh"
+
+    inst_simple "$moddir/cm-lib.sh" "/lib/cm-lib.sh"
+}

--- a/modules.d/35connman/module-setup.sh
+++ b/modules.d/35connman/module-setup.sh
@@ -25,6 +25,7 @@ install() {
     # in an emergency shell.
     inst_multiple ip sed grep
 
+    inst_script "$moddir/netroot.sh" "/sbin/netroot"
     inst connmand
     inst connmanctl
     inst connmand-wait-online

--- a/modules.d/35connman/netroot.sh
+++ b/modules.d/35connman/netroot.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+command -v getarg > /dev/null || . /lib/dracut-lib.sh
+command -v setup_net > /dev/null || . /lib/net-lib.sh
+
+# Huh? Empty $1?
+[ -z "$1" ] && exit 1
+
+# [ ! -z $2 ] means this is for manually bringing up network
+# instead of real netroot; If It's called without $2, then there's
+# no sense in doing something if no (net)root info is available
+# or root is already there
+[ -d "$NEWROOT"/proc ] && exit 0
+
+if [ -z "$netroot" ]; then
+    netroot=$(getarg netroot=)
+fi
+
+[ -z "$netroot" ] && exit 1
+
+# Set or override primary interface
+netif=$1
+[ -e "/tmp/net.bootdev" ] && read -r netif < /tmp/net.bootdev
+
+case "$netif" in
+    ??:??:??:??:??:??) # MAC address
+        for i in /sys/class/net/*/address; do
+            mac=$(cat "$i")
+            if [ "$mac" = "$netif" ]; then
+                i=${i%/address}
+                netif=${i##*/}
+                break
+            fi
+        done ;;
+esac
+
+# Figure out the handler for root=dhcp by recalling all netroot cmdline
+# handlers when this is not called from manually network bringing up.
+if [ -z "$2" ]; then
+    if getarg "root=dhcp" || getarg "netroot=dhcp" || getarg "root=dhcp6" || getarg "netroot=dhcp6"; then
+        # Load dhcp options
+        # shellcheck disable=SC1090
+        [ -e /tmp/dhclient."$netif".dhcpopts ] && . /tmp/dhclient."$netif".dhcpopts
+
+        # If we have a specific bootdev with no dhcpoptions or empty root-path,
+        # we die. Otherwise we just warn
+        if [ -z "$new_root_path" ]; then
+            [ -n "$BOOTDEV" ] && die "No dhcp root-path received for '$BOOTDEV'"
+            warn "No dhcp root-path received for '$netif' trying other interfaces if available"
+            exit 1
+        fi
+
+        rm -f -- "$hookdir"/initqueue/finished/dhcp.sh
+
+        # Set netroot to new_root_path, so cmdline parsers don't call
+        netroot=$new_root_path
+
+        # FIXME!
+        unset rootok
+        for f in "$hookdir"/cmdline/90*.sh; do
+            # shellcheck disable=SC1090
+            [ -f "$f" ] && . "$f"
+        done
+    else
+        rootok="1"
+    fi
+
+    # Check: do we really know how to handle (net)root?
+    if [ -z "$root" ]; then
+        root=$(getarg root=)
+    fi
+    [ -z "$root" ] && die "No or empty root= argument"
+    [ -z "$rootok" ] && die "Don't know how to handle 'root=$root'"
+
+    handler=${netroot%%:*}
+    handler=${handler%%4}
+    handler=$(command -v "${handler}"root)
+    if [ -z "$netroot" ] || [ ! -e "$handler" ]; then
+        die "No handler for netroot type '$netroot'"
+    fi
+fi
+
+# Source netroot hooks before we start the handler
+source_hook netroot "$netif"
+
+# Run the handler; don't store the root, it may change from device to device
+# XXX other variables to export?
+[ -n "$handler" ] && "$handler" "$netif" "$netroot" "$NEWROOT"
+save_netinfo "$netif"
+
+exit 0

--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -9,7 +9,7 @@ check() {
 depends() {
     is_qemu_virtualized && echo -n "qemu-net "
 
-    for module in network-wicked network-manager network-legacy systemd-networkd; do
+    for module in network-wicked connman network-manager network-legacy systemd-networkd; do
         if dracut_module_included "$module"; then
             network_handler="$module"
             break
@@ -19,6 +19,8 @@ depends() {
     if [ -z "$network_handler" ]; then
         if [[ -e $dracutsysrootdir$systemdsystemunitdir/wicked.service ]]; then
             network_handler="network-wicked"
+        elif [[ -e $dracutsysrootdir$systemdsystemunitdir/connman.service ]]; then
+            network_handler="connman"
         elif [[ -x $dracutsysrootdir/usr/libexec/nm-initrd-generator ]] || [[ -x $dracutsysrootdir/usr/lib/nm-initrd-generator ]]; then
             network_handler="network-manager"
         elif [[ -x $dracutsysrootdir$systemdutildir/systemd-networkd ]]; then


### PR DESCRIPTION
Signed-off-by: Zoltán Böszörményi <zboszor@gmail.com>

## Changes

Add a new 35connman module.

This module supersedes issue #1682 as almost all of my Yocto images use connman and the remote booted one was the odd one out. This module allows using connman as the network tool both in initramfs and the squashfs root that the initramfs is generated from.

The network-connman module depends on systemd, since connman, unlike NetworkManager, doesn't have a configure-and-exit mode so a scripted network initialization is not possible. Also, connman deletes the connections when exiting.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [x] I am providing new code

Fixes #
