### PR TITLE
Update dracut and dracut.conf man, dracut usage and bash completion

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -79,57 +79,69 @@ Creates initial ramdisk images for preloading modules
 
   --kver [VERSION]      Set kernel version to [VERSION].
   -f, --force           Overwrite existing initramfs file.
+  [OUTPUT_FILE] --rebuild
+                        Append the current arguments to those with which the
+                         input initramfs image was built. This option helps in
+                         incrementally building the initramfs for testing.
+                         If optional [OUTPUT_FILE] is not provided, the input
+                         initramfs provided to rebuild will be used as output
+                         file.
   -a, --add [LIST]      Add a space-separated list of dracut modules.
-  --rebuild         Append arguments to those of existing image and rebuild
+  --force-add [LIST]    Force to add a space-separated list of dracut modules
+                         to the default set of modules, when -H is specified.
+  -o, --omit [LIST]     Omit a space-separated list of dracut modules.
   -m, --modules [LIST]  Specify a space-separated list of dracut modules to
                          call when building the initramfs. Modules are located
                          in /usr/lib/dracut/modules.d.
-  -o, --omit [LIST]     Omit a space-separated list of dracut modules.
-  --force-add [LIST]    Force to add a space-separated list of dracut modules
-                         to the default set of modules, when -H is specified.
-  -d, --drivers [LIST]  Specify a space-separated list of kernel modules to
-                         exclusively include in the initramfs.
+                         This option forces dracut to only include the specified
+                         dracut modules.
+                         In most cases the --add option is what you want to use.
   --add-drivers [LIST]  Specify a space-separated list of kernel
                          modules to add to the initramfs.
-  --force-drivers [LIST] Specify a space-separated list of kernel
+  --force-drivers [LIST]
+                        Specify a space-separated list of kernel
                          modules to add to the initramfs and make sure they
                          are tried to be loaded via modprobe same as passing
                          rd.driver.pre=DRIVER kernel parameter.
   --omit-drivers [LIST] Specify a space-separated list of kernel
                          modules not to add to the initramfs.
+  -d, --drivers [LIST]  Specify a space-separated list of kernel modules to
+                         exclusively include in the initramfs.
   --filesystems [LIST]  Specify a space-separated list of kernel filesystem
                          modules to exclusively include in the generic
                          initramfs.
-  -k, --kmoddir [DIR]   Specify the directory, where to look for kernel
-                         modules
-  --fwdir [DIR]         Specify additional directories, where to look for
-                         firmwares, separated by :
+  -k, --kmoddir [DIR]   Specify the directory where to look for kernel
+                         modules.
+  --fwdir [DIR]         Specify additional colon-separated list of directories
+                         where to look for firmware files.
   --libdirs [LIST]      Specify a space-separated list of directories
                          where to look for libraries.
-  --kernel-only         Only install kernel drivers and firmware files
-  --no-kernel           Do not install kernel drivers and firmware files
-  --print-cmdline       Print the kernel command line for the given disk layout
-  --early-microcode     Combine early microcode with ramdisk
-  --no-early-microcode  Do not combine early microcode with ramdisk
-  --kernel-cmdline [PARAMETERS] Specify default kernel command line parameters
-  --strip               Strip binaries in the initramfs
+  --kernel-only         Only install kernel drivers and firmware files.
+  --no-kernel           Do not install kernel drivers and firmware files.
+  --print-cmdline       Print the kernel command line for the given disk layout.
+  --early-microcode     Combine early microcode with ramdisk.
+  --no-early-microcode  Do not combine early microcode with ramdisk.
+  --kernel-cmdline [PARAMETERS]
+                        Specify default kernel command line parameters.
+  --strip               Strip binaries in the initramfs.
   --aggresive-strip     Strip more than just debug symbol and sections,
-                        for a smaller initramfs build.
-  --nostrip             Do not strip binaries in the initramfs
-  --hardlink            Hardlink files in the initramfs
-  --nohardlink          Do not hardlink files in the initramfs
-  --prefix [DIR]        Prefix initramfs files with [DIR]
-  --noprefix            Do not prefix initramfs files
-  --mdadmconf           Include local /etc/mdadm.conf
-  --nomdadmconf         Do not include local /etc/mdadm.conf
-  --lvmconf             Include local /etc/lvm/lvm.conf
-  --nolvmconf           Do not include local /etc/lvm/lvm.conf
+                         for a smaller initramfs build. The --strip option must
+                         also be specified.
+  --nostrip             Do not strip binaries in the initramfs.
+  --hardlink            Hardlink files in the initramfs.
+  --nohardlink          Do not hardlink files in the initramfs.
+  --prefix [DIR]        Prefix initramfs files with [DIR].
+  --noprefix            Do not prefix initramfs files.
+  --mdadmconf           Include local /etc/mdadm.conf file.
+  --nomdadmconf         Do not include local /etc/mdadm.conf file.
+  --lvmconf             Include local /etc/lvm/lvm.conf file.
+  --nolvmconf           Do not include local /etc/lvm/lvm.conf file.
   --fscks [LIST]        Add a space-separated list of fsck helpers.
   --nofscks             Inhibit installation of any fsck helpers.
   --ro-mnt              Mount / and /usr read-only by default.
-  -h, --help            This message
-  --debug               Output debug information of the build process
-  --profile             Output profile information of the build process
+  -h, --help            This message.
+  --debug               Output debug information of the build process.
+  --profile             Output profile information of the build process.
   -L, --stdlog [0-6]    Specify logging level (to standard error)
                          0 - suppress any messages
                          1 - only fatal errors
@@ -138,8 +150,8 @@ Creates initial ramdisk images for preloading modules
                          4 - info
                          5 - debug info (here starts lots of output)
                          6 - trace info (and even more)
-  -v, --verbose         Increase verbosity level
-  -q, --quiet           Decrease verbosity level
+  -v, --verbose         Increase verbosity level.
+  -q, --quiet           Decrease verbosity level.
   -c, --conf [FILE]     Specify configuration file to use.
                          Default: /etc/dracut.conf
   --confdir [DIR]       Specify configuration directory to use *.conf files
@@ -151,49 +163,51 @@ Creates initial ramdisk images for preloading modules
                          directory instead of the system-wide installed in
                          /usr/lib/dracut/modules.d.
                          Useful when running dracut from a git checkout.
