### PR TITLE
fix(dracut-install): copy files preserving ownership attributes

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -327,10 +327,10 @@ normal_copy:
         pid = fork();
         if (pid == 0) {
                 if (geteuid() == 0 && no_xattr == false)
-                        execlp("cp", "cp", "--reflink=auto", "--sparse=auto", "--preserve=mode,xattr,timestamps", "-fL",
+                        execlp("cp", "cp", "--reflink=auto", "--sparse=auto", "--preserve=mode,xattr,timestamps,ownership", "-fL",
                                src, dst, NULL);
                 else
-                        execlp("cp", "cp", "--reflink=auto", "--sparse=auto", "--preserve=mode,timestamps", "-fL", src,
+                        execlp("cp", "cp", "--reflink=auto", "--sparse=auto", "--preserve=mode,timestamps,ownership", "-fL", src,
                                dst, NULL);
                 _exit(EXIT_FAILURE);
         }
@@ -339,10 +339,10 @@ normal_copy:
                 if (errno != EINTR) {
                         ret = -1;
                         if (geteuid() == 0 && no_xattr == false)
-                                log_error("Failed: cp --reflink=auto --sparse=auto --preserve=mode,xattr,timestamps -fL %s %s",
+                                log_error("Failed: cp --reflink=auto --sparse=auto --preserve=mode,xattr,timestamps,ownership -fL %s %s",
                                           src, dst);
                         else
-                                log_error("Failed: cp --reflink=auto --sparse=auto --preserve=mode,timestamps -fL %s %s",
+                                log_error("Failed: cp --reflink=auto --sparse=auto --preserve=mode,timestamps,ownership -fL %s %s",
                                           src, dst);
                         break;
                 }


### PR DESCRIPTION
While the "clone copy" operation changes the ownership of the cloned files, the "normal copy" using `cp` does not preserve it.

This causes errors with configuration files with o= permissions that belong to a systemd group. E.g., systemd-networkd using WireGuard keys (https://wiki.archlinux.org/title/WireGuard#systemd-networkd):
```
localhost:~ # ls -l /etc/systemd/network
total 4
-rw-r----- 1 root systemd-network 39 Apr  4 09:06 20-wired.network
localhost:~ # lsinitrd | grep etc/systemd/network/
-rw-r-----   1 root     root       39 Apr  4 09:06 etc/systemd/network/20-wired.network
localhost:~ # journalctl -b -p3
Apr 04 09:37:11 localhost systemd-networkd[335]: Failed to open configuration file '/etc/systemd/network/20-wired.network': Permission denied
Apr 04 09:37:11 localhost systemd-networkd[335]: Failed to load /etc/systemd/network/20-wired.network: Permission denied
Apr 04 09:37:11 localhost systemd-networkd[335]: Could not load configuration files: Permission denied
Apr 04 09:37:11 localhost systemd[1]: Failed to start Network Configuration.
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
