### PR TITLE
Add missing usage and man section of --libdirs option

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -104,6 +104,8 @@ Creates initial ramdisk images for preloading modules
                          modules
   --fwdir [DIR]         Specify additional directories, where to look for
                          firmwares, separated by :
+  --libdirs [LIST]      Specify a space-separated list of directories
+                         where to look for libraries.
   --kernel-only         Only install kernel drivers and firmware files
   --no-kernel           Do not install kernel drivers and firmware files
   --print-cmdline       Print the kernel command line for the given disk layout

--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -190,6 +190,20 @@ example:
     specify additional directories, where to look for firmwares. This parameter
     can be specified multiple times.
 
+**--libdirs** _<list of directories>_::
+    specify a space-separated list of directories to look for libraries to
+    include in the generic initramfs. This parameter can be specified multiple
+    times.
++
+[NOTE]
+===============================
+If [LIST] has multiple arguments, then you have to put these in quotes. For
+example:
+----
+# dracut --libdirs "dir1 dir2"  ...
+----
+===============================
+
 **--kernel-cmdline <parameters>**::
     specify default kernel command line parameters
 


### PR DESCRIPTION
This pull request adds the missing usage and man section of the `--libdirs` option (introduced almost 10 years ago... https://github.com/dracutdevs/dracut/commit/c9143a63).

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
