### PR TITLE
WIP: feat(plymouth-ng): alternative module to use plymouth as boot splash

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -236,6 +236,20 @@ inst() {
     fi
 }
 
+inst_recur() {
+    for x in "$dracutsysrootdir${1%/}"/*; do
+        x=${x#$dracutsysrootdir}
+        if [[ -d "$dracutsysrootdir$x" ]]; then
+            inst_dir "$x"
+            inst_recur "$x"
+        elif [[ -f "$dracutsysrootdir$x" ]]; then
+            inst "$x"
+        else
+            break
+        fi
+    done
+}
+
 inst_simple() {
     local _ret _hostonly_install
     if [[ $1 == "-H" ]]; then

--- a/modules.d/01systemd-ask-password/module-setup.sh
+++ b/modules.d/01systemd-ask-password/module-setup.sh
@@ -39,7 +39,7 @@ install() {
     $SYSTEMCTL -q --root "$initdir" enable systemd-ask-password-console.service
 
     # Install systemd-ask-password plymouth units if plymouth is enabled.
-    if dracut_module_included "plymouth"; then
+    if dracut_module_included "plymouth" || dracut_module_included "plymouth-ng"; then
         inst_multiple -o \
             "$systemdsystemunitdir"/systemd-ask-password-plymouth.path \
             "$systemdsystemunitdir"/systemd-ask-password-plymouth.service

--- a/modules.d/50boot-animation/module-setup.sh
+++ b/modules.d/50boot-animation/module-setup.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+    return 255
+}
+
+# called by dracut
+depends() {
+    # shellcheck disable=SC2043
+    for module in plymouth-ng; do
+        if dracut_module_included "$module"; then
+            splash_backend="$module"
+            break
+        fi
+    done
+
+    if [ -z "$splash_backend" ]; then
+        if [[ -e $dracutsysrootdir$systemdsystemunitdir/plymouth-start.service ]]; then
+            splash_backend="plymouth-ng"
+        fi
+    fi
+    echo "$splash_backend"
+    return 0
+}
+
+# called by dracut
+installkernel() {
+    return 0
+}
+
+# called by dracut
+install() {
+    return 0
+}

--- a/modules.d/50plymouth-ng/module-setup.sh
+++ b/modules.d/50plymouth-ng/module-setup.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+pkglib_dir() {
+    local _dirs="/usr/lib/plymouth /usr/lib64/plymouth /usr/libexec/plymouth"
+    if find_binary dpkg-architecture &> /dev/null; then
+        local _arch
+        _arch=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2> /dev/null)
+        [ -n "$_arch" ] && _dirs+=" /usr/lib/$_arch/plymouth"
+    fi
+    for _dir in $_dirs; do
+        if [[ -x "$dracutsysrootdir""$_dir"/plymouthd-fd-escrow ]]; then
+            echo "$_dir"
+            return
+        fi
+        if [[ -x "$dracutsysrootdir""$_dir"/plymouth-populate-initrd ]]; then
+            echo "$_dir"
+            return
+        fi
+    done
+}
+
+plugin_dir() {
+    local _dirs="/usr/lib/plymouth /usr/lib64/plymouth /usr/libexec/plymouth"
+    if find_binary dpkg-architecture &> /dev/null; then
+        local _arch
+        _arch=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2> /dev/null)
+        [[ -n $_arch ]] && _dirs+=" /usr/lib/$_arch/plymouth"
+    fi
+    for _dir in $_dirs; do
+        if [[ -d "$dracutsysrootdir""$_dir"/renderers ]]; then
+            echo "$_dir"
+            return
+        fi
+    done
+}
+
+# $1: Configuration file
+# $2: Setting name
+function read_setting_from_file() {
+    grep -v '^#' "$1" 2> /dev/null \
+        | awk 'BEGIN { FS="[=[:space:]]+"; OFS=""; ORS="" } $1 ~/^'"$2"'$/ { print $2 }'
+}
+
+# $1: Configuration file
+function set_configured_theme_path_from_file() {
+    [[ -z $CONFIGURED_THEME_DIR ]] && CONFIGURED_THEME_DIR=$(read_setting_from_file "$1" "ThemeDir")
+    [[ -z $CONFIGURED_THEME_DIR ]] && CONFIGURED_THEME_DIR=/usr/share/plymouth/themes
+    CONFIGURED_THEME_NAME=$(read_setting_from_file "$1" "Theme")
+}
+
+function set_theme_dir() {
+    set_configured_theme_path_from_file "$dracutsysrootdir"/etc/plymouth/plymouthd.conf
+    if [[ -z $CONFIGURED_THEME_DIR ]] || [[ ! -d "$dracutsysrootdir$CONFIGURED_THEME_DIR/$CONFIGURED_THEME_NAME" ]]; then
+        set_configured_theme_path_from_file "$dracutsysrootdir"/usr/share/plymouth/plymouthd.defaults
+    fi
+
+    if [[ -n $CONFIGURED_THEME_DIR ]] && [[ -d $dracutsysrootdir$CONFIGURED_THEME_DIR ]]; then
+        PLYMOUTH_THEME_DIR="$CONFIGURED_THEME_DIR"
+    else
+        PLYMOUTH_THEME_DIR=/usr/share/plymouth/themes
+    fi
+    PLYMOUTH_THEME_NAME=${CONFIGURED_THEME_NAME:-spinner}
+}
+
+# called by dracut
+check() {
+    [[ "$mount_needs" ]] && return 1
+    [[ $(pkglib_dir) ]] || return 1
+
+    require_binaries plymouthd plymouth plymouth-set-default-theme || return 1
+
+    set_theme_dir
+    [[ -n $PLYMOUTH_THEME_NAME ]] || return 1
+
+    return 255
+}
+
+# called by dracut
+depends() {
+    echo drm
+}
+
+# called by dracut
+install() {
+    PKGLIBDIR=$(pkglib_dir)
+    PLUGINDIR=$(plugin_dir)
+
+    inst_multiple readlink
+
+    inst_multiple plymouthd plymouth
+    inst_multiple -o "$PKGLIBDIR"/plymouthd-fd-escrow
+
+    inst_multiple -o "$PLUGINDIR/renderers/drm.so"
+    inst_multiple "$PLUGINDIR/renderers/frame-buffer.so"
+
+    set_theme_dir
+    inst_dir "$PLYMOUTH_THEME_DIR"
+
+    inst_multiple "$PLUGINDIR"/text.so "$PLUGINDIR"/details.so
+    inst_recur "$PLYMOUTH_THEME_DIR"/text
+    inst_recur "$PLYMOUTH_THEME_DIR"/details
+
+    PLYMOUTH_MODULE_NAME=$(grep "ModuleName *= *" "$dracutsysrootdir$PLYMOUTH_THEME_DIR/$PLYMOUTH_THEME_NAME/$PLYMOUTH_THEME_NAME.plymouth" | sed 's/ModuleName *= *//')
+    PLYMOUTH_IMAGE_DIR=$(grep "ImageDir *= *" "$dracutsysrootdir$PLYMOUTH_THEME_DIR/$PLYMOUTH_THEME_NAME/$PLYMOUTH_THEME_NAME.plymouth" | sed 's/ImageDir *= *//')
+
+    inst_multiple -o "$PLUGINDIR/$PLYMOUTH_MODULE_NAME.so"
+    inst_recur "$PLYMOUTH_THEME_DIR/$PLYMOUTH_THEME_NAME"
+
+    if [[ $PLYMOUTH_IMAGE_DIR != "$PLYMOUTH_THEME_DIR/$PLYMOUTH_THEME_NAME" ]] && [[ -n $PLYMOUTH_IMAGE_DIR ]] && [[ -d "$dracutsysrootdir$PLYMOUTH_IMAGE_DIR" ]]; then
+        inst_recur "$PLYMOUTH_IMAGE_DIR"
+    fi
+
+    inst_multiple \
+        /usr/share/plymouth/plymouthd.defaults \
+        /etc/plymouth/plymouthd.conf
+
+    inst_multiple -o /usr/share/plymouth/themes/default.plymouth
+
+    inst_multiple -o "/usr/share/plymouth/*.png"
+
+    inst_multiple -o /etc/system-release
+
+    inst_hook emergency 50 "$moddir"/plymouth-emergency.sh
+
+    if dracut_module_included "systemd"; then
+        inst_multiple \
+            "$systemdsystemunitdir"/systemd-ask-password-plymouth.path \
+            "$systemdsystemunitdir"/systemd-ask-password-plymouth.service \
+            "$systemdsystemunitdir"/plymouth-switch-root.service \
+            "$systemdsystemunitdir"/plymouth-start.service \
+            "$systemdsystemunitdir"/plymouth-quit.service \
+            "$systemdsystemunitdir"/plymouth-quit-wait.service \
+            "$systemdsystemunitdir"/plymouth-reboot.service \
+            "$systemdsystemunitdir"/plymouth-kexec.service \
+            "$systemdsystemunitdir"/plymouth-poweroff.service \
+            "$systemdsystemunitdir"/plymouth-halt.service \
+            "$systemdsystemunitdir"/initrd-switch-root.target.wants/plymouth-switch-root.service \
+            "$systemdsystemunitdir"/initrd-switch-root.target.wants/plymouth-start.service \
+            "$systemdsystemunitdir"/sysinit.target.wants/plymouth-start.service \
+            "$systemdsystemunitdir"/multi-user.target.wants/plymouth-quit.service \
+            "$systemdsystemunitdir"/multi-user.target.wants/plymouth-quit-wait.service \
+            "$systemdsystemunitdir"/reboot.target.wants/plymouth-reboot.service \
+            "$systemdsystemunitdir"/kexec.target.wants/plymouth-kexec.service \
+            "$systemdsystemunitdir"/poweroff.target.wants/plymouth-poweroff.service \
+            "$systemdsystemunitdir"/halt.target.wants/plymouth-halt.service
+    else
+        inst_hook pre-trigger 10 "$moddir"/plymouth-pretrigger.sh
+        inst_hook pre-pivot 90 "$moddir"/plymouth-newroot.sh
+    fi
+}

