### PR TITLE
kernel-install: Add --verbose if KERNEL_INSTALL_VERBOSE=1

### DIFF
--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -54,7 +54,12 @@ case "$COMMAND" in
                 break
             fi
         done
-	dracut -f ${noimageifnotneeded:+--noimageifnotneeded} "$BOOT_DIR_ABS/$INITRD" "$KERNEL_VERSION"
+
+        dracut -f \
+            ${noimageifnotneeded:+--noimageifnotneeded} \
+            $([[ "$KERNEL_INSTALL_VERBOSE" == 1 ]] && echo --verbose) \
+            "$BOOT_DIR_ABS/$INITRD" \
+            "$KERNEL_VERSION"
         ret=$?
 	;;
     remove)


### PR DESCRIPTION
If KERNEL_INSTALL_VERBOSE=1, let's make sure dracut also produces
extended output for debugging purposes.

This pull request changes...

## Changes

## Checklist
- [ X ] I have tested it locally
- [ X ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
