### PR TITLE
fix(Makefile): reduce the number of shell invocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 -include dracut-version.sh
 
-DRACUT_MAIN_VERSION ?= $(shell env GIT_CEILING_DIRECTORIES=$(CURDIR)/.. git describe --abbrev=0 --tags --always 2>/dev/null || :)
+DRACUT_MAIN_VERSION := $(shell env GIT_CEILING_DIRECTORIES=$(CURDIR)/.. git describe --abbrev=0 --tags --always 2>/dev/null || :)
 ifeq ($(DRACUT_MAIN_VERSION),)
 DRACUT_MAIN_VERSION = $(DRACUT_VERSION)
 endif
-DRACUT_FULL_VERSION ?= $(shell env GIT_CEILING_DIRECTORIES=$(CURDIR)/.. git describe --tags --always 2>/dev/null || :)
+DRACUT_FULL_VERSION := $(shell env GIT_CEILING_DIRECTORIES=$(CURDIR)/.. git describe --tags --always 2>/dev/null || :)
 ifeq ($(DRACUT_FULL_VERSION),)
 DRACUT_FULL_VERSION = $(DRACUT_VERSION)
 endif


### PR DESCRIPTION
Makefile uses recursively expanded macros and as can be seen by simply
adding `$(warning Call to shell)` in front of `$(shell ...)` Foo's in the
Makefile, we are calling out to shell 9 times just to get the working
directory, a working directory which doesn't change during Make!

Let's save few pony's and reduce it to 2...
