### PR TITLE
ci(container): add openssl to all containers 

### DIFF
--- a/test/container/Dockerfile-Arch
+++ b/test/container/Dockerfile-Arch
@@ -9,7 +9,7 @@ RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)'
 
 # Install needed packages for the dracut CI container
 RUN pacman --noconfirm -Sy \
-    linux dash strace dhclient asciidoc cpio pigz squashfs-tools \
+    linux dash strace dhclient asciidoc cpio pigz squashfs-tools openssl \
     qemu btrfs-progs mdadm dmraid nfs-utils nfsidmap lvm2 nbd \
     dhcp networkmanager multipath-tools vi tcpdump open-iscsi \
     git shfmt shellcheck astyle which base-devel glibc && yes | pacman -Scc

--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -44,6 +44,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && DEBIAN_FRONTEND=nonintera
     network-manager \
     nfs-kernel-server \
     open-iscsi \
+    libssl-dev \
     pigz \
     pkg-config \
     procps \

--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -49,6 +49,8 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     which \
     ShellCheck \
     shfmt \
+    openssl \
+    openssl-devel \
     && dnf -y update && dnf clean all
 
 # Set default command

--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -13,7 +13,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     strace libkmod-devel gcc bzip2 xz tar wget rpm-build make git bash-completion \
     sudo kernel dhcp-client qemu-kvm /usr/bin/qemu-system-$(uname -m) e2fsprogs \
     tcpdump iproute iputils kbd NetworkManager btrfsprogs tgt dbus-broker \
-    iscsiuio open-iscsi which ShellCheck procps pigz \
+    iscsiuio open-iscsi which ShellCheck procps pigz openssl-devel \
     && dnf -y update && dnf clean all
 
 RUN shfmt_version=3.2.4; wget "https://github.com/mvdan/sh/releases/download/v${shfmt_version}/shfmt_v${shfmt_version}_linux_amd64" -O /usr/local/bin/shfmt \


### PR DESCRIPTION
It allows to build and test dracut with openssl flags.

Blocks #1827
