### PR TITLE
Add missing dracut default output files

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1028,7 +1028,15 @@ stdloglvl=$((stdloglvl + verbosity_mod_l))
 
 if ! [[ $outfile ]]; then
     if [[ $machine_id != "no" ]]; then
-        [[ -f "$dracutsysrootdir"/etc/machine-id ]] && read -r MACHINE_ID < "$dracutsysrootdir"/etc/machine-id
+        if [[ -d "$dracutsysrootdir"/efi/Default ]] \
+            || [[ -d "$dracutsysrootdir"/boot/Default ]] \
+            || [[ -d "$dracutsysrootdir"/boot/efi/Default ]]; then
+            MACHINE_ID="Default"
+        elif [[ -f "$dracutsysrootdir"/etc/machine-id ]]; then
+            read -r MACHINE_ID < "$dracutsysrootdir"/etc/machine-id
+        else
+            MACHINE_ID="Default"
+        fi
     fi
 
     if [[ $uefi == "yes" ]]; then
@@ -1052,7 +1060,7 @@ if ! [[ $outfile ]]; then
                 efidir=/efi/EFI
             else
                 efidir=/boot/EFI
-                if [[ -d $dracutsysrootdir/boot/efi/EFI ]]; then
+                if [[ -d /boot/efi/EFI ]]; then
                     efidir=/boot/efi/EFI
                 fi
             fi
@@ -1065,12 +1073,28 @@ if ! [[ $outfile ]]; then
         mkdir -p "$dracutsysrootdir$efidir/Linux"
         outfile="$dracutsysrootdir$efidir/Linux/linux-$kernel${MACHINE_ID:+-${MACHINE_ID}}${BUILD_ID:+-${BUILD_ID}}.efi"
     else
-        if [[ -e $dracutsysrootdir/boot/vmlinuz-$kernel ]]; then
-            outfile="/boot/initramfs-$kernel.img"
-        elif [[ $MACHINE_ID ]] && { [[ -d $dracutsysrootdir/boot/${MACHINE_ID} ]] || [[ -L $dracutsysrootdir/boot/${MACHINE_ID} ]]; }; then
-            outfile="$dracutsysrootdir/boot/${MACHINE_ID}/$kernel/initrd"
+        if [[ -d "$dracutsysrootdir"/efi/loader/entries || -L "$dracutsysrootdir"/efi/loader/entries ]] \
+            && [[ $MACHINE_ID ]] \
+            && [[ -d "$dracutsysrootdir"/efi/${MACHINE_ID} || -L "$dracutsysrootdir"/efi/${MACHINE_ID} ]]; then
+            outfile="$dracutsysrootdir/efi/${MACHINE_ID}/${kernel}/initrd"
+        elif [[ -d "$dracutsysrootdir"/boot/loader/entries || -L "$dracutsysrootdir"/boot/loader/entries ]] \
+            && [[ $MACHINE_ID ]] \
+            && [[ -d "$dracutsysrootdir"/boot/${MACHINE_ID} || -L "$dracutsysrootdir"/boot/${MACHINE_ID} ]]; then
+            outfile="$dracutsysrootdir/boot/${MACHINE_ID}/${kernel}/initrd"
+        elif [[ -d "$dracutsysrootdir"/boot/efi/loader/entries || -L "$dracutsysrootdir"/boot/efi/loader/entries ]] \
+            && [[ $MACHINE_ID ]] \
+            && [[ -d "$dracutsysrootdir"/boot/efi/${MACHINE_ID} || -L "$dracutsysrootdir"/boot/efi/${MACHINE_ID} ]]; then
+            outfile="$dracutsysrootdir/boot/efi/${MACHINE_ID}/${kernel}/initrd"
+        elif [[ -f "$dracutsysrootdir"/lib/modules/${kernel}/initrd ]]; then
+            outfile="$dracutsysrootdir/lib/modules/${kernel}/initrd"
+        elif [[ -e $dracutsysrootdir/boot/vmlinuz-${kernel} ]]; then
+            outfile="$dracutsysrootdir/boot/initramfs-${kernel}.img"
+        elif [[ -z $dracutsysrootdir ]] && mountpoint -q /efi; then
+            outfile="/efi/${MACHINE_ID}/${kernel}/initrd"
+        elif [[ -z $dracutsysrootdir ]] && mountpoint -q /boot/efi; then
+            outfile="/boot/efi/${MACHINE_ID}/${kernel}/initrd"
         else
