### PR TITLE
fix(nfs): give /run/rpcbind ownership to rpc user and add missing requirements

### DIFF
--- a/modules.d/95nfs/module-setup.sh
+++ b/modules.d/95nfs/module-setup.sh
@@ -21,7 +21,7 @@ get_nfs_type() {
 check() {
     # If our prerequisites are not met, fail anyways.
     require_any_binary rpcbind portmap || return 1
-    require_binaries rpc.statd mount.nfs mount.nfs4 umount || return 1
+    require_binaries rpc.statd mount.nfs mount.nfs4 umount sed chmod chown || return 1
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         [[ "$(get_nfs_type)" ]] && return 0
@@ -76,7 +76,7 @@ cmdline() {
 # called by dracut
 install() {
     local _nsslibs
-    inst_multiple -o rpc.idmapd mount.nfs mount.nfs4 umount sed /etc/netconfig chmod "$tmpfilesdir/rpcbind.conf"
+    inst_multiple -o rpc.idmapd mount.nfs mount.nfs4 umount sed /etc/netconfig chmod chown "$tmpfilesdir/rpcbind.conf"
     inst_multiple -o /etc/idmapd.conf
     inst_multiple -o /etc/services /etc/nsswitch.conf /etc/rpc /etc/protocols
     inst_multiple -o /usr/etc/services /usr/etc/nsswitch.conf /usr/etc/rpc /usr/etc/protocols

--- a/modules.d/95nfs/nfs-start-rpc.sh
+++ b/modules.d/95nfs/nfs-start-rpc.sh
@@ -9,6 +9,7 @@ if modprobe sunrpc || strstr "$(cat /proc/filesystems)" rpc_pipefs; then
     command -v portmap > /dev/null && [ -z "$(pidof portmap)" ] && portmap
     if command -v rpcbind > /dev/null && [ -z "$(pidof rpcbind)" ]; then
         mkdir -p /run/rpcbind
+        chown rpc:rpc /run/rpcbind
         rpcbind
     fi
 


### PR DESCRIPTION
- `parse-nfsroot.sh` requires `sed`, `chmod` and `chown`.
```
# grep -r -n -w -e sed -e chmod -e chown modules.d/95nfs | grep -v module-setup
modules.d/95nfs/parse-nfsroot.sh:92:        sed -i -e \
modules.d/95nfs/parse-nfsroot.sh:96:    # and even again after the sed, in case it was not yet specified
modules.d/95nfs/parse-nfsroot.sh:127:chown rpc:rpc /var/lib/rpcbind
modules.d/95nfs/parse-nfsroot.sh:128:chmod 770 /var/lib/rpcbind
```
- Avoid errors when `rpcbind` tries to write to the `/run/rpcbind` directory.
```
Apr 13 11:35:43 localhost systemd[1]: Starting dracut pre-pivot and cleanup hook...
Apr 13 11:33:13 localhost rpc.idmapd[262]: exiting on signal 15
Apr 13 11:33:13 localhost rpcbind[253]: cannot open file = /run/rpcbind/rpcbind.xdr for writing
Apr 13 11:33:13 localhost rpcbind[253]: cannot save any registration
Apr 13 11:33:13 localhost rpcbind[253]: cannot open file = /run/rpcbind/portmap.xdr for writing
Apr 13 11:33:13 localhost rpcbind[253]: cannot save any registration
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it