### PR TITLE
Added cmdline options to enable use of detached headers with rootfs.

### DIFF
--- a/modules.d/90crypt/cryptroot-ask.sh
+++ b/modules.d/90crypt/cryptroot-ask.sh
@@ -134,6 +134,16 @@ fi
 
 unset allowdiscards
 
+# parse for header file
+luks_header_filename=$(getargs "rd.luks.header")
+luks_header_disk=$(getargs "rd.luks.header.disk")
+if [ -n "$luks_header_filename" ]; then
+    cryptsetupopts="$cryptsetupopts --header /headerdiskmount/$luks_header_filename"
+fi
+
+unset luks_header_filename
+unset luks_header_disk
+
 # fallback to passphrase
 ask_passphrase=1
 

--- a/modules.d/90crypt/parse-crypt.sh
+++ b/modules.d/90crypt/parse-crypt.sh
@@ -34,7 +34,16 @@ else
     PARTUUID=$(getargs rd.luks.partuuid -d rd_LUKS_PARTUUID)
     SERIAL=$(getargs rd.luks.serial -d rd_LUKS_SERIAL)
     LUKS=$(getargs rd.luks.uuid -d rd_LUKS_UUID)
+    HEADER=$(getargs rd.luks.header -d rd_LUKS_HEADER)
+    HEADER_DISK=$(getargs rd.luks.header.disk -d rd_LUKS_HEADER_DISK)
     tout=$(getarg rd.luks.key.tout)
+
+
+    if [ -n "$HEADER_DISK" ]; then
+        mkdir /headerdiskmount
+        mount $HEADER_DISK /headerdiskmount
+    fi
+
 
     if [ -e /etc/crypttab ]; then
         while read -r _ _dev _ || [ -n "$_dev" ]; do


### PR DESCRIPTION
Detached headers may be mounted from external media or placed in the initramfs under /headerdiskmount.

Tested on all my own systems (Gentoo).

### Example

I store my detached header (e.g. "definitely_not_a_luks_header.img") on a separate disk (e.g. /dev/vda1) and use the following dracut cmdline options in my GRUB config:
```
menuentry "Gentoo" {
  linux /vmlinuz-superkernel \
    rd.luks.partuuid=3c9d04af-02 \
    rd.luks.header=definitely_not_a_luks_header.img \
    rd.luks.header.disk=/dev/vda1 \
    root=/dev/mapper/luks-3c9d04af-02 \
    rw \
    quiet
  initrd /initramfs-superkernel.img
}
```