-  -H, --hostonly        Host-Only mode: Install only what is needed for
-                        booting the local host instead of a generic host.
-  -N, --no-hostonly     Disables Host-Only mode
-  --hostonly-mode <mode>
-                        Specify the hostonly mode to use. <mode> could be
-                        one of "sloppy" or "strict". "sloppy" mode is used
-                        by default.
-                        In "sloppy" hostonly mode, extra drivers and modules
-                        will be installed, so minor hardware change won't make
-                        the image unbootable (eg. changed keyboard), and the
-                        image is still portable among similar hosts.
-                        With "strict" mode enabled, anything not necessary
-                        for booting the local host in its current state will
-                        not be included, and modules may do some extra job
-                        to save more space. Minor change of hardware or
-                        environment could make the image unbootable.
-                        DO NOT use "strict" mode unless you know what you
-                        are doing.
+  -H, --hostonly        Host-only mode: Install only what is needed for
+                         booting the local host instead of a generic host.
+  -N, --no-hostonly     Disables host-only mode.
+  --hostonly-mode [MODE]
+                        Specify the host-only mode to use. [MODE] could be
+                         one of "sloppy" or "strict". "sloppy" mode is used
+                         by default.
+                         In "sloppy" host-only mode, extra drivers and modules
+                         will be installed, so minor hardware change won't make
+                         the image unbootable (e.g. changed keyboard), and the
+                         image is still portable among similar hosts.
+                         With "strict" mode enabled, anything not necessary
+                         for booting the local host in its current state will
+                         not be included, and modules may do some extra job
+                         to save more space. Minor change of hardware or
+                         environment could make the image unbootable.
+                         DO NOT use "strict" mode unless you know what you
+                         are doing.
   --hostonly-cmdline    Store kernel command line arguments needed
-                        in the initramfs
+                         in the initramfs.
   --no-hostonly-cmdline Do not store kernel command line arguments needed
-                        in the initramfs
+                         in the initramfs.
   --no-hostonly-default-device
                         Do not generate implicit host devices like root,
-                        swap, fstab, etc. Use "--mount" or "--add-device"
-                        to explicitly add devices as needed.
+                         swap, fstab, etc. Use "--mount" or "--add-device"
+                         to explicitly add devices as needed.
   --hostonly-i18n       Install only needed keyboard and font files according
-                        to the host configuration (default).
+                         to the host configuration (default).
   --no-hostonly-i18n    Install all keyboard and font files available.
   --hostonly-nics [LIST]
-                        Only enable listed NICs in the initramfs.
+                        Only enable listed NICs in the initramfs. The list can
+                         be empty, so other modules can install only the
+                         necessary network drivers.
   --persistent-policy [POLICY]
                         Use [POLICY] to address disks and partitions.
-                        POLICY can be any directory name found in /dev/disk.
-                        E.g. "by-uuid", "by-label"
+                         POLICY can be any directory name found in /dev/disk.
+                         E.g. "by-uuid", "by-label"
   --fstab               Use /etc/fstab to determine the root device.
-  --add-fstab [FILE]    Add file to the initramfs fstab
+  --add-fstab [FILE]    Add file to the initramfs fstab.
   --mount "[DEV] [MP] [FSTYPE] [FSOPTS]"
                         Mount device [DEV] on mountpoint [MP] with filesystem
-                        [FSTYPE] and options [FSOPTS] in the initramfs
+                         [FSTYPE] and options [FSOPTS] in the initramfs.
   --mount "[MP]"        Same as above, but [DEV], [FSTYPE] and [FSOPTS] are
-                        determined by looking at the current mounts.
-  --add-device "[DEV]"  Bring up [DEV] in initramfs
+                         determined by looking at the current mounts.
+  --add-device "[DEV]"  Bring up [DEV] in initramfs.
   -i, --include [SOURCE] [TARGET]
                         Include the files in the SOURCE directory into the
                          Target directory in the final initramfs.
@@ -201,7 +215,8 @@ Creates initial ramdisk images for preloading modules
                          in the final initramfs.
   -I, --install [LIST]  Install the space separated list of files into the
                          initramfs.
-  --install-optional [LIST]  Install the space separated list of files into the
+  --install-optional [LIST]
+                        Install the space separated list of files into the
                          initramfs, if they exist.
   --gzip                Compress the generated initramfs using gzip.
                          This will be done by default, unless another
@@ -224,37 +239,41 @@ Creates initial ramdisk images for preloading modules
   --zstd                Compress the generated initramfs using Zstandard.
                          Make sure that your kernel has zstd support compiled
                          in, otherwise you will not be able to boot.
-  --compress [COMPRESSION] Compress the generated initramfs with the
+  --compress [COMPRESSION]
+                        Compress the generated initramfs with the
                          passed compression program.  Make sure your kernel
                          knows how to decompress the generated initramfs,
                          otherwise you will not be able to boot.
-  --no-compress         Do not compress the generated initramfs.  This will
+  --no-compress         Do not compress the generated initramfs. This will
                          override any other compression options.
-  --squash-compressor [COMPRESSION] Specify the compressor and compressor
-                         specific options used by mksquashfs if squash module
-                         is called when building the initramfs.
+  --squash-compressor [COMPRESSION]
+                        Specify the compressor and compressor specific options
+                         used by mksquashfs if squash module is called when
+                         building the initramfs.
   --enhanced-cpio       Attempt to reflink cpio file data using dracut-cpio.
   --list-modules        List all available dracut modules.
   -M, --show-modules    Print included module's name to standard output during
                          build.
-  --keep                Keep the temporary initramfs for debugging purposes
-  --printsize           Print out the module install size
-  --sshkey [SSHKEY]     Add ssh key to initramfs (use with ssh-client module)
-  --logfile [FILE]      Logfile to use (overrides configuration setting)
-  --reproducible        Create reproducible images
-  --no-reproducible     Do not create reproducible images
-  --loginstall [DIR]    Log all files installed from the host to [DIR]
+  --keep                Keep the temporary initramfs for debugging purposes.
+  --printsize           Print out the module install size.
+  --sshkey [SSHKEY]     Add SSH key to initramfs (use with ssh-client module).
+  --logfile [FILE]      Logfile to use (overrides configuration setting).
+  --reproducible        Create reproducible images.
+  --no-reproducible     Do not create reproducible images.
+  --loginstall [DIR]    Log all files installed from the host to [DIR].
   --uefi                Create an UEFI executable with the kernel cmdline and
-                        kernel combined
-  --no-uefi             Disables UEFI mode
-  --uefi-stub [FILE]    Use the UEFI stub [FILE] to create an UEFI executable
+                         kernel combined.
+  --no-uefi             Disables UEFI mode.
+  --no-machineid        Affects the default output filename of the UEFI
+                         executable, discarding the <MACHINE_ID> part.
+  --uefi-stub [FILE]    Use the UEFI stub [FILE] to create an UEFI executable.
   --uefi-splash-image [FILE]
                         Use [FILE] as a splash image when creating an UEFI
-                        executable
-  --kernel-image [FILE] location of the kernel image
+                         executable. Requires bitmap (.bmp) image format.
+  --kernel-image [FILE] Location of the kernel image.
   --regenerate-all      Regenerate all initramfs images at the default location
-                        for the kernel versions found on the system
-  --version             Display version
+                         for the kernel versions found on the system.
+  --version             Display version.
 
 If [LIST] has multiple arguments, then you have to put these in quotes.
 
