### PR TITLE
Avoid using nullglob option and fix dracut-install

### DIFF
--- a/docs/BASH.md
+++ b/docs/BASH.md
@@ -16,8 +16,8 @@ Don't use `dirname`, use:
 If you set `shopt` in a function, reset to its default state with `trap`:
 ```shell
 func() {
-  trap "$(shopt -p nullglob globstar)" RETURN
-  shopt -q -s nullglob globstar
+  trap "$(shopt -p globstar)" RETURN
+  shopt -q -s globstar
 }
 ```
 
@@ -51,8 +51,8 @@ func() {
 Or collect the filenames in an array, if you need them more than once:
 ```shell
 func() {
-    trap "$(shopt -p nullglob globstar)" RETURN
-    shopt -q -s nullglob globstar
+    trap "$(shopt -p globstar)" RETURN
+    shopt -q -s globstar
 
     filenames=( /usr/lib*/**/lib*.a )
 

--- a/modules.d/10i18n/module-setup.sh
+++ b/modules.d/10i18n/module-setup.sh
@@ -31,10 +31,6 @@ install() {
     VCONFIG_CONF="/etc/vconsole.conf"
 
     findkeymap() {
-        # shellcheck disable=SC2064
-        trap "$(shopt -p nullglob globstar)" RETURN
-        shopt -q -s nullglob globstar
-
         local -a MAPS
         local MAPNAME
         local INCLUDES
@@ -46,7 +42,10 @@ install() {
             MAPS=("$1")
         else
             MAPNAME=${1%.map*}
-            MAPS=("$dracutsysrootdir""${kbddir}"/keymaps/**/"${MAPNAME}"{,.map{,.*}})
+
+            mapfile -t -d '' MAPS < <(
+                find "${dracutsysrootdir}${kbddir}"/keymaps/ -type f \( -name "${MAPNAME}" -o -name "${MAPNAME}.map*" \) -print0
+            )
         fi
 
         for MAP in "${MAPS[@]}"; do

--- a/modules.d/10i18n/module-setup.sh
+++ b/modules.d/10i18n/module-setup.sh
@@ -30,7 +30,11 @@ install() {
     I18N_CONF="/etc/locale.conf"
     VCONFIG_CONF="/etc/vconsole.conf"
 
-    _findkeymap() {
+    findkeymap() {
+        # shellcheck disable=SC2064
+        trap "$(shopt -p nullglob globstar)" RETURN
+        shopt -q -s nullglob globstar
+
         local -a MAPS
         local MAPNAME
         local INCLUDES
@@ -62,19 +66,10 @@ install() {
             for INCL in "${INCLUDES[@]}"; do
                 for FN in "$dracutsysrootdir""${kbddir}"/keymaps/**/"$INCL"*; do
                     [[ -f $FN ]] || continue
-                    [[ -v KEYMAPS["$FN"] ]] || _findkeymap "$FN"
+                    [[ -v KEYMAPS["$FN"] ]] || findkeymap "$FN"
                 done
             done
         done
-    }
-
-    # Wrapper around the recursive _findkeymap making sure the shell
-    # options are restored correctly
-    findkeymap() {
-        # shellcheck disable=SC2064
-        trap "$(shopt -p nullglob globstar)" RETURN
-        shopt -q -s nullglob globstar
-        _findkeymap "$@"
     }
 
     # Function gathers variables from distributed files among the tree, maps to

--- a/modules.d/62bluetooth/module-setup.sh
+++ b/modules.d/62bluetooth/module-setup.sh
@@ -51,8 +51,8 @@ installkernel() {
 # Install the required file(s) for the module in the initramfs.
 install() {
     # shellcheck disable=SC2064
-    trap "$(shopt -p nullglob globstar)" RETURN
-    shopt -q -s nullglob globstar
+    trap "$(shopt -p globstar)" RETURN
+    shopt -q -s globstar
     local -a var_lib_files
 
     inst_multiple -o \

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -1175,8 +1175,12 @@ static int parse_argv(int argc, char *argv[])
         }
 
         if (!optind || optind == argc) {
-                log_error("No SOURCE argument given");
-                usage(EXIT_FAILURE);
+                if (!arg_optional) {
+                        log_error("No SOURCE argument given");
+                        usage(EXIT_FAILURE);
+                } else {
+                        exit(EXIT_SUCCESS);
+                }
         }
 
         return 1;

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -47,8 +47,8 @@ test_run() {
 
 test_setup() {
     # shellcheck disable=SC2064
-    trap "$(shopt -p nullglob globstar)" RETURN
-    shopt -q -s nullglob globstar
+    trap "$(shopt -p globstar)" RETURN
+    shopt -q -s globstar
 
     export kernel=$KVERSION
     # Create what will eventually be our root filesystem onto an overlay


### PR DESCRIPTION
Glob is in most cases not expected to evaluate to null. To avoid unexpected failures, don't use the `nullglob` option.

I've found no code (WRT the modifications applied) where nullglob is needed, as the variable is either checked explicitly by `[[ -f $file ]]`, or passed to `inst_multiple -o` where the file string is actually expected instead. I think more code is actually expecting an invalid argument instead of missing one (f.e. `cp`), so this increases resiliency.

## Changes
 - removed `nullglob` option use
 - alternative implementation for findkeymap (10i18n module) with `mapfile` (recursion overwrites `trap` setting)
 - fixed `dracut-install` not to fail when `-o` is specified, but no source is specified

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
_ _ _ _

## Additional

E.g., a PR which I don't think should be needed: https://github.com/msekletar/prefixdevname/pull/1

## Tests
keymapfile: https://gist.github.com/f6048df4d7f2a2d609974283a674b9fd
dracut-install: https://gist.github.com/07171bb36863394728852810b21c026f
