### PR TITLE
fix(lvm): add missing grep requirement

### DIFF
--- a/modules.d/90lvm/module-setup.sh
+++ b/modules.d/90lvm/module-setup.sh
@@ -3,7 +3,7 @@
 # called by dracut
 check() {
     # No point trying to support lvm if the binaries are missing
-    require_binaries lvm || return 1
+    require_binaries lvm grep || return 1
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         for fs in "${host_fs_types[@]}"; do
@@ -48,7 +48,7 @@ installkernel() {
 
 # called by dracut
 install() {
-    inst lvm
+    inst_multiple lvm grep
 
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _lvmconf


### PR DESCRIPTION
Since commit https://github.com/dracutdevs/dracut/commit/7ffc5e38 `lvm_scan.sh` requires `grep`.

https://github.com/dracutdevs/dracut/blob/a7a4b76c4ad5794f5f8a24ecd5b495f1512d05f7/modules.d/90lvm/lvm_scan.sh#L55-L65

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