-            outfile="$dracutsysrootdir/boot/initramfs-$kernel.img"
+            outfile="$dracutsysrootdir/boot/initramfs-${kernel}.img"
         fi
     fi
 fi

--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -18,8 +18,13 @@ DESCRIPTION
 
 Create an initramfs <image> for the kernel with the version <kernel version>.
 If <kernel version> is omitted, then the version of the actual running
-kernel is used. If <image> is omitted or empty, then the default location
-/boot/initramfs-<kernel version>.img is used.
+kernel is used. If <image> is omitted or empty, depending on bootloader
+specification, the default location can be
+_/efi/<machine-id>/<kernel-version>/initrd_,
+_/boot/<machine-id>/<kernel-version>/initrd_,
+_/boot/efi/<machine-id>/<kernel-version>/initrd_,
+_/lib/modules/<kernel-version>/initrd_ or
+_/boot/initramfs-<kernel-version>.img_.
 
 dracut creates an initial image used by the kernel for preloading the block
 device modules (such as IDE, SCSI or RAID) which are needed to access the root

--- a/man/dracut.usage.asc
+++ b/man/dracut.usage.asc
@@ -5,9 +5,13 @@ To create a initramfs image, the most simple command is:
 
 This will generate a general purpose initramfs image, with all possible
 functionality resulting of the combination of the installed dracut modules and
-system tools. The image is /boot/initramfs-_++<kernel version>++_.img and
-contains the kernel modules of the currently active kernel with version
-_++<kernel version>++_.
+system tools. The image, depending on bootloader specification, can be
+_/efi/_++<machine-id>++_/_++<kernel-version>++_/initrd_,
+_/boot/_++<machine-id>++_/_++<kernel-version>++_/initrd_,
+_/boot/efi/_++<machine-id>++_/_++<kernel-version>++_/initrd_,
+_/lib/modules/_++<kernel-version>++_/initrd_ or
+_/boot/initramfs-_++<kernel-version>++_.img_ and contains the kernel modules of
+the currently active kernel with version _++<kernel-version>++_.
 
 If the initramfs image already exists, dracut will display an error message, and
 to overwrite the existing image, you have to use the --force option.

--- a/man/lsinitrd.1.asc
+++ b/man/lsinitrd.1.asc
@@ -13,12 +13,15 @@ SYNOPSIS
 --------
 *lsinitrd* ['OPTION...'] [<image> [<filename> [<filename> [...] ]]]
 
-*lsinitrd* ['OPTION...'] -k <kernel-version>
+*lsinitrd* ['OPTION...'] -k <kernel version>
 
 DESCRIPTION
 -----------
 lsinitrd shows the contents of an initramfs image. if <image> is omitted, then
-lsinitrd uses the default image _/boot/<machine-id>/<kernel-version>/initrd_ or
+lsinitrd uses the default image _/efi/<machine-id>/<kernel-version>/initrd_,
+_/boot/<machine-id>/<kernel-version>/initrd_,
+_/boot/efi/<machine-id>/<kernel-version>/initrd_,
+_/lib/modules/<kernel-version>/initrd_ or
 _/boot/initramfs-<kernel-version>.img_.
 
 OPTIONS


### PR DESCRIPTION
Consistent with issue #1628 and PR #1634, add missing dracut default output files.

When using systemd-boot and kernel-install, dracut runs a hook script (install.d/50-dracut.install) to generate the initrd at the correct place in the ESP. However, when calling dracut manually the initrd is saved in the traditional place in /boot. The same happens with lsinitrd, it does not detect the default initrd.

Fix the auto detection that doesn't notice the bootloader spec installation.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
