### PR TITLE
Fix dracut-install subprocesses

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -500,12 +500,10 @@ static char *get_real_file(const char *src, bool fullyresolve)
 
 static int resolve_deps(const char *src)
 {
-        int ret = 0;
+        int ret = 0, err;
 
         _cleanup_free_ char *buf = NULL;
-        size_t linesize = LINE_MAX;
-        _cleanup_pclose_ FILE *fptr = NULL;
-        _cleanup_free_ char *cmd = NULL;
+        size_t linesize = LINE_MAX + 1;
         _cleanup_free_ char *fullsrcpath = NULL;
 
         fullsrcpath = get_real_file(src, true);
@@ -513,7 +511,7 @@ static int resolve_deps(const char *src)
         if (!fullsrcpath)
                 return 0;
 
-        buf = malloc0(LINE_MAX);
+        buf = malloc(linesize);
         if (buf == NULL)
                 return -errno;
 
@@ -523,11 +521,11 @@ static int resolve_deps(const char *src)
                 if (fd < 0)
                         return -errno;
 
-                ret = read(fd, buf, LINE_MAX);
+                ret = read(fd, buf, linesize - 1);
                 if (ret == -1)
                         return -errno;
 
-                buf[LINE_MAX - 1] = '\0';
+                buf[ret] = '\0';
                 if (buf[0] == '#' && buf[1] == '!') {
                         /* we have a shebang */
                         char *p, *q;
@@ -542,25 +540,28 @@ static int resolve_deps(const char *src)
                 }
         }
 
-        /* run ldd */
-        _asprintf(&cmd, "%s %s 2>&1", ldd, fullsrcpath);
-
-        log_debug("%s", cmd);
-
-        ret = 0;
-
-        fptr = popen(cmd, "r");
-        if (fptr == NULL) {
-                log_error("Error '%s' initiating pipe stream from '%s'", strerror(errno), cmd);
+        int fds[2];
+        FILE *fptr;
+        if (pipe2(fds, O_CLOEXEC) == -1 || (fptr = fdopen(fds[0], "r")) == NULL) {
+                log_error("Error '%m' initiating pipe stream for %s", ldd);
                 exit(EXIT_FAILURE);
         }
 
-        while (!feof(fptr)) {
-                char *p;
+        log_debug("%s %s", ldd, fullsrcpath);
+        pid_t ldd_pid;
+        if ((ldd_pid = fork()) == 0) {
+                dup2(fds[1], 1);
+                dup2(fds[1], 2);
+                putenv("LC_ALL=C");
+                execlp(ldd, ldd, fullsrcpath, (char *)NULL);
+                _exit(errno == ENOENT ? 127 : 126);
+        }
+        close(fds[1]);
 
-                memset(buf, 0, LINE_MAX);
-                if (getline(&buf, &linesize, fptr) <= 0)
-                        continue;
+        ret = 0;
+
+        while (getline(&buf, &linesize, fptr) >= 0) {
+                char *p;
 
                 log_debug("ldd: '%s'", buf);
 
@@ -571,7 +572,7 @@ static int resolve_deps(const char *src)
                 }
 
                 /* errors from cross-compiler-ldd */
-                if (strstr(buf, "unable to find sysroot") || strstr(buf, "command not found")) {
+                if (strstr(buf, "unable to find sysroot")) {
                         log_error("%s", buf);
                         ret += 1;
                         break;
@@ -623,7 +624,21 @@ static int resolve_deps(const char *src)
                 }
         }
 
-        return ret;
+        fclose(fptr);
+        while (waitpid(ldd_pid, &err, 0) == -1) {
+                if (errno != EINTR) {
+                        log_error("ERROR: waitpid() failed: %m");
+                        return 1;
+                }
+        }
+        err = WIFSIGNALED(err) ? 128 + WTERMSIG(err) : WEXITSTATUS(err);
+        /* ldd has error conditions we largely don't care about ("not a dynamic executable", &c.):
+           only error out on hard errors (ENOENT, ENOEXEC, signals) */
+        if (err >= 126) {
+                log_error("ERROR: '%s %s' failed with %d", ldd, fullsrcpath, err);
+                return err;
+        } else
+                return ret;
 }
 
 /* Install ".<filename>.hmac" file for FIPS self-checks */

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -325,28 +325,22 @@ static int cp(const char *src, const char *dst)
 
 normal_copy:
         pid = fork();
+        const char *preservation = (geteuid() == 0
+                                    && no_xattr == false) ? "--preserve=mode,xattr,timestamps,ownership" : "--preserve=mode,timestamps,ownership";
         if (pid == 0) {
-                if (geteuid() == 0 && no_xattr == false)
-                        execlp("cp", "cp", "--reflink=auto", "--sparse=auto", "--preserve=mode,xattr,timestamps,ownership", "-fL",
-                               src, dst, NULL);
-                else
-                        execlp("cp", "cp", "--reflink=auto", "--sparse=auto", "--preserve=mode,timestamps,ownership", "-fL", src,
-                               dst, NULL);
-                _exit(EXIT_FAILURE);
+                execlp("cp", "cp", "--reflink=auto", "--sparse=auto", preservation, "-fL", src, dst, NULL);
+                _exit(errno == ENOENT ? 127 : 126);
         }
 
-        while (waitpid(pid, &ret, 0) < 0) {
+        while (waitpid(pid, &ret, 0) == -1) {
                 if (errno != EINTR) {
-                        ret = -1;
-                        if (geteuid() == 0 && no_xattr == false)
-                                log_error("Failed: cp --reflink=auto --sparse=auto --preserve=mode,xattr,timestamps,ownership -fL %s %s",
-                                          src, dst);
-                        else
-                                log_error("Failed: cp --reflink=auto --sparse=auto --preserve=mode,timestamps,ownership -fL %s %s",
-                                          src, dst);
-                        break;
+                        log_error("ERROR: waitpid() failed: %m");
+                        return 1;
                 }
         }
+        ret = WIFSIGNALED(ret) ? 128 + WTERMSIG(ret) : WEXITSTATUS(ret);
+        if (ret != 0)
+                log_error("ERROR: 'cp --reflink=auto --sparse=auto %s -fL %s %s' failed with %d", preservation, src, dst, ret);
         log_debug("cp ret = %d", ret);
         return ret;
 }


### PR DESCRIPTION
## Changes
The four commits @marcosfrm mentioned in https://github.com/dracutdevs/dracut/pull/1796/files#r899623860:
  * popen() is awful and, helpfully, splits on the unescaped filename
  * ldd messages may be internationalised
  * fix waiting (and string parsing instead of waiting) for cp and ldd

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it
