### PR TITLE
fix(dracut.sh): always check that MACHINE_ID is not empty 

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1089,9 +1089,13 @@ if ! [[ $outfile ]]; then
             outfile="$dracutsysrootdir/lib/modules/${kernel}/initrd"
         elif [[ -e $dracutsysrootdir/boot/vmlinuz-${kernel} ]]; then
             outfile="$dracutsysrootdir/boot/initramfs-${kernel}.img"
-        elif [[ -z $dracutsysrootdir ]] && mountpoint -q /efi; then
+        elif [[ -z $dracutsysrootdir ]] \
+            && [[ $MACHINE_ID ]] \
+            && mountpoint -q /efi; then
             outfile="/efi/${MACHINE_ID}/${kernel}/initrd"
-        elif [[ -z $dracutsysrootdir ]] && mountpoint -q /boot/efi; then
+        elif [[ -z $dracutsysrootdir ]] \
+            && [[ $MACHINE_ID ]] \
+            && mountpoint -q /boot/efi; then
             outfile="/boot/efi/${MACHINE_ID}/${kernel}/initrd"
         else
             outfile="$dracutsysrootdir/boot/initramfs-${kernel}.img"

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -133,9 +133,11 @@ else
         image="/lib/modules/${KERNEL_VERSION}/initrd"
     elif [[ -f /boot/initramfs-${KERNEL_VERSION}.img ]]; then
         image="/boot/initramfs-${KERNEL_VERSION}.img"
-    elif mountpoint -q /efi; then
+    elif [[ $MACHINE_ID ]] \
+        && mountpoint -q /efi; then
         image="/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
-    elif mountpoint -q /boot/efi; then
+    elif [[ $MACHINE_ID ]] \
+        && mountpoint -q /boot/efi; then
         image="/boot/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
     else
         image=""


### PR DESCRIPTION
On new installations, /etc/machine-id may exist and be empty, and also /efi or /boot/efi may be a mount point, leading to an invalid initramfs output file.

Excerpt from a failed openQA test:
```
2022-05-01 09:03:19 <3> install(3949) [Ruby] lib/cheetah.rb(log_stream_line):211 Error output: dracut: Executing: /usr/bin/dracut --kver=5.17.4-1-default --force
2022-05-01 09:03:19 <3> install(3949) [Ruby] lib/cheetah.rb(log_stream_line):211 Error output: dracut: Can't write to /boot/efi//5.17.4-1-default: Directory /boot/efi//5.17.4-1-default does not exist or is not accessible.
2022-05-01 09:03:19 <3> install(3949) [Ruby] lib/cheetah.rb(record_status):183 Status: 1
2022-05-01 09:03:19 <3> install(3949) [Ruby] yast2/execute.rb(rescue in popup_error):232 Execution of command "[["/usr/bin/dracut", "--force", "--regenerate-all"]]" failed.
```

Checking also that `MACHINE_ID` is not empty in `lsinitrd.sh`, though it is not critical, just following what is being done previously in its code.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
