### PR TITLE
docs(dracut.conf): regenerate_all not supported

### DIFF
--- a/man/dracut.conf.5.asc
+++ b/man/dracut.conf.5.asc
@@ -257,11 +257,6 @@ Logging levels:
 *reproducible=*"__{yes|no}__"::
     Create reproducible images (default=no).
 
-*regenerate_all=*"__{yes|no}__"::
-    Regenerate all initramfs images at the default location with the kernel
-    versions found on the system. Additional parameters are passed through
-    (default=no).
-
 *noimageifnotneeded=*"__{yes|no}__"::
     Do not create an image in host-only mode, if no kernel driver is needed
     and no /etc/cmdline/*.conf will be generated into the initramfs


### PR DESCRIPTION
The `regenerate_all` option is used before sourcing the configuration files. 
I introduced this wrong manual entry in #1815, somehow I missed it, sorry.

https://github.com/dracutdevs/dracut/blob/9bef71094eba84a9eac161fc45386ccd73bd2b34/dracut.sh#L873

https://github.com/dracutdevs/dracut/blob/9bef71094eba84a9eac161fc45386ccd73bd2b34/dracut.sh#L950-L962

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
