### PR TITLE
fix(iscsi): iscsiroot: remove redundant ifaces config in initrd

### DIFF
--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -198,14 +198,9 @@ install() {
         "$systemdsystemunitdir"/sockets.target.wants/iscsid.socket \
         "$systemdsystemunitdir"/sockets.target.wants/iscsiuio.socket
 
+    inst_simple /etc/iscsi/iscsid.conf
     if [[ $hostonly ]]; then
-        local -a _filenames
-
-        inst_dir /etc/iscsi
-        mapfile -t -d '' _filenames < <(find /etc/iscsi -type f -print0)
-        inst_multiple "${_filenames[@]}"
-    else
-        inst_simple /etc/iscsi/iscsid.conf
+        inst_simple /etc/iscsi/initiatorname.iscsi
     fi
 
     # Detect iBFT and perform mandatory steps


### PR DESCRIPTION
As issue in https://github.com/dracutdevs/dracut/issues/1797, there are two way to address it,
First is not add these files in initrd by modify module-setup, another one is to remove the redundant ifaces before discoverying.

Here we remove redundant ifaces configure before discoverying as a workaround to address this issue.

## Changes
iscsiroot: remove redundant ifaces configure before discoverying

## Influence
The removal is before iscsiroot create new ifaces according to cmdline, so it would not affect it.

## Checklist
- [✓] I have tested it locally
- [✓] I have reviewed and updated any documentation if relevant
- [✓] I am providing new code and test(s) for it

Fixes #1797