@@ -2184,7 +2203,7 @@ if [[ $do_strip == yes ]]; then
         fi
     done
 
-    if [[ $aggresive_strip ]]; then
+    if [[ $aggresive_strip == yes ]]; then
         # `eu-strip` and `strip` both strips all unneeded parts by default
         strip_args=(-p)
     else

--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -53,22 +53,28 @@ include::dracut.usage.asc[]
 OPTIONS
 -------
 **--kver** _<kernel version>_::
-    set the kernel version. This enables to specify the kernel version, without
+    Set the kernel version. This enables to specify the kernel version, without
     specifying the location of the initramfs image. For example:
 ----
 # dracut --kver 3.5.0-0.rc7.git1.2.fc18.x86_64
 ----
 
 **-f, --force**::
-    overwrite existing initramfs file.
+    Overwrite existing initramfs file.
+
+_<output file>_ **--rebuild**::
+    Append the current arguments to those with which the input initramfs image
+    was built. This option helps in incrementally building the initramfs for
+    testing. If optional _<output file>_ is not provided, the input initramfs
+    provided to rebuild will be used as output file.
 
 **-a, --add** _<list of dracut modules>_::
-    add a space-separated list of dracut modules to the default set of modules.
+    Add a space-separated list of dracut modules to the default set of modules.
     This parameter can be specified multiple times.
 +
 [NOTE]
 ===============================
-If [LIST] has multiple arguments, then you have to put these in quotes. For
+If the list has multiple arguments, then you have to put these in quotes. For
 example:
 ----
 # dracut --add "module1 module2"  ...
@@ -76,13 +82,13 @@ example:
 ===============================
 
 **--force-add** _<list of dracut modules>_::
-    force to add a space-separated list of dracut modules to the default set of
+    Force to add a space-separated list of dracut modules to the default set of
     modules, when -H is specified. This parameter can be specified multiple
     times.
 +
 [NOTE]
 ===============================
-If [LIST] has multiple arguments, then you have to put these in quotes. For
+If the list has multiple arguments, then you have to put these in quotes. For
 example:
 ----
 # dracut --force-add "module1 module2"  ...
@@ -90,12 +96,12 @@ example:
 ===============================
 
 **-o, --omit** _<list of dracut modules>_::
-    omit a space-separated list of dracut modules. This parameter can be
+    Omit a space-separated list of dracut modules. This parameter can be
     specified multiple times.
 +
 [NOTE]
 ===============================
-If [LIST] has multiple arguments, then you have to put these in quotes. For
+If the list has multiple arguments, then you have to put these in quotes. For
 example:
 ----
 # dracut --omit "module1 module2"  ...
@@ -103,7 +109,7 @@ example:
 ===============================
 
 **-m, --modules** _<list of dracut modules>_::
-    specify a space-separated list of dracut modules to call when building the
+    Specify a space-separated list of dracut modules to call when building the
     initramfs. Modules are located in _/usr/lib/dracut/modules.d_. This
     parameter can be specified multiple times.
     This option forces dracut to only include the specified dracut modules.
@@ -111,7 +117,7 @@ example:
 +
 [NOTE]
 ===============================
-If [LIST] has multiple arguments, then you have to put these in quotes. For
+If the list has multiple arguments, then you have to put these in quotes. For
 example:
 ----
 # dracut --modules "module1 module2"  ...
@@ -119,13 +125,13 @@ example:
 ===============================
 
 **-d, --drivers** _<list of kernel modules>_::
-    specify a space-separated list of kernel modules to exclusively include
+    Specify a space-separated list of kernel modules to exclusively include
     in the initramfs. The kernel modules have to be specified without the ".ko"
     suffix. This parameter can be specified multiple times.
 +
 [NOTE]
 ===============================
-If [LIST] has multiple arguments, then you have to put these in quotes. For
+If the list has multiple arguments, then you have to put these in quotes. For
 example:
 ----
 # dracut --drivers "kmodule1 kmodule2"  ...
@@ -133,13 +139,13 @@ example:
 ===============================
 
 **--add-drivers** _<list of kernel modules>_::
-    specify a space-separated list of kernel modules to add to the initramfs.
+    Specify a space-separated list of kernel modules to add to the initramfs.
     The kernel modules have to be specified without the ".ko" suffix. This
     parameter can be specified multiple times.
 +
 [NOTE]
 ===============================
-If [LIST] has multiple arguments, then you have to put these in quotes. For
+If the list has multiple arguments, then you have to put these in quotes. For
 example:
 ----
 # dracut --add-drivers "kmodule1 kmodule2"  ...
@@ -152,7 +158,7 @@ example:
 +
 [NOTE]
 ===============================
-If [LIST] has multiple arguments, then you have to put these in quotes. For
+If the list has multiple arguments, then you have to put these in quotes. For
 example:
 ----
 # dracut --force-drivers "kmodule1 kmodule2"  ...
@@ -160,14 +166,14 @@ example:
 ===============================
 
 **--omit-drivers** _<list of kernel modules>_::
-    specify a space-separated list of kernel modules not to add to the
+    Specify a space-separated list of kernel modules not to add to the
     initramfs.
     The kernel modules have to be specified without the ".ko" suffix. This
     parameter can be specified multiple times.
 +
 [NOTE]
 ===============================
-If [LIST] has multiple arguments, then you have to put these in quotes. For
+If the list has multiple arguments, then you have to put these in quotes. For
 example:
 ----
 # dracut --omit-drivers "kmodule1 kmodule2"  ...
@@ -175,13 +181,13 @@ example:
 ===============================
 
 **--filesystems** _<list of filesystems>_::
-    specify a space-separated list of kernel filesystem modules to exclusively
+    Specify a space-separated list of kernel filesystem modules to exclusively
     include in the generic initramfs. This parameter can be specified multiple
     times.
 +
 [NOTE]
 ===============================
-If [LIST] has multiple arguments, then you have to put these in quotes. For
+If the list has multiple arguments, then you have to put these in quotes. For
 example:
 ----
 # dracut --filesystems "filesystem1 filesystem2"  ...
@@ -189,20 +195,20 @@ example:
 ===============================
 
 **-k, --kmoddir** _<kernel directory>_::
-    specify the directory, where to look for kernel modules
+    Specify the directory, where to look for kernel modules.
 
 **--fwdir** _<dir>[:<dir>...]++_::
-    specify additional directories, where to look for firmwares. This parameter
+    Specify additional directories, where to look for firmwares. This parameter
     can be specified multiple times.
 
 **--libdirs** _<list of directories>_::
-    specify a space-separated list of directories to look for libraries to
+    Specify a space-separated list of directories to look for libraries to
     include in the generic initramfs. This parameter can be specified multiple
     times.
 +
 [NOTE]
 ===============================
-If [LIST] has multiple arguments, then you have to put these in quotes. For
+If the list has multiple arguments, then you have to put these in quotes. For
 example:
 ----
 # dracut --libdirs "dir1 dir2"  ...
