### PR TITLE
ci: install sudo for the debian container

### DIFF
--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -45,6 +45,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && DEBIAN_FRONTEND=nonintera
     shellcheck \
     squashfs-tools \
     strace \
+    sudo \
     tcpdump \
     vim \
     wget \


### PR DESCRIPTION
sudo is required to run the CI tests.

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


