### PR TITLE
fix(nvmf): deprecate old nvmf cmdline options

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -895,6 +895,9 @@ NOTE: letters in the MAC-address must be lowercase!
 
 NVMf
 ~~~~
+**rd.nonvmf=0**::
+    Disable NVMf
+
 **rd.nvmf.hostnqn=**__<hostNQN>__::
     NVMe host NQN to use
 

--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -78,17 +78,17 @@ cmdline() {
         [ -z "$trtype" ] && return 0
         nvme list-subsys "${PWD##*/}" | while read -r _ _ trtype traddr host_traddr _; do
             [ "$trtype" != "${trtype#NQN}" ] && continue
-            echo -n " nvmf.discover=$trtype,${traddr#traddr=},${host_traddr#host_traddr=}"
+            echo -n " rd.nvmf.discover=$trtype,${traddr#traddr=},${host_traddr#host_traddr=}"
         done
     }
 
     if [ -f /etc/nvme/hostnqn ]; then
         _hostnqn=$(cat /etc/nvme/hostnqn)
-        echo -n " nvmf.hostnqn=${_hostnqn}"
+        echo -n " rd.nvmf.hostnqn=${_hostnqn}"
     fi
     if [ -f /etc/nvme/hostid ]; then
         _hostid=$(cat /etc/nvme/hostid)
-        echo -n " nvmf.hostid=${_hostid}"
+        echo -n " rd.nvmf.hostid=${_hostid}"
     fi
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
 #
 # Supported formats:
-# nvmf.hostnqn=<hostnqn>
-# nvmf.hostid=<hostid>
-# nvmf.discover=<transport>,<traddr>,<host-traddr>,<trsvcid>
+# rd.nvmf.hostnqn=<hostnqn>
+# rd.nvmf.hostid=<hostid>
+# rd.nvmf.discover=<transport>,<traddr>,<host-traddr>,<trsvcid>
 #
 # Examples:
-# nvmf.hostnqn=nqn.2014-08.org.nvmexpress:uuid:37303738-3034-584d-5137-333230423843
-# nvmf.discover=rdma,192.168.1.3,,4420
-# nvmf.discover=tcp,192.168.1.3,,4420
-# nvmf.discover=tcp,192.168.1.3
-# nvmf.discover=fc,nn-0x200400a098d85236:pn-0x201400a098d85236,nn-0x200000109b7db455:pn-0x100000109b7db455
-# nvmf.discover=fc,auto
+# rd.nvmf.hostnqn=nqn.2014-08.org.nvmexpress:uuid:37303738-3034-584d-5137-333230423843
+# rd.nvmf.discover=rdma,192.168.1.3,,4420
+# rd.nvmf.discover=tcp,192.168.1.3,,4420
+# rd.nvmf.discover=tcp,192.168.1.3
+# rd.nvmf.discover=fc,nn-0x200400a098d85236:pn-0x201400a098d85236,nn-0x200000109b7db455:pn-0x100000109b7db455
+# rd.nvmf.discover=fc,auto
 #
 # Note: FC does autodiscovery, so typically there is no need to
 # specify any discover parameters for FC.
@@ -82,7 +82,7 @@ parse_nvmf_discover() {
             [ -n "$4" ] && trsvcid=$4
             ;;
         *)
-            warn "Invalid arguments for nvmf.discover=$1"
+            warn "Invalid arguments for rd.nvmf.discover=$1"
             return 0
             ;;
     esac
@@ -114,16 +114,16 @@ parse_nvmf_discover() {
     return 0
 }
 
-nvmf_hostnqn=$(getarg nvmf.hostnqn=)
+nvmf_hostnqn=$(getarg rd.nvmf.hostnqn -d nvmf.hostnqn=)
 if [ -n "$nvmf_hostnqn" ]; then
     echo "$nvmf_hostnqn" > /etc/nvme/hostnqn
 fi
-nvmf_hostid=$(getarg nvmf.hostid=)
+nvmf_hostid=$(getarg rd.nvmf.hostid -d nvmf.hostid=)
 if [ -n "$nvmf_hostid" ]; then
     echo "$nvmf_hostid" > /etc/nvme/hostid
 fi
 
-for d in $(getargs nvmf.discover=); do
+for d in $(getargs rd.nvmf.discover -d nvmf.discover=); do
     parse_nvmf_discover "$d" || break
 done
 


### PR DESCRIPTION
- Deprecate old nvmf cmdline options without the `rd.` prefix.
- Add missing `rd.nonvmf` cmdline option to man page.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1831