@@ -210,44 +216,43 @@ example:
 ===============================
 
 **--kernel-cmdline <parameters>**::
-    specify default kernel command line parameters
-
+    Specify default kernel command line parameters.
 
 **--kernel-only**::
-    only install kernel drivers and firmware files
+    Only install kernel drivers and firmware files.
 
 **--no-kernel**::
-    do not install kernel drivers and firmware files
+    Do not install kernel drivers and firmware files.
 
 **--early-microcode**::
-    Combine early microcode with ramdisk
+    Combine early microcode with ramdisk.
 
 **--no-early-microcode**::
-    Do not combine early microcode with ramdisk
+    Do not combine early microcode with ramdisk.
 
 **--print-cmdline**::
-    print the kernel command line for the current disk layout
+    Print the kernel command line for the current disk layout.
 
 **--mdadmconf**::
-    include local _/etc/mdadm.conf_
+    Include local _/etc/mdadm.conf_ file.
 
 **--nomdadmconf**::
-    do not include local _/etc/mdadm.conf_
+    Do not include local _/etc/mdadm.conf_ file.
 
 **--lvmconf**::
-    include local _/etc/lvm/lvm.conf_
+    Include local _/etc/lvm/lvm.conf_ file.
 
 **--nolvmconf**::
-    do not include local _/etc/lvm/lvm.conf_
+    Do not include local _/etc/lvm/lvm.conf_ file.
 
-**--fscks** [LIST]::
-    add a space-separated list of fsck tools, in addition to _dracut.conf_'s
+**--fscks** _<list of fsck tools>_::
+    Add a space-separated list of fsck tools, in addition to _dracut.conf_'s
     specification; the installation is opportunistic (non-existing tools are
-    ignored)
+    ignored).
 +
 [NOTE]
 ===============================
-If [LIST] has multiple arguments, then you have to put these in quotes. For
+If the list has multiple arguments, then you have to put these in quotes. For
 example:
 ----
 # dracut --fscks "fsck.foo barfsck"  ...
@@ -255,60 +260,65 @@ example:
 ===============================
 
 **--nofscks**::
-    inhibit installation of any fsck tools
+    Inhibit installation of any fsck tools.
 
 **--strip**::
-    strip binaries in the initramfs (default)
+    Strip binaries in the initramfs (default).
+
+**--aggresive-strip**::
+    Strip more than just debug symbol and sections, for a smaller initramfs
+    build. The --strip option must also be specified.
 
 **--nostrip**::
-    do not strip binaries in the initramfs
+    Do not strip binaries in the initramfs.
 
 **--hardlink**::
-    hardlink files in the initramfs (default)
+    Hardlink files in the initramfs (default).
 
 **--nohardlink**::
-    do not hardlink files in the initramfs
+    Do not hardlink files in the initramfs.
 
 **--prefix** _<dir>_::
-    prefix initramfs files with the specified directory
+    Prefix initramfs files with the specified directory.
 
 **--noprefix**::
-    do not prefix initramfs files (default)
+    Do not prefix initramfs files (default).
 
 **-h, --help**::
-    display help text and exit.
+    Display help text and exit.
 
 **--debug**::
-    output debug information of the build process
+    Output debug information of the build process.
 
 **-v, --verbose**::
-    increase verbosity level (default is info(4))
+    Increase verbosity level (default is info(4)).
 
 **--version**::
-    display version and exit
+    Display version and exit.
 
-**-q, --quiet**:: decrease verbosity level (default is info(4))
+**-q, --quiet**::
+    Decrease verbosity level (default is info(4)).
 
 **-c, --conf** _<dracut configuration file>_::
-    specify configuration file to use.
+    Specify configuration file to use.
 +
 Default:
    _/etc/dracut.conf_
 
 **--confdir** _<configuration directory>_::
-    specify configuration directory to use.
+    Specify configuration directory to use.
 +
 Default:
    _/etc/dracut.conf.d_
 
 **--tmpdir** _<temporary directory>_::
-    specify temporary directory to use.
+    Specify temporary directory to use.
 +
 Default:
    _/var/tmp_
 
 **-r, --sysroot** _<sysroot directory>_::
-    specify the sysroot directory to collect files from.
+    Specify the sysroot directory to collect files from.
     This is useful to create the initramfs image from
     a cross-compiled sysroot directory. For the extra helper
     variables, see *ENVIRONMENT* below.
@@ -316,22 +326,23 @@ Default:
 Default:
     _empty_
 
-**--sshkey** _<sshkey file>_:: ssh key file used with ssh-client module.
+**--sshkey** _<sshkey file>_::
+    SSH key file used with ssh-client module.
 
-**--logfile** _<logfile>_:: logfile to use; overrides any setting from
-    the configuration files.
+**--logfile** _<logfile>_::
+    Logfile to use; overrides any setting from the configuration files.
 +
 Default:
     _/var/log/dracut.log_
 
 **-l, --local**::
-    activates the local mode. dracut will use modules from the current working
+    Activates the local mode. dracut will use modules from the current working
     directory instead of the system-wide installed modules in
     _/usr/lib/dracut/modules.d_.
     This is useful when running dracut from a git checkout.
 
 **-H, --hostonly**::
-    Host-Only mode: Install only what is needed for booting the local host
+    Host-only mode: Install only what is needed for booting the local host
     instead of a generic host and generate host-specific configuration.
 +
 [WARNING]
@@ -341,23 +352,42 @@ provide a valid _/etc/fstab_.
 ====
 
 **-N, --no-hostonly**::
-    Disable Host-Only mode
+    Disable host-only mode.
 
-**--hostonly-cmdline**:
-    Store kernel command line arguments needed in the initramfs
+**--hostonly-mode _<mode>_**::
+    Specify the host-only mode to use. _<mode>_ could be one of "sloppy" or
+    "strict".
+    In "sloppy" host-only mode, extra drivers and modules will be installed, so
+    minor hardware change won't make the image unbootable (e.g. changed
+    keyboard), and the image is still portable among similar hosts.
+    With "strict" mode enabled, anything not necessary for booting the local
+    host in its current state will not be included, and modules may do some
+    extra job to save more space. Minor change of hardware or environment could
+    make the image unbootable.
++
+Default:
+    _sloppy_
 
-**--no-hostonly-cmdline**:
-    Do not store kernel command line arguments needed in the initramfs
+**--hostonly-cmdline**::
+    Store kernel command line arguments needed in the initramfs.
 
-**--no-hostonly-default-device**:
+**--no-hostonly-cmdline**::
+    Do not store kernel command line arguments needed in the initramfs.
+
+**--no-hostonly-default-device**::
     Do not generate implicit host devices like root, swap, fstab, etc.
     Use "--mount" or "--add-device" to explicitly add devices as needed.
 
