### PR TITLE
Fix firmware loading paths, supprt .zst-suffixed firmware

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -72,8 +72,6 @@ srcmods="$dracutsysrootdir/lib/modules/$kernel/"
 }
 export srcmods
 
-[[ $DRACUT_FIRMWARE_PATH ]] || export DRACUT_FIRMWARE_PATH="/lib/firmware/updates:/lib/firmware:/lib/firmware/$kernel"
-
 # export standard hookdirs
 [[ $hookdirs ]] || {
     hookdirs="cmdline pre-udev pre-trigger netroot "

--- a/dracut.sh
+++ b/dracut.sh
@@ -1001,7 +1001,10 @@ stdloglvl=$((stdloglvl + verbosity_mod_l))
 [[ $mdadmconf_l ]] && mdadmconf=$mdadmconf_l
 [[ $lvmconf_l ]] && lvmconf=$lvmconf_l
 [[ $dracutbasedir ]] || dracutbasedir="$dracutsysrootdir"/usr/lib/dracut
-[[ $fw_dir ]] || fw_dir="$dracutsysrootdir/lib/firmware/updates:$dracutsysrootdir/lib/firmware:$dracutsysrootdir/lib/firmware/$kernel"
+[[ $fw_dir ]] || {
+    fw_path_para=$(< /sys/module/firmware_class/parameters/path)
+    fw_dir="${fw_path_para:+$dracutsysrootdir$fw_path_para:}$dracutsysrootdir/lib/firmware/updates/$kernel:$dracutsysrootdir/lib/firmware/updates:$dracutsysrootdir/lib/firmware/$kernel:$dracutsysrootdir/lib/firmware"
+}
 [[ $tmpdir_l ]] && tmpdir="$tmpdir_l"
 [[ $tmpdir ]] || tmpdir="$TMPDIR"
 [[ $tmpdir ]] || tmpdir="$dracutsysrootdir"/var/tmp

--- a/modules.d/62bluetooth/module-setup.sh
+++ b/modules.d/62bluetooth/module-setup.sh
@@ -28,24 +28,23 @@ depends() {
 installkernel() {
     instmods bluetooth btrtl btintel btbcm bnep ath3k btusb rfcomm hidp
     inst_multiple -o \
-        /usr/lib/firmware/ar3k/AthrBT* \
-        /usr/lib/firmware/ar3k/ramps* \
-        /usr/lib/firmware/ath3k-1.fw \
-        /usr/lib/firmware/BCM2033-MD.hex \
-        /usr/lib/firmware/bfubase.frm \
-        /usr/lib/firmware/BT3CPCC.bin \
-        /usr/lib/firmware/brcm/*.hcd \
-        /usr/lib/firmware/mediatek/mt7622pr2h.bin \
-        /usr/lib/firmware/qca/nvm* \
-        /usr/lib/firmware/qca/crnv* \
-        /usr/lib/firmware/qca/rampatch* \
-        /usr/lib/firmware/qca/crbtfw* \
-        /usr/lib/firmware/rtl_bt/* \
-        /usr/lib/firmware/intel/ibt* \
-        /usr/lib/firmware/ti-connectivity/TIInit_* \
-        /usr/lib/firmware/nokia/bcmfw.bin \
-        /usr/lib/firmware/nokia/ti1273.bin
-
+        /lib/firmware/ar3k/AthrBT* \
+        /lib/firmware/ar3k/ramps* \
+        /lib/firmware/ath3k-1.fw* \
+        /lib/firmware/BCM2033-MD.hex* \
+        /lib/firmware/bfubase.frm* \
+        /lib/firmware/BT3CPCC.bin* \
+        /lib/firmware/brcm/*.hcd* \
+        /lib/firmware/mediatek/mt7622pr2h.bin* \
+        /lib/firmware/qca/nvm* \
+        /lib/firmware/qca/crnv* \
+        /lib/firmware/qca/rampatch* \
+        /lib/firmware/qca/crbtfw* \
+        /lib/firmware/rtl_bt/* \
+        /lib/firmware/intel/ibt* \
+        /lib/firmware/ti-connectivity/TIInit_* \
+        /lib/firmware/nokia/bcmfw.bin* \
+        /lib/firmware/nokia/ti1273.bin*
 }
 
 # Install the required file(s) for the module in the initramfs.

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -1371,18 +1371,20 @@ static int install_all(int argc, char **argv)
 
 static int install_firmware_fullpath(const char *fwpath)
 {
-        const char *fw;
-        _cleanup_free_ char *fwpath_xz = NULL;
-        fw = fwpath;
+        const char *fw = fwpath;
+        _cleanup_free_ char *fwpath_compressed = NULL;
         struct stat sb;
         int ret;
         if (stat(fwpath, &sb) != 0) {
-                _asprintf(&fwpath_xz, "%s.xz", fwpath);
-                if (stat(fwpath_xz, &sb) != 0) {
-                        log_debug("stat(%s) != 0", fwpath);
-                        return 1;
+                _asprintf(&fwpath_compressed, "%s.zst", fwpath);
+                if (access(fwpath_compressed, F_OK) != 0) {
+                        strcpy(fwpath_compressed + strlen(fwpath) + 1, "xz");
+                        if (access(fwpath_compressed, F_OK) != 0) {
+                                log_debug("stat(%s) != 0", fwpath);
+                                return 1;
+                        }
                 }
-                fw = fwpath_xz;
+                fw = fwpath_compressed;
         }
         ret = dracut_install(fw, fw, false, false, true);
         if (ret == 0) {


### PR DESCRIPTION
## Changes
The firmware loading path is
1. contents of /sys/module/firmware_class/parameters/path (`fw_path_para`), if any
2. /lib/firmware/updates/$(uname -r)
3. /lib/firmware/updates
4. /lib/firmware/$(uname -r)
5. /lib/firmware

Always.

Repeated single-character strstr()s -> strpbrk() and stat()s with unused buffers -> access()es.

Also check for `.zst`-suffixed firmware, coming in 5.19: https://git.kernel.org/pub/scm/linux/kernel/git/gregkh/driver-core.git/commit/?h=driver-core-next&id=23cfbc6ec44e5e80d5522976ff45ffcdcddfb230

62bluetooth `inst_multiple`s its firmware (for some reason?); glob at the end of the unglobbed paths to catch compressed fw.