### PR TITLE
fix(man): correct typo

### DIFF
--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -606,7 +606,7 @@ and no /etc/cmdline/*.conf will be generated into the initramfs.
     io::copy(). When specified, initramfs archives are also padded to ensure
     optimal data alignment for extent sharing. To retain reflink data
     deduplication benefits, this should be used alongside the **--no-compress**
-    and **--no-strip** parameters, with initramfs source files, **--tmpdir**
+    and **--nostrip** parameters, with initramfs source files, **--tmpdir**
     staging area and destination all on the same copy-on-write capable
     filesystem.
 


### PR DESCRIPTION
`s/--no-strip/--nostrip`

Fixes #1852
