### PR TITLE
WIP: ci: update action-sh-checker to the latest release ( v0.4.0 )

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: shfmt
-        uses: luizm/action-sh-checker@v0.2.2
+        uses: luizm/action-sh-checker@v0.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHFMT_OPTS: -s # arguments to shfmt.


### PR DESCRIPTION
This pull request updates the action-sh-checker to the latest release which uses shellcheck
v0.8.0 and shfmt v0.4.3

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
