### PR TITLE
ci(integration): replace Fedora 33 with Fedora latest

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,11 +14,11 @@ jobs:
         strategy:
             matrix:
                 container: [
-                        "fedora:33",
-                        "fedora:rawhide",
-                        "opensuse:latest",
                         "arch:latest",
                         "debian:latest",
+                        "fedora:latest",
+                        "fedora:rawhide",
+                        "opensuse:latest",
                 ]
                 test: [
                         "04",


### PR DESCRIPTION
Fedora 33 reached end-of-life on 2021-11-30, replacing it with
Fedora latest

Alphabetically ordering the distributions in the container section

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
