### PR TITLE
feat(url-lib.sh): Add --retry-connrefused to default curl arguments

### DIFF
--- a/modules.d/45url-lib/url-lib.sh
+++ b/modules.d/45url-lib/url-lib.sh
@@ -56,7 +56,7 @@ add_url_handler() {
 
 export CURL_HOME="/run/initramfs/url-lib"
 mkdir -p $CURL_HOME
-curl_args="--globoff --location --retry 3 --fail --show-error"
+curl_args="--globoff --location --retry 3 --retry-connrefused --fail --show-error"
 getargbool 0 rd.noverifyssl && curl_args="$curl_args --insecure"
 
 proxy=$(getarg proxy=)


### PR DESCRIPTION
Trigger the existing retry condition on connection refused
to mitigate transient connectivity issues.

This pull request updates the default curl options to include `--retry-connrefused`, triggering retry behavior if connections are refused.

Testing (using a python web server serving single file, foo)
```
# without commit (connection is refused, immediate fail)
jamesm@x1:~/src/dracut$ curl --globoff --location --retry 3 --fail --show-error  localhost:8000/foo
curl: (7) Failed to connect to localhost port 8000: Connection refused

# with commit (immediate success, retry is not triggered)
jamesm@x1:~/src/dracut$ curl --globoff --location --retry 3 --fail --show-error  localhost:8000/foo
hello dracut
jamesm@x1:~/src/dracut$ echo $?
0

# with commit (connection is refused, fail, fail, fail, success)
jamesm@x1:~/src/dracut$ curl --globoff --location --retry 3 --fail --show-error --retry-connrefused localhost:8000/foo
curl: (7) Failed to connect to localhost port 8000: Connection refused
Warning: Problem : connection refused. Will retry in 1 seconds. 3 retries 
Warning: left.
curl: (7) Failed to connect to localhost port 8000: Connection refused
Warning: Problem : connection refused. Will retry in 2 seconds. 2 retries 
Warning: left.
curl: (7) Failed to connect to localhost port 8000: Connection refused
Warning: Problem : connection refused. Will retry in 4 seconds. 1 retries 
Warning: left.
hello dracut
jamesm@x1:~/src/dracut$ echo $?
0
```
## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
