### PR TITLE
integrity: minor fix and missing option in doc

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1264,13 +1264,22 @@ masterkey=/etc/keys/kmk-trusted.blob
 masterkeytype=trusted
 --
 
-**evmkey=**__<EVM key path name>__::
-    Set the path name of the EVM key.
+**evmkey=**__<EVM HMAC key path name>__::
+    Set the path name of the EVM HMAC key.
 +
 [listing]
 .Example
 --
 evmkey=/etc/keys/evm-trusted.blob
+--
+
+**evmx509=**__<EVM X.509 cert path name>__::
+    Set the path name of the EVM X.509 certificate.
++
+[listing]
+.Example
+--
+evmx509=/etc/keys/x509_evm.der
 --
 
 **ecryptfskey=**__<eCryptfs key path name>__::

--- a/modules.d/98integrity/ima-keys-load.sh
+++ b/modules.d/98integrity/ima-keys-load.sh
@@ -17,8 +17,7 @@ load_x509_keys() {
         IMAKEYSDIR="/etc/keys/ima"
     fi
 
-    PUBKEY_LIST=$(ls "${NEWROOT}"${IMAKEYSDIR}/*)
-    for PUBKEY in ${PUBKEY_LIST}; do
+    for PUBKEY in "${NEWROOT}${IMAKEYSDIR}"/*; do
         # check for public key's existence
         if [ ! -f "${PUBKEY}" ]; then
             if [ "${RD_DEBUG}" = "yes" ]; then


### PR DESCRIPTION
- Add missing `evmx509` option to dracut.cmdline man page.
- Avoid displaying `ls` error when there is no IMA certificate (IMA appraisal can be used without digital signatures, just by storing hash digests instead, and protecting against file tampering using EVM):

```
May 24 17:25:05 localhost dracut-pre-pivot[510]: ls: cannot access '/sysroot/etc/keys/ima/*': No such file or directory
```

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