--- a/modules.d/50plymouth-ng/plymouth-emergency.sh
+++ b/modules.d/50plymouth-ng/plymouth-emergency.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+plymouth --hide-splash 2> /dev/null || :

--- a/modules.d/50plymouth-ng/plymouth-newroot.sh
+++ b/modules.d/50plymouth-ng/plymouth-newroot.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if type plymouth > /dev/null 2>&1 && [ -z "$DRACUT_SYSTEMD" ]; then
+    plymouth --newroot="$NEWROOT"
+fi

--- a/modules.d/50plymouth-ng/plymouth-pretrigger.sh
+++ b/modules.d/50plymouth-ng/plymouth-pretrigger.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+if type plymouthd > /dev/null 2>&1 && [ -z "$DRACUT_SYSTEMD" ]; then
+    if getargbool 1 plymouth.enable && getargbool 1 rd.plymouth -d -n rd_NO_PLYMOUTH; then
+        # first trigger graphics subsystem
+        udevadm trigger --action=add --attr-match=class=0x030000 > /dev/null 2>&1
+        # first trigger graphics and tty subsystem
+        udevadm trigger --action=add \
+            --subsystem-match=graphics \
+            --subsystem-match=drm \
+            --subsystem-match=tty \
+            --subsystem-match=acpi \
+            > /dev/null 2>&1
+
+        udevadm settle --timeout=180 2>&1 | vinfo
+
+        info "Starting plymouth daemon"
+        mkdir -m 0755 /run/plymouth
+        read -r consoledev rest < /sys/class/tty/console/active
+        consoledev=${consoledev:-tty0}
+        [ -x /lib/udev/console_init -a -e "/dev/$consoledev" ] && /lib/udev/console_init "/dev/$consoledev"
+        plymouthd --attach-to-session --pid-file /run/plymouth/pid
+        plymouth --show-splash 2>&1 | vinfo
+        # reset tty after plymouth messed with it
+        [ -x /lib/udev/console_init -a -e "/dev/$consoledev" ] && /lib/udev/console_init "/dev/$consoledev"
+    fi
+fi

