### PR TITLE
Avoid calling unavailable dracut-logger functions from boot scripts

### DIFF
--- a/modules.d/35network-manager/nm-lib.sh
+++ b/modules.d/35network-manager/nm-lib.sh
@@ -11,7 +11,7 @@ nm_generate_connections() {
         # shellcheck disable=SC2046
         /usr/lib/nm-initrd-generator -- $(getcmdline)
     else
-        derror "nm-initrd-generator not found"
+        warn "nm-initrd-generator not found"
     fi
 
     if getargbool 0 rd.neednet; then

--- a/modules.d/45ifcfg/write-ifcfg.sh
+++ b/modules.d/45ifcfg/write-ifcfg.sh
@@ -104,7 +104,7 @@ interface_bind() {
     local _macaddr="$2"
 
     if [ ! -e "/sys/class/net/$_netif" ]; then
-        derror "Cannot find network interface '$_netif'!"
+        warn "Cannot find network interface '$_netif'!"
         return 1
     fi
 


### PR DESCRIPTION
The dracut-logger functions are only available during the initrd generation.
For internal initrd scripts that run at boot, dracut-lib provides `warn()` and `info()`.

This PR should cover all the wrong calls:
```
# grep -r -n -w -e dfatal -e derror -e dwarn -e dwarning -e dinfo -e ddebug -e dtrace modules.d | grep -v module-setup
modules.d/35network-manager/nm-lib.sh:14:        derror "nm-initrd-generator not found"
modules.d/45ifcfg/write-ifcfg.sh:107:        derror "Cannot find network interface '$_netif'!"
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it