### PR TITLE
UEFI: Use kernel version if no VERSION value is given in os-release

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2535,6 +2535,12 @@ if [[ $uefi == yes ]]; then
 
     [[ -s $dracutsysrootdir/usr/lib/os-release ]] && uefi_osrelease="$dracutsysrootdir/usr/lib/os-release"
     [[ -s $dracutsysrootdir/etc/os-release ]] && uefi_osrelease="$dracutsysrootdir/etc/os-release"
+    if ! grep -q VERSION= "$uefi_osrelease"; then
+        cp "$uefi_osrelease" "${uefi_outdir}/os-release"
+        uefi_osrelease="${uefi_outdir}/os-release"
+        printf "VERSION=%s\n" "$kernel" >> "$uefi_osrelease"
+    fi
+
     if [[ -s ${dracutsysrootdir}${uefi_splash_image} ]]; then
         uefi_splash_image="${dracutsysrootdir}${uefi_splash_image}"
     else


### PR DESCRIPTION
This pull request changes the uefi section of dracut.sh to create a local temporary copy of os-release if the system-provided os-release file does not specify a value for VERSION. (Systemd-boot / gummiboot expects that VERSION is present to automatically files saved to /EFI/Linux/*.efi, and some distributions like Void Linux don't set a VERSION value.)

## Changes

## Checklist
- [X] I have tested it locally
- [N/A] I have reviewed and updated any documentation if relevant
- [Code only] I am providing new code and test(s) for it

Fixes #N/A
