### PR TITLE
feat(virtiofs): virtiofs root filesystem support

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -228,6 +228,9 @@ udev-rules:
 virtfs:
   - modules.d/95virtfs/*
 
+virtiofs:
+  - modules.d/95virtiofs/*
+
 zfcp:
   - modules.d/95zfcp/*
 

--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -928,6 +928,25 @@ NOTE:
     If "exportname" instead of "port" is given the standard port is used.
     Newer versions of nbd are only supported with "exportname".
 
+VIRTIOFS
+~~~~~~~~
+**root=**virtiofs:__<mount-tag>__::
+    mount virtiofs share using the tag <mount-tag>.
+    The tag name is arbitrary and must match the tag given in the qemu '-device' command.
+
+**rootfstype=**virtiofs **root=**__<mount-tag>__::
+    mount virtiofs share using the tag <mount-tag>.
+    The tag name is arbitrary and must match the tag given in the qemu '-device' command.
+
+Both formats are supported by the 'virtiofs' dracut module.
+See https://gitlab.com/virtio-fs/virtiofsd for more information.
+
+[listing]
+.Example
+--
+root=virtiofs:host rw
+--
+
 DASD
 ~~~~
 **rd.dasd=**....::

--- a/modules.d/95virtiofs/module-setup.sh
+++ b/modules.d/95virtiofs/module-setup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/bash
+
+# called by dracut
+check() {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
+        is_qemu_virtualized && return 0
+
+        for fs in "${host_fs_types[@]}"; do
+            [[ $fs == "virtiofs" ]] && return 0
+        done
+        return 255
+    }
+
+    return 0
+}
+
+# called by dracut
+depends() {
+    return 0
+}
+
+# called by dracut
+installkernel() {
+    instmods virtiofs
+}
+
+# called by dracut
+install() {
+    inst_hook cmdline 95 "$moddir/parse-virtiofs.sh"
+    inst_hook pre-mount 99 "$moddir/mount-virtiofs.sh"
+}

--- a/modules.d/95virtiofs/mount-virtiofs.sh
+++ b/modules.d/95virtiofs/mount-virtiofs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/sh
+
+if [ "${fstype}" = "virtiofs" -o "${root%%:*}" = "virtiofs" ]; then
+    if ! { modprobe virtiofs || strstr "$(cat /proc/filesystems)" virtiofs; }; then
+        die "virtiofs is required but not available."
+    fi
+
+    mount -t virtiofs -o "$rflags" "${root#virtiofs:}" "$NEWROOT" 2>&1 | vinfo
+    if ! ismounted "$NEWROOT"; then
+        die "virtiofs: failed to mount root fs"
+        exit 1
+    fi
+
+    info "virtiofs: root fs mounted (options: '${rflags}')"
+
+    [ -f "$NEWROOT"/forcefsck ] && rm -f -- "$NEWROOT"/forcefsck 2> /dev/null
+    [ -f "$NEWROOT"/.autofsck ] && rm -f -- "$NEWROOT"/.autofsck 2> /dev/null
+fi
+:

--- a/modules.d/95virtiofs/parse-virtiofs.sh
+++ b/modules.d/95virtiofs/parse-virtiofs.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/sh
+# Accepted formats:
+# 	rootfstype=virtiofs root=<tag>
+# 	root=virtiofs:<tag>
+
+if [ "${fstype}" = "virtiofs" -o "${root%%:*}" = "virtiofs" ]; then
+    # shellcheck disable=SC2034
+    rootok=1
+fi

--- a/pkgbuild/dracut.spec
+++ b/pkgbuild/dracut.spec
@@ -386,6 +386,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/modules.d/95terminfo
 %{dracutlibdir}/modules.d/95udev-rules
 %{dracutlibdir}/modules.d/95virtfs
+%{dracutlibdir}/modules.d/95virtiofs
 %ifarch s390 s390x
 %{dracutlibdir}/modules.d/80cms
 %{dracutlibdir}/modules.d/81cio_ignore


### PR DESCRIPTION
Currently, dracut can't mount virtiofs as root filesystem.
Make possible to boot virtual machines off virtiofs,
passing "root=virtiofs:\<mtag\>", using the mount tag <mtag>
as root filesystem. Alternatively this module also supports
"rootfstype=virtiofs root=\<mtag\>"

## Checklist
- [ x ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

