### PR TITLE
Use Documentation= to point to man page

### DIFF
--- a/modules.d/98dracut-systemd/dracut-cmdline-ask.service
+++ b/modules.d/98dracut-systemd/dracut-cmdline-ask.service
@@ -1,9 +1,8 @@
 #  This file is part of dracut.
-#
-# See dracut.bootup(7) for details
 
 [Unit]
 Description=dracut ask for additional cmdline parameters
+Documentation=man:dracut.bootup(7)
 DefaultDependencies=no
 Before=dracut-cmdline.service
 Wants=systemd-journald.socket

--- a/modules.d/98dracut-systemd/dracut-cmdline.service
+++ b/modules.d/98dracut-systemd/dracut-cmdline.service
@@ -1,10 +1,8 @@
 #  This file is part of dracut.
-#
-# See dracut.bootup(7) for details
 
 [Unit]
 Description=dracut cmdline hook
-Documentation=man:dracut-cmdline.service(8)
+Documentation=man:dracut-cmdline.service(8) man:dracut.bootup(7)
 DefaultDependencies=no
 Before=dracut-pre-udev.service
 After=systemd-journald.socket

--- a/modules.d/98dracut-systemd/dracut-emergency.service
+++ b/modules.d/98dracut-systemd/dracut-emergency.service
@@ -1,9 +1,8 @@
 #  This file is part of dracut.
-#
-# See dracut.bootup(7) for details
 
 [Unit]
 Description=Dracut Emergency Shell
+Documentation=man:dracut.bootup(7)
 DefaultDependencies=no
 After=systemd-vconsole-setup.service
 Wants=systemd-vconsole-setup.service

--- a/modules.d/98dracut-systemd/dracut-initqueue.service
+++ b/modules.d/98dracut-systemd/dracut-initqueue.service
@@ -1,10 +1,8 @@
 #  This file is part of dracut.
-#
-# See dracut.bootup(7) for details
 
 [Unit]
 Description=dracut initqueue hook
-Documentation=man:dracut-initqueue.service(8)
+Documentation=man:dracut-initqueue.service(8) man:dracut.bootup(7)
 DefaultDependencies=no
 Before=remote-fs-pre.target
 Wants=remote-fs-pre.target

--- a/modules.d/98dracut-systemd/dracut-mount.service
+++ b/modules.d/98dracut-systemd/dracut-mount.service
@@ -1,10 +1,8 @@
 #  This file is part of dracut.
-#
-# See dracut.bootup(7) for details
 
 [Unit]
 Description=dracut mount hook
-Documentation=man:dracut-mount.service(8)
+Documentation=man:dracut-mount.service(8) man:dracut.bootup(7)
 After=initrd-root-fs.target initrd-parse-etc.service
 After=dracut-initqueue.service dracut-pre-mount.service
 ConditionPathExists=/usr/lib/initrd-release

--- a/modules.d/98dracut-systemd/dracut-pre-mount.service
+++ b/modules.d/98dracut-systemd/dracut-pre-mount.service
@@ -1,10 +1,8 @@
 #  This file is part of dracut.
-#
-# See dracut.bootup(7) for details
 
 [Unit]
 Description=dracut pre-mount hook
-Documentation=man:dracut-pre-mount.service(8)
+Documentation=man:dracut-pre-mount.service(8) man:dracut.bootup(7)
 DefaultDependencies=no
 Before=initrd-root-fs.target sysroot.mount systemd-fsck-root.service
 After=dracut-initqueue.service cryptsetup.target

--- a/modules.d/98dracut-systemd/dracut-pre-pivot.service
+++ b/modules.d/98dracut-systemd/dracut-pre-pivot.service
@@ -1,10 +1,8 @@
 #  This file is part of dracut.
-#
-# See dracut.bootup(7) for details
 
 [Unit]
 Description=dracut pre-pivot and cleanup hook
-Documentation=man:dracut-pre-pivot.service(8)
+Documentation=man:dracut-pre-pivot.service(8) man:dracut.bootup(7)
 DefaultDependencies=no
 After=initrd.target initrd-parse-etc.service sysroot.mount
 After=dracut-initqueue.service dracut-pre-mount.service dracut-mount.service

--- a/modules.d/98dracut-systemd/dracut-pre-trigger.service
+++ b/modules.d/98dracut-systemd/dracut-pre-trigger.service
@@ -1,10 +1,8 @@
 #  This file is part of dracut.
-#
-# See dracut.bootup(7) for details
 
 [Unit]
 Description=dracut pre-trigger hook
-Documentation=man:dracut-pre-trigger.service(8)
+Documentation=man:dracut-pre-trigger.service(8) man:dracut.bootup(7)
 DefaultDependencies=no
 Before=systemd-udev-trigger.service dracut-initqueue.service
 After=dracut-pre-udev.service systemd-udevd.service systemd-tmpfiles-setup-dev.service

--- a/modules.d/98dracut-systemd/dracut-pre-udev.service
+++ b/modules.d/98dracut-systemd/dracut-pre-udev.service
@@ -1,10 +1,8 @@
 #  This file is part of dracut.
-#
-# See dracut.bootup(7) for details
 
 [Unit]
 Description=dracut pre-udev hook
-Documentation=man:dracut-pre-udev.service(8)
+Documentation=man:dracut-pre-udev.service(8) man:dracut.bootup(7)
 DefaultDependencies=no
 Before=systemd-udevd.service dracut-pre-trigger.service
 After=dracut-cmdline.service

--- a/modules.d/98dracut-systemd/dracut-shutdown-onfailure.service
+++ b/modules.d/98dracut-systemd/dracut-shutdown-onfailure.service
@@ -1,6 +1,4 @@
 #  This file is part of dracut.
-#
-# See dracut.bootup(7) for details
 
 [Unit]
 Description=Service executing upon dracut-shutdown failure to perform cleanup

--- a/modules.d/98dracut-systemd/dracut-shutdown.service
+++ b/modules.d/98dracut-systemd/dracut-shutdown.service
@@ -1,6 +1,4 @@
 #  This file is part of dracut.
-#
-# See dracut.bootup(7) for details
 
 [Unit]
 Description=Restore /run/initramfs on shutdown

--- a/modules.d/98dracut-systemd/emergency.service
+++ b/modules.d/98dracut-systemd/emergency.service
@@ -1,9 +1,8 @@
 #  This file is part of dracut.
-#
-# See dracut.bootup(7) for details
 
 [Unit]
 Description=Emergency Shell
+Documentation=man:dracut.bootup(7)
 DefaultDependencies=no
 After=systemd-vconsole-setup.service
 Wants=systemd-vconsole-setup.service


### PR DESCRIPTION
This pull request improves dracut's service files a tiny bit.

## Changes
- Remove reference to dracut.bootup(7) from two services that are not part of boot process.
- Use Documentation= directive instead of a comment to refer to a man page.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it