### PR TITLE
improvement: Add support for single password boot on non-systemd setups.

### DIFF
--- a/modules.d/90crypt/crypt-lib.sh
+++ b/modules.d/90crypt/crypt-lib.sh
@@ -104,10 +104,10 @@ ask_for_password() {
                 shift
                 ;;
             --tty-echo-off) tty_echo_off=yes ;;
-	    --key-name)
-	        key_name="$2"
-		shift
-		;;
+            --key-name)
+                key_name="$2"
+            shift
+            ;;
         esac
         shift
     done

--- a/modules.d/90crypt/crypt-lib.sh
+++ b/modules.d/90crypt/crypt-lib.sh
@@ -106,14 +106,14 @@ ask_for_password() {
             --tty-echo-off) tty_echo_off=yes ;;
             --key-name)
                 key_name="$2"
-            shift
-            ;;
+                shift
+                ;;
         esac
         shift
     done
 
     # should we add the key to the root user's keyring?
-    if [ ! -z "$key_name" ] && command -v keyctl &>/dev/null; then
+    if [ -n "$key_name" ] && command -v keyctl > /dev/null; then
         ply_cmd="password-helper ${key_name} ${ply_cmd}"
         tty_cmd="password-helper ${key_name} ${tty_cmd}"
     fi

--- a/modules.d/90crypt/cryptroot-ask.sh
+++ b/modules.d/90crypt/cryptroot-ask.sh
@@ -178,11 +178,16 @@ if [ $ask_passphrase -ne 0 ]; then
     luks_open="$(command -v cryptsetup) $cryptsetupopts luksOpen"
     _timeout=$(getargs "rd.luks.timeout")
     _timeout=${_timeout:-0}
+
+    # systemd-cryptsetup uses the key name 'cryptsetup' when
+    # it uses systemd-ask-password to ask a disk password
     ask_for_password --ply-tries 5 \
         --ply-cmd "$luks_open -T1 $device $luksname" \
         --ply-prompt "Password ($device)" \
         --tty-tries 1 \
-        --tty-cmd "$luks_open -T5 -t $_timeout $device $luksname"
+        --tty-cmd "$luks_open -T5 -t $_timeout $device $luksname" \
+        --key-name cryptsetup
+
     unset luks_open
     unset _timeout
 fi

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -107,7 +107,7 @@ install() {
         inst_hook cleanup 30 "$moddir/crypt-cleanup.sh"
 
         # keyctl if present
-        if find_binary keyctl &>/dev/null; then
+        if find_binary keyctl > /dev/null; then
             inst_multiple keyctl tee
             inst_script "$moddir"/password-helper.sh /bin/password-helper
         fi

--- a/modules.d/90crypt/password-helper.sh
+++ b/modules.d/90crypt/password-helper.sh
@@ -5,13 +5,9 @@ name="$1"
 shift
 
 # rest of the parameters are evaluated as a command line.
-# you should not pass parameters with spaces in them, as
-# $@ will not handle them correctly. we don't care about
-# that, as plymouth doesn't either. (plymouth splits the
-# --command parameter with a space delimiter directly, so
-# the functionality here is essentially equivalent)
+# (this will handle parameters with spaces, but plytmouth doesn't)
 
 # pipe the first line of stdin into keyctl and the user
 # specified program
-((head -n1 | tee /dev/fd/5 | \
-	keyctl padd user "$name" @u &>/dev/null) 5>&1 | $@) 4>&1
+( ( head -n1 | tee /dev/fd/5 | \
+	keyctl padd user "$name" @u >/dev/null 2>&1 ) 5>&1 | "$@" ) 4>&1

--- a/modules.d/90crypt/password-helper.sh
+++ b/modules.d/90crypt/password-helper.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# first parameter gives us the key name
+name="$1"
+shift
+
+# rest of the parameters are evaluated as a command line.
+# you should not pass parameters with spaces in them, as
+# $@ will not handle them correctly. we don't care about
+# that, as plymouth doesn't either. (plymouth splits the
+# --command parameter with a space delimiter directly, so
+# the functionality here is essentially equivalent)
+
+# pipe the first line of stdin into keyctl and the user
+# specified program
+((head -n1 | tee /dev/fd/5 | \
+	keyctl padd user "$name" @u &>/dev/null) 5>&1 | $@) 4>&1

--- a/modules.d/90crypt/password-helper.sh
+++ b/modules.d/90crypt/password-helper.sh
@@ -9,5 +9,5 @@ shift
 
 # pipe the first line of stdin into keyctl and the user
 # specified program
-( ( head -n1 | tee /dev/fd/5 | \
-	keyctl padd user "$name" @u >/dev/null 2>&1 ) 5>&1 | "$@" ) 4>&1
+( (head -n1 | tee /dev/fd/5 \
+    | keyctl padd user "$name" @u > /dev/null 2>&1) 5>&1 | "$@") 4>&1


### PR DESCRIPTION
`ask_for_password()` in the crypt module (`modules.d/90crypt/crypt-lib.sh`) can now store passwords in the kernel keyring via `keyctl`, mimicing the behavior of `systemd-ask-password`. This allows `pam_gdm.so` (a standalone PAM module from GDM) to work on non-systemd setups and unlock a GNOME keyring when autologin is enabled without asking for a password. (given that the keyring password is the same as the disk encryption password)

## Changes
- `keyctl` (and `tee`) added as an optional includes in the crypt module. (detected with `find_binary()` in `install()`)
- `ask_for_password()` will pipe passwords to `keyctl` (via a helper script) if it's available and the `--key-name` option is used.
- The helper script (`modules.d/90crypt/password-helper.sh`) is required due to the way plymouth handles the `--command` parameter.
- `modules.d/90crypt/cryptroot-ask.sh` will now try to store the result of `ask_for_password()` in the kernel keyring with the name "cryptsetup", allowing `pam_gdm.so` to work.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it