-**--hostonly-i18n**:
-    Install only needed keyboard and font files according to the host configuration (default).
+**--hostonly-i18n**::
+    Install only needed keyboard and font files according to the host
+    configuration (default).
 
-**--no-hostonly-i18n**:
+**--no-hostonly-i18n**::
     Install all keyboard and font files available.
+
+**--hostonly-nics** _<list of nics>_::
+    Only enable listed NICs in the initramfs. The list can be empty, so other
+    modules can install only the necessary network drivers.
 
 **--persistent-policy** _<policy>_::
     Use _<policy>_ to address disks and partitions.
@@ -376,7 +406,7 @@ provide a valid _/etc/fstab_.
     be specified, see fstab manpage for the details.
     The default _<filesystem options>_ is "defaults".
     The default _<dump frequency>_ is "0".
-    the default _<fsck order>_ is "2".
+    The default _<fsck order>_ is "2".
 
 **--mount** "_<mountpoint>_"::
     Like above, but _<device>_, _<filesystem type>_ and _<filesystem options>_
@@ -384,22 +414,22 @@ provide a valid _/etc/fstab_.
 
 **--add-device** _<device>_ ::
     Bring up _<device>_ in initramfs, _<device>_ should be the device name.
-    This can be useful in hostonly mode for resume support when your swap is on
+    This can be useful in host-only mode for resume support when your swap is on
     LVM or an encrypted partition.
     [NB --device can be used for compatibility with earlier releases]
 
 **-i, --include** _<SOURCE>_ _<TARGET>_::
-    include the files in the SOURCE directory into the
+    Include the files in the SOURCE directory into the
     TARGET directory in the final initramfs. If SOURCE is a file, it will be
     installed to TARGET in the final initramfs. This parameter can be specified
     multiple times.
 
 **-I, --install** _<file list>_::
-    install the space separated list of files into the initramfs.
+    Install the space separated list of files into the initramfs.
 +
 [NOTE]
 ===============================
-If [LIST] has multiple arguments, then you have to put these in quotes. For
+If the list has multiple arguments, then you have to put these in quotes. For
 example:
 ----
 # dracut --install "/bin/foo /sbin/bar"  ...
@@ -407,12 +437,12 @@ example:
 ===============================
 
 **--install-optional** _<file list>_::
-    install the space separated list of files into the initramfs, if they exist.
+    Install the space separated list of files into the initramfs, if they exist.
 
 **--gzip**::
     Compress the generated initramfs using gzip. This will be done by default,
     unless another compression option or --no-compress is passed. Equivalent to
-    "--compress=gzip -9"
+    "--compress=gzip -9".
 
 **--bzip2**::
     Compress the generated initramfs using bzip2.
@@ -420,7 +450,7 @@ example:
 [WARNING]
 ====
 Make sure your kernel has bzip2 decompression support compiled in, otherwise you
-will not be able to boot. Equivalent to "--compress=bzip2"
+will not be able to boot. Equivalent to "--compress=bzip2 -9".
 ====
 
 **--lzma**::
@@ -429,7 +459,7 @@ will not be able to boot. Equivalent to "--compress=bzip2"
 [WARNING]
 ====
 Make sure your kernel has lzma decompression support compiled in, otherwise you
-will not be able to boot. Equivalent to "lzma --compress=lzma -9"
+will not be able to boot. Equivalent to "--compress=lzma -9 -T0".
 ====
 
 **--xz**::
@@ -439,31 +469,34 @@ will not be able to boot. Equivalent to "lzma --compress=lzma -9"
 ====
 Make sure your kernel has xz decompression support compiled in, otherwise you
 will not be able to boot. Equivalent to
-"lzma --compress=xz --check=crc32 --lzma2=dict=1MiB"
+"--compress=xz --check=crc32 --lzma2=dict=1MiB -T0".
 ====
 
 **--lzo**::
     Compress the generated initramfs using lzop.
++
 [WARNING]
 ====
 Make sure your kernel has lzo decompression support compiled in, otherwise you
-will not be able to boot.
+will not be able to boot. Equivalent to "--compress=lzop -9".
 ====
 
 **--lz4**::
     Compress the generated initramfs using lz4.
++
 [WARNING]
 ====
 Make sure your kernel has lz4 decompression support compiled in, otherwise you
-will not be able to boot.
+will not be able to boot. Equivalent to "--compress=lz4 -l -9".
 ====
 
 **--zstd**::
     Compress the generated initramfs using Zstandard.
++
 [WARNING]
 ====
 Make sure your kernel has zstd decompression support compiled in, otherwise you
-will not be able to boot.
+will not be able to boot. Equivalent to "--compress=zstd -15 -q -T0".
 ====
 
 **--compress** _<compressor>_::
@@ -472,7 +505,8 @@ will not be able to boot.
     program with known-working arguments. If you pass a quoted string with
     arguments, it will be called with exactly those arguments. Depending on what
     you pass, this may result in an initramfs that the kernel cannot decompress.
-    The default value can also be set via the _INITRD_COMPRESS_ environment variable.
+    The default value can also be set via the _INITRD_COMPRESS_ environment
+    variable.
 
 **--squash-compressor** _<compressor>_::
     Compress the squashfs image using the passed compressor and compressor
@@ -500,16 +534,16 @@ will not be able to boot.
     Keep the initramfs temporary directory for debugging purposes.
 
 **--printsize**::
-    Print out the module install size
+    Print out the module install size.
 
-**--profile**:
-    Output profile information of the build process
+**--profile**::
+    Output profile information of the build process.
 
-**--ro-mnt**:
+**--ro-mnt**::
     Mount / and /usr read-only by default.
 
 **-L, --stdlog** _<level>_::
-    [0-6] Specify logging level (to standard error)
+    [0-6] Specify logging level (to standard error).
 ----
           0 - suppress any messages
           1 - only fatal errors
@@ -524,36 +558,42 @@ will not be able to boot.
     Regenerate all initramfs images at the default location with the kernel
     versions found on the system. Additional parameters are passed through.
 
