### PR TITLE
ci(github) add manual trigger to all workflows

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,5 +1,6 @@
 name: Container
 on:
+    workflow_dispatch:
     schedule:
         -  cron: '30 11 * * *'   # every day at 4:40
     push:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,7 @@
 name: Integration Test
 
 on:
+    workflow_dispatch:
     pull_request:
         branches: [ master ]
 

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,6 +1,8 @@
 name: "Pull Request Labeler"
 
-on: pull_request_target
+on:
+    workflow_dispatch:
+    pull_request_target:
 
 jobs:
     triage:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: Lint
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
   pull_request:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,6 @@
 name: Commisery
 on:
+  workflow_dispatch:
   pull_request:
     types: [edited, opened, synchronize, reopened]
 


### PR DESCRIPTION
This pull enables manual triggers to all workflows. 
Manual triggers allow to not wait for containers to build on schedule once a day or re-run a flaky test on a PR.