### PR TITLE
Use Make variable CURDIR for current directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 -include dracut-version.sh
 
-DRACUT_MAIN_VERSION ?= $(shell env GIT_CEILING_DIRECTORIES=$(CWD)/.. git describe --abbrev=0 --tags --always 2>/dev/null || :)
+DRACUT_MAIN_VERSION ?= $(shell env GIT_CEILING_DIRECTORIES=$(CURDIR)/.. git describe --abbrev=0 --tags --always 2>/dev/null || :)
 ifeq ($(DRACUT_MAIN_VERSION),)
 DRACUT_MAIN_VERSION = $(DRACUT_VERSION)
 endif
-DRACUT_FULL_VERSION ?= $(shell env GIT_CEILING_DIRECTORIES=$(CWD)/.. git describe --tags --always 2>/dev/null || :)
+DRACUT_FULL_VERSION ?= $(shell env GIT_CEILING_DIRECTORIES=$(CURDIR)/.. git describe --tags --always 2>/dev/null || :)
 ifeq ($(DRACUT_FULL_VERSION),)
 DRACUT_FULL_VERSION = $(DRACUT_VERSION)
 endif


### PR DESCRIPTION
`CWD` is not a Make variable. This may have worked accidentally for some
people if their shell happend to provide `CWD` and Make picked it up.

As is, this tends to pick up git versions of unrelated parent
directories, e.g. when packaging for distributions.

This pull request changes...

## Changes

* Fix usage of potentially unset variable to determine git ceiling in Makefile

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [N/A] I am providing new code and test(s) for it

Here as an example building the release tarball on with Archlinux/GNU Make/Bash (no `$CWD`):

```
conrad@serotonin ~/hack/dracut-apk $ git log -1 --oneline
f5145bc (HEAD -> master, origin/master) Initial release
conrad@serotonin ~/hack/dracut-apk $ tar xf dracut-056.tar.xz
conrad@serotonin ~/hack/dracut-apk $ cd dracut-056/
conrad@serotonin ~/hack/dracut-apk/dracut-056 $ ./configure
conrad@serotonin ~/hack/dracut-apk/dracut-056 $ make
cc -c -O2 -g -Wall -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2   src/install/dracut-install.c -o src/install/dracut-install.o
cc -c -O2 -g -Wall -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2   src/install/hashmap.c -o src/install/hashmap.o
cc -c -O2 -g -Wall -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2   src/install/log.c -o src/install/log.o
cc -c -O2 -g -Wall -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2   src/install/strv.c -o src/install/strv.o
cc -c -O2 -g -Wall -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2   src/install/util.c -o src/install/util.o
cc  -o src/install/dracut-install src/install/dracut-install.o src/install/hashmap.o src/install/log.o src/install/strv.o src/install/util.o  -lc -lkmod
ln -fs src/install/dracut-install dracut-install
cc -c -O2 -g -Wall -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2   src/skipcpio/skipcpio.c -o src/skipcpio/skipcpio.o
cc   src/skipcpio/skipcpio.o   -o src/skipcpio/skipcpio
cc -c -O2 -g -Wall -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2   src/util/util.c -o src/util/util.o
cc   src/util/util.o   -o src/util/util
cp -a src/util/util dracut-util
conrad@serotonin ~/hack/dracut-apk/dracut-056 $ grep Version dracut.pc
Version: f5145bc
```