-**--loginstall _<DIR>_**::
-    Log all files installed from the host to _<DIR>_.
+**--noimageifnotneeded**::
+    Do not create an image in host-only mode, if no kernel driver is needed
+and no /etc/cmdline/*.conf will be generated into the initramfs.
+
+**--loginstall _<directory>_**::
+    Log all files installed from the host to _<directory>_.
 
 **--uefi**::
-    Instead of creating an initramfs image, dracut will create an UEFI executable,
-    which can be executed by an UEFI BIOS. The default output filename is
-    _<EFI>/EFI/Linux/linux-$kernel$-<MACHINE_ID>-<BUILD_ID>.efi_. <EFI> might be
-    _/efi_, _/boot_ or _/boot/efi_ depending on where the ESP partition is mounted.
-    The <BUILD_ID> is taken from BUILD_ID in _/usr/lib/os-release_ or if it exists
-    _/etc/os-release_ and is left out, if BUILD_ID is non-existant or empty.
+    Instead of creating an initramfs image, dracut will create an UEFI
+    executable, which can be executed by an UEFI BIOS. The default output
+    filename is _<EFI>/EFI/Linux/linux-$kernel$-<MACHINE_ID>-<BUILD_ID>.efi_.
+    <EFI> might be _/efi_, _/boot_ or _/boot/efi_ depending on where the ESP
+    partition is mounted. The <BUILD_ID> is taken from BUILD_ID in
+    _/usr/lib/os-release_ or if it exists _/etc/os-release_ and is left out,
+    if BUILD_ID is non-existant or empty.
 
 **--no-uefi**::
     Disables UEFI mode.
 
 **--no-machineid**::
-    affects the default output filename of **--uefi** and will discard the <MACHINE_ID>
-    part.
+    Affects the default output filename of **--uefi** and will discard the
+    <MACHINE_ID> part.
 
-**--uefi-stub _<FILE>_**::
-    Specifies the UEFI stub loader, which will load the attached kernel, initramfs and
-    kernel command line and boots the kernel. The default is
-    _$prefix/lib/systemd/boot/efi/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
+**--uefi-stub _<file>_**::
+    Specifies the UEFI stub loader, which will load the attached kernel,
+    initramfs and kernel command line and boots the kernel. The default is
+    _$prefix/lib/systemd/boot/efi/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_.
 
-**--uefi-splash-image _<FILE>_**::
-    Specifies the UEFI stub loader's splash image. Requires bitmap (**.bmp**) image
-    format.
+**--uefi-splash-image _<file>_**::
+    Specifies the UEFI stub loader's splash image. Requires bitmap (**.bmp**)
+    image format.
 
-**--kernel-image _<FILE>_**::
-    Specifies the kernel image, which to include in the UEFI executable. The default is
-    _/lib/modules/<KERNEL-VERSION>/vmlinuz_ or _/boot/vmlinuz-<KERNEL-VERSION>_
+**--kernel-image _<file>_**::
+    Specifies the kernel image, which to include in the UEFI executable. The
+    default is _/lib/modules/<KERNEL-VERSION>/vmlinuz_ or
+    _/boot/vmlinuz-<KERNEL-VERSION>_.
 
 **--enhanced-cpio**::
     Attempt to use the dracut-cpio binary, which optimizes archive creation for
@@ -562,7 +602,8 @@ will not be able to boot.
     optimal data alignment for extent sharing. To retain reflink data
     deduplication benefits, this should be used alongside the **--no-compress**
     and **--no-strip** parameters, with initramfs source files, **--tmpdir**
-    staging area and destination all on the same copy-on-write capable filesystem.
+    staging area and destination all on the same copy-on-write capable
+    filesystem.
 
 ENVIRONMENT
 -----------

--- a/man/dracut.conf.5.asc
+++ b/man/dracut.conf.5.asc
@@ -36,20 +36,20 @@ Configuration files must have the extension .conf; other extensions are ignored.
     Add a space-separated list of dracut modules to call when building the
     initramfs. Modules are located in _/usr/lib/dracut/modules.d_.
 
-*dracutmodules+=*" __<dracut modules>__ "::
-    Specify a space-separated list of dracut modules to call when building the
-    initramfs. Modules are located in _/usr/lib/dracut/modules.d_.
-    This option forces dracut to only include the specified dracut modules.
-    In most cases the "add_dracutmodules" option is what you want to use.
+*force_add_dracutmodules+=*" __<dracut modules>__ "::
+    Force to add a space-separated list of dracut modules to the default set of
+    modules, when host-only mode is specified. This parameter can be specified
+    multiple times.
 
 *omit_dracutmodules+=*" __<dracut modules>__ "::
     Omit a space-separated list of dracut modules to call when building the
     initramfs. Modules are located in _/usr/lib/dracut/modules.d_.
 
-*drivers+=*" __<kernel modules>__ "::
-    Specify a space-separated list of kernel modules to exclusively include in
-    the initramfs. The kernel modules have to be specified without the ".ko"
-    suffix.
+*dracutmodules+=*" __<dracut modules>__ "::
+    Specify a space-separated list of dracut modules to call when building the
+    initramfs. Modules are located in _/usr/lib/dracut/modules.d_.
+    This option forces dracut to only include the specified dracut modules.
+    In most cases the "add_dracutmodules" option is what you want to use.
 
 *add_drivers+=*" __<kernel modules>__ "::
     Specify a space-separated list of kernel modules to add to the initramfs.
@@ -63,15 +63,24 @@ Configuration files must have the extension .conf; other extensions are ignored.
     Specify a space-separated list of kernel modules not to add to the
     initramfs. The kernel modules have to be specified without the ".ko" suffix.
 
+*drivers+=*" __<kernel modules>__ "::
+    Specify a space-separated list of kernel modules to exclusively include in
+    the initramfs. The kernel modules have to be specified without the ".ko"
+    suffix.
+
 *filesystems+=*" __<filesystem names>__ "::
     Specify a space-separated list of kernel filesystem modules to exclusively
     include in the generic initramfs.
 
 *drivers_dir=*"__<kernel modules directory>__"::
-    Specify the directory, where to look for kernel modules
+    Specify the directory where to look for kernel modules.
 
 *fw_dir+=*" :__<dir>__[:__<dir>__ ...] "::
-    Specify additional directories, where to look for firmwares, separated by :
+    Specify additional colon-separated list of directories where to look for
+    firmware files.
+
+*libdirs+=*" __<dir>__[ __<dir>__ ...] "::
+    Specify a space-separated list of directories where to look for libraries.
 
 *install_items+=*" __<file>__[ __<file>__ ...] "::
     Specify additional files to include in the initramfs, separated by spaces.
@@ -83,20 +92,53 @@ Configuration files must have the extension .conf; other extensions are ignored.
 *compress=*"__{cat|bzip2|lzma|xz|gzip|lzo|lz4|zstd|<compressor [args ...]>}__"::
     Compress the generated initramfs using the passed compression program. If
     you pass it just the name of a compression program, it will call that
-    program with known-working arguments. If you pass arguments, it will be called
-    with exactly those arguments. Depending on what you pass, this may result in
-    an initramfs that the kernel cannot decompress.
+    program with known-working arguments. If you pass arguments, it will be
+    called with exactly those arguments. Depending on what you pass, this may
+    result in an initramfs that the kernel cannot decompress.
     To disable compression, use "cat".
 
+*squash_compress=*"__{<compressor [args ...]>}__"::
+    Compress the squashfs image using the passed compressor and compressor
+    specific options for mksquashfs. You can refer to mksquashfs manual for
+    supported compressors and compressor specific options. If squash module is
+    not called when building the initramfs, this option will not take effect.
+
 *do_strip=*"__{yes|no}__"::
-    Strip binaries in the initramfs (default=yes)
+    Strip binaries in the initramfs (default=yes).
+
+*aggresive_strip=*"__{yes|no}__"::
+    Strip more than just debug symbol and sections, for a smaller initramfs
+    build. The "do_strip=yes" option must also be specified (default=no).
+
+*do_hardlink=*"__{yes|no}__"::
+    Hardlink files in the initramfs (default=yes).
+
+*prefix=*" __<directory>__ "::
+    Prefix initramfs files with __<directory>__.
 
 *hostonly=*"__{yes|no}__"::
-    Host-Only mode: Install only what is needed for booting the local host
-    instead of a generic host and generate host-specific configuration.
+    Host-only mode: Install only what is needed for booting the local host
+    instead of a generic host and generate host-specific configuration
+    (default=no).
+
+*hostonly_mode=*"__{sloppy|strict}__"::
+    Specify the host-only mode to use (default=sloppy).
+    In "sloppy" host-only mode, extra drivers and modules will be installed, so
+    minor hardware change won't make the image unbootable (e.g. changed
+    keyboard), and the image is still portable among similar hosts.
+    With "strict" mode enabled, anything not necessary for booting the local
+    host in its current state will not be included, and modules may do some
+    extra job to save more space. Minor change of hardware or environment could
+    make the image unbootable.
 
 *hostonly_cmdline=*"__{yes|no}__"::
-    If set to "yes", store the kernel command line arguments needed in the initramfs
+    If set to "yes", store the kernel command line arguments needed in the
+    initramfs. If **hostonly="yes"** and this option is not configured, it's
+    automatically set to "yes".
+
+*hostonly_nics+=*" [__<nic>__[ __<nic>__ ...]] "::
+    Only enable listed NICs in the initramfs. The list can be empty, so other
+    modules can install only the necessary network drivers.
 
 *persistent_policy=*"__<policy>__"::
     Use _<policy>_ to address disks and partitions.
@@ -113,21 +155,21 @@ provide a valid _/etc/fstab_.
 ====
 
 *use_fstab=*"__{yes|no}__"::
-    Use _/etc/fstab_ instead of _/proc/self/mountinfo_.
+    Use _/etc/fstab_ instead of _/proc/self/mountinfo_ (default=no).
 
 *add_fstab+=*" __<filename>__ "::
     Add entries of __<filename>__ to the initramfs /etc/fstab.
 
 *add_device+=*" __<device>__ "::
     Bring up _<device>_ in initramfs, _<device>_ should be the device name.
-    This can be useful in hostonly mode for resume support when your swap is on
+    This can be useful in host-only mode for resume support when your swap is on
     LVM an encrypted partition.
 
 *mdadmconf=*"__{yes|no}__"::
-    Include local _/etc/mdadm.conf_ (default=yes)
+    Include local _/etc/mdadm.conf_ (default=no).
 
 *lvmconf=*"__{yes|no}__"::
-    Include local _/etc/lvm/lvm.conf_ (default=yes)
+    Include local _/etc/lvm/lvm.conf_ (default=no).
 
 *fscks=*" __<fsck tools>__ "::
     Add a space-separated list of fsck tools. If nothing is specified, the
@@ -136,19 +178,19 @@ provide a valid _/etc/fstab_.
     (non-existing tools are ignored).
 
 *nofscks=*"__{yes|no}__"::
-    If specified, inhibit installation of any fsck tools.
+    If specified, inhibit installation of any fsck tools (default=no).
 
 *ro_mnt=*"__{yes|no}__"::
-    Mount _/_ and _/usr_ read-only by default.
+    Mount _/_ and _/usr_ read-only by default (default=no).
 
 *kernel_cmdline=*"__parameters__"::
-    Specify default kernel command line parameters
+    Specify default kernel command line parameters.
 
 *kernel_only=*"__{yes|no}__"::
-    Only install kernel drivers and firmware files. (default=no)
+    Only install kernel drivers and firmware files (default=no).
 
 *no_kernel=*"__{yes|no}__"::
-    Do not install kernel drivers and firmware files (default=no)
+    Do not install kernel drivers and firmware files (default=no).
 
 *acpi_override=*"__{yes|no}__"::
     [WARNING] ONLY USE THIS IF YOU KNOW WHAT YOU ARE DOING! +
@@ -166,22 +208,40 @@ provide a valid _/etc/fstab_.
     Directory to search for ACPI tables if acpi_override= is set to yes.
 
 *early_microcode=*"{yes|no}"::
-    Combine early microcode with ramdisk (default=yes)
+    Combine early microcode with ramdisk (default=yes).
 
 *stdloglvl*="__\{0-6\}__"::
-    Set logging to standard error level.
+    Specify logging level for standard error (default=4).
+
+[NOTE]
+===============================
+Logging levels:
+----
+    0 - suppress any messages
+    1 - only fatal errors
+    2 - all errors
+    3 - warnings
+    4 - info
+    5 - debug info (here starts lots of output)
+    6 - trace info (and even more)
+----
+===============================
 
 *sysloglvl*="__\{0-6\}__"::
-    Set logging to syslog level.
+    Specify logging level for syslog (default=0).
 
 *fileloglvl=*"__\{0-6\}__"::
-    Set logging to file level.
+    Specify logging level for logfile (default=4).
 
 *logfile=*"__<file>__"::
-    Path to log file.
+    Path to logfile.
+
+*sshkey=*"__<file>__"::
+    SSH key file used with ssh-client module.
 
 *show_modules=*"__{yes|no}__"::
-    Print the name of the included modules to standard output during build.
+    Print the name of the included modules to standard output during build
+    (default=no).
 
 *i18n_vars=*"__<variable mapping>__"::
     Distribution specific variable mapping.
@@ -192,29 +252,66 @@ provide a valid _/etc/fstab_.
     Default is "eurlatgr".
 
 *i18n_install_all=*"__{yes|no}__"::
-    Install everything regardless of generic or hostonly mode.
+    Install everything regardless of generic or host-only mode (default=no).
 
 *reproducible=*"__{yes|no}__"::
-    Create reproducible images.
+    Create reproducible images (default=no).
 
-*loginstall=*"__<DIR>__"::
-    Log all files installed from the host to _<DIR>_.
+*regenerate_all=*"__{yes|no}__"::
+    Regenerate all initramfs images at the default location with the kernel
+    versions found on the system. Additional parameters are passed through
+    (default=no).
 
-*uefi_stub=*"_<FILE>_"::
-    Specifies the UEFI stub loader, which will load the attached kernel, initramfs and
-    kernel command line and boots the kernel. The default is
-    _/lib/systemd/boot/efi/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_
+*noimageifnotneeded=*"__{yes|no}__"::
+    Do not create an image in host-only mode, if no kernel driver is needed
+    and no /etc/cmdline/*.conf will be generated into the initramfs
+    (default=no).
 
-*uefi_splash_image=*"_<FILE>_"::
-    Specifies the UEFI stub loader's splash image. Requires bitmap (**.bmp**) image format.
+*loginstall=*"__<directory>__"::
+    Log all files installed from the host to _<directory>_.
 
-*uefi_secureboot_cert=*"_<FILE>_", *uefi_secureboot_key=*"_<FILE>_"::
-    Specifies a certificate and corresponding key, which are used to sign the created UEFI executable.
-    Requires both certificate and key need to be specified and _sbsign_ to be installed.
+*uefi=*"__{yes|no}__"::
+    Instead of creating an initramfs image, dracut will create an UEFI
+    executable, which can be executed by an UEFI BIOS (default=no).
+    The default output filename is
+    _<EFI>/EFI/Linux/linux-$kernel$-<MACHINE_ID>-<BUILD_ID>.efi_.
+    <EFI> might be _/efi_, _/boot_ or _/boot/efi_ depending on where the ESP
+    partition is mounted. The <BUILD_ID> is taken from BUILD_ID in
+    _/usr/lib/os-release_ or if it exists _/etc/os-release_ and is left out,
+    if BUILD_ID is non-existant or empty.
 
-*kernel_image=*"_<FILE>_"::
-    Specifies the kernel image, which to include in the UEFI executable. The default is
-    _/lib/modules/<KERNEL-VERSION>/vmlinuz_ or _/boot/vmlinuz-<KERNEL-VERSION>_
+*machine_id=*"__{yes|no}__"::
+    Affects the default output filename of the UEFI executable, including the
+    <MACHINE_ID> part (default=yes).
+
+*uefi_stub=*"_<file>_"::
+    Specifies the UEFI stub loader, which will load the attached kernel,
+    initramfs and kernel command line and boots the kernel. The default is
+    _/lib/systemd/boot/efi/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_.
+
+*uefi_splash_image=*"_<file>_"::
+    Specifies the UEFI stub loader's splash image. Requires bitmap (**.bmp**)
+    image format.
+
+*uefi_secureboot_cert=*"_<file>_", *uefi_secureboot_key=*"_<file>_"::
+    Specifies a certificate and corresponding key, which are used to sign the
+    created UEFI executable.
+    Requires both certificate and key need to be specified and _sbsign_ to be
+    installed.
+
+*kernel_image=*"_<file>_"::
+    Specifies the kernel image, which to include in the UEFI executable. The
+    default is _/lib/modules/<KERNEL-VERSION>/vmlinuz_ or
+    _/boot/vmlinuz-<KERNEL-VERSION>_.
+
+*enhanced_cpio=*"__{yes|no}__"::
+    Attempt to use the dracut-cpio binary, which optimizes archive creation for
+    copy-on-write filesystems (default=no).
+    When specified, initramfs archives are also padded to ensure optimal data
+    alignment for extent sharing. To retain reflink data deduplication benefits,
+    this should be used alongside the **compress="cat"** and **do_strip="no"**
+    parameters, with initramfs source files, **tmpdir** staging area and
+    destination all on the same copy-on-write capable filesystem.
 
 Files
 -----

--- a/shell-completion/bash/dracut
+++ b/shell-completion/bash/dracut
@@ -33,24 +33,32 @@ _dracut() {
             --xz --zstd --no-compress --gzip --list-modules --show-modules --keep
             --printsize --regenerate-all --noimageifnotneeded --early-microcode
             --no-early-microcode --print-cmdline --reproducible --uefi
-            --enhanced-cpio'
-        [ARG]='-a -m -o -d -I -k -c -L --kver --add --force-add --add-drivers
+            --enhanced-cpio --rebuild --aggresive-strip --hostonly-cmdline
+            --no-hostonly-cmdline --no-hostonly-default-device --nofscks
+            --hostonly-i18n --no-hostonly-i18n --lzo --lz4 --no-reproducible
+            --no-uefi --no-machineid --version
+            '
+        [ARG]='-a -m -o -d -I -k -c -L -r -i
+            --kver --add --force-add --add-drivers --force-drivers
             --omit-drivers --modules --omit --drivers --filesystems --install
-            --fwdir --libdirs --fscks --add-fstab --mount --device --nofscks
+            --fwdir --libdirs --fscks --add-fstab --mount --device
             --kmoddir --conf --confdir --tmpdir --stdlog --compress --prefix
             --kernel-cmdline --sshkey --persistent-policy --install-optional
             --loginstall --uefi-stub --kernel-image --squash-compressor
+            --sysroot --hostonly-mode --hostonly-nics --include --logfile
+            --uefi-splash-image
             '
     )
 
     # shellcheck disable=SC2086
     if __contains_word "$prev" ${OPTS[ARG]}; then
         case $prev in
-            --kmoddir | -k | --fwdir | --confdir | --tmpdir)
+            --kmoddir | -k | --fwdir | --confdir | --tmpdir | -r | --sysroot)
                 comps=$(compgen -d -- "$cur")
                 compopt -o filenames
                 ;;
-            -c | --conf | --sshkey | --add-fstab | --add-device | -I | --install | --install-optional)
+            -c | --conf | --sshkey | --add-fstab | --add-device | -I | \
+                --install | --install-optional | --uefi-splash-image)
                 comps=$(compgen -f -- "$cur")
                 compopt -o filenames
                 ;;
@@ -67,6 +75,15 @@ _dracut() {
                 comps=$(
                     cd /lib/modules || return 0
                     echo [0-9]*
+                )
+                ;;
+            --hostonly-mode)
+                comps="sloppy strict"
+                ;;
+            --hostonly-nics)
+                comps=$(
+                    cd /sys/class/net/ || return 0
+                    printf -- "%s " *
                 )
                 ;;
             *)

--- a/shell-completion/bash/lsinitrd
+++ b/shell-completion/bash/lsinitrd
@@ -25,7 +25,7 @@ __contains_word() {
 _lsinitrd() {
     local cur=${COMP_WORDS[COMP_CWORD]} prev=${COMP_WORDS[COMP_CWORD - 1]}
     local -A OPTS=(
-        [STANDALONE]='-s --size -h --help'
+        [STANDALONE]='-s --size -h --help --unpack --unpackearly -v --verbose'
         [ARG]='-f --file -k --kver'
     )
 


### PR DESCRIPTION
This PR adds missing bash completion options, missing options in dracut.sh usage, dracut and dracut.conf man pages and attempts to unify the text format of each part. Specifically:

- man/dracut.conf: set common format to each option, add/correct default values and add missing options.
```
force_add_dracutmodules
libdirs
squash_compress
aggresive_strip
do_hardlink
prefix
hostonly_mode
hostonly_nics
sshkey
regenerate_all
noimageifnotneeded
uefi
machine_id
enhanced_cpio
```
- man/dracut: set common format to each option, correct default compression options and add missing options.
```
--rebuild
--aggresive-strip
--hostonly-mode
--hostonly-nics
--noimageifnotneeded
```
- dracut.sh: set common format to each usage option and add missing options.
```
--no-machineid
```

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it