--- a/modules.d/50plymouth/module-setup.sh
+++ b/modules.d/50plymouth/module-setup.sh
@@ -19,6 +19,8 @@ pkglib_dir() {
 check() {
     [[ "$mount_needs" ]] && return 1
     [[ $(pkglib_dir) ]] || return 1
+    dracut_module_included boot-animation && return 1
+    dracut_module_included plymouth-ng && return 1
 
     require_binaries plymouthd plymouth plymouth-set-default-theme
 }

--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -76,7 +76,8 @@ test_setup() {
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -m "dash rootfs-block kernel-modules qemu" \
+        -m "dash rootfs-block kernel-modules qemu boot-animation" \
+        -o "plymouth" \
         -d "piix ide-gd_mod ata_piix ext3 sd_mod" \
         --nomdadmconf \
         --no-hostonly-cmdline -N \

--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -74,7 +74,8 @@ test_setup() {
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -m "dash rootfs-block kernel-modules qemu" \
+        -m "dash rootfs-block kernel-modules qemu boot-animation" \
+        -o "plymouth" \
         -d "piix ide-gd_mod ata_piix ext3 sd_mod" \
         --nomdadmconf \
         --no-hostonly-cmdline -N \

--- a/test/TEST-03-USR-MOUNT/test.sh
+++ b/test/TEST-03-USR-MOUNT/test.sh
@@ -58,7 +58,8 @@ test_setup() {
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -m "test-makeroot dash btrfs rootfs-block kernel-modules" \
+        -m "test-makeroot dash btrfs rootfs-block kernel-modules boot-animation" \
+        -o "plymouth" \
         -d "piix ide-gd_mod ata_piix btrfs sd_mod" \
         -I "mkfs.btrfs" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -247,7 +247,8 @@ EOF
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -m "bash btrfs rootfs-block kernel-modules qemu" \
+        -m "bash btrfs rootfs-block kernel-modules qemu boot-animation" \
+        -o "plymouth" \
         -d "piix ide-gd_mod ata_piix btrfs sd_mod" \
         --nomdadmconf \
         --nohardlink \
@@ -293,7 +294,7 @@ EOF
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -a "debug systemd i18n qemu" \
         ${EXTRA_MACHINE:+-I "$EXTRA_MACHINE"} \
-        -o "dash network plymouth lvm mdraid resume crypt caps dm terminfo usrmount kernel-network-modules rngd" \
+        -o "dash network plymouth boot-animation lvm mdraid resume crypt caps dm terminfo usrmount kernel-network-modules rngd" \
         -d "piix ide-gd_mod ata_piix btrfs sd_mod i6300esb ib700wdt" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1


### PR DESCRIPTION
Signed-off-by: Zoltán Böszörményi <zboszor@gmail.com>

## Changes

Added new modules: plymouth-ng and boot-animation, the second being a meta-module.
plymouth-ng is an alternative to the plymouth module. The difference is that it doesn't rely on plymouth's "populate initrd" script.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and tests for it
