### PR TITLE
fix(iscsi): do not exit in handle_netroot() if discovery failed

### DIFF
--- a/modules.d/95iscsi/iscsiroot.sh
+++ b/modules.d/95iscsi/iscsiroot.sh
@@ -229,7 +229,7 @@ handle_netroot() {
             echo "$target"
         done
     })
-    [ -z "$targets" ] && echo "Target discovery to $iscsi_target_ip:${iscsi_target_port:+$iscsi_target_port} failed with status $?" && exit 1
+    [ -z "$targets" ] && warn "Target discovery to $iscsi_target_ip:${iscsi_target_port:+$iscsi_target_port} failed with status $?" && return 1
 
     found=
     for target in $targets; do


### PR DESCRIPTION
This pull request changes...

## Changes

If user specify multiple netroot in cmdline, and one of it is not accessible, previous implement would exit discovery flow.
After this chang, it would continue trying other netroot.

Actually, the previous implement is not reasonable in another way, if we specify 3 netroot, and the second netroot would fail, the others are ok. Then the first netroot would connect success, and the third would not be connected.

## Checklist
- [✓] I have tested it locally
- [✓] I have reviewed and updated any documentation if relevant
- [✓] I am providing new code and test(s) for it

Fixes https://github.com/dracutdevs/dracut/issues/1798