### PR TITLE
fix(dracut.sh): avoid calling dfatal before dracut-logger is sourced

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1032,12 +1032,12 @@ if ! [[ $outfile ]]; then
     if [[ $uefi == "yes" ]]; then
         # shellcheck disable=SC2154
         if [[ -n $uefi_secureboot_key && -z $uefi_secureboot_cert ]] || [[ -z $uefi_secureboot_key && -n $uefi_secureboot_cert ]]; then
-            dfatal "Need 'uefi_secureboot_key' and 'uefi_secureboot_cert' both to be set."
+            printf "%s\n" "dracut: Need 'uefi_secureboot_key' and 'uefi_secureboot_cert' both to be set." >&2
             exit 1
         fi
 
         if [[ -n $uefi_secureboot_key && -n $uefi_secureboot_cert ]] && ! command -v sbsign &> /dev/null; then
-            dfatal "Need 'sbsign' to create a signed UEFI executable"
+            printf "%s\n" "dracut: Need 'sbsign' to create a signed UEFI executable." >&2
             exit 1
         fi
 


### PR DESCRIPTION
dracut-logger is sourced in dracut-init, so any earlier calls to logger functions before dracut-init is sourced fail.

Fix issue #1758

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1758
