### PR TITLE
feat(dracut): support parallel execution with --parallel

### DIFF
--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -558,6 +558,11 @@ will not be able to boot. Equivalent to "--compress=zstd -15 -q -T0".
     Regenerate all initramfs images at the default location with the kernel
     versions found on the system. Additional parameters are passed through.
 
+**-p, --parallel**::
+    Try to execute tasks in parallel. Currently only supported with
+    **--regenerate-all** (build initramfs images for all kernel
+    versions simultaneously).
+
 **--noimageifnotneeded**::
     Do not create an image in host-only mode, if no kernel driver is needed
 and no /etc/cmdline/*.conf will be generated into the initramfs.

--- a/man/dracut.conf.5.asc
+++ b/man/dracut.conf.5.asc
@@ -308,6 +308,10 @@ Logging levels:
     parameters, with initramfs source files, **tmpdir** staging area and
     destination all on the same copy-on-write capable filesystem.
 
+*parallel=*"__{yes|no}__"::
+   If set to _yes_, try to execute tasks in parallel (currently only supported
+   for _--regenerate-all_).
+
 Files
 -----
 _/etc/dracut.conf_::


### PR DESCRIPTION
Add an option `--parallel` which can currently be used with
`--regenerate-all`. With `--regenerate-all --parallel`, dracut will be
run in parallel for all kernels found.

Also introduce a config file equivalent setting: `parallel="yes"`.

In my testing I've found a linear speed up in execution time.

## Changes

 * add option `--regenerate-parallel`

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

