### PR TITLE
Wipe LUKS Disk Encryption Key for Root Disk from RAM during Shutdown to defeat Cold Boot Attacks

### DIFF
--- a/modules.d/40sdmem/README.md
+++ b/modules.d/40sdmem/README.md
@@ -1,0 +1,4 @@
+### Make sure sdmem is part of the initramfs
+sudo apt-get install secure-delete 
+
+sudo dracut --include /usr/bin/sdmem /etc/sdmem --force

--- a/modules.d/40sdmem/README.md
+++ b/modules.d/40sdmem/README.md
@@ -1,4 +1,4 @@
 ### Make sure sdmem is part of the initramfs
 sudo apt-get install secure-delete 
 
-sudo dracut --include /usr/bin/sdmem /etc/sdmem --force
+sudo dracut --include /usr/bin/sdmem /bin/sdmem --force

--- a/modules.d/40sdmem/module-setup.sh
+++ b/modules.d/40sdmem/module-setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+check() {
+return 0
+}
+
+depends() {
+return 0
+}
+
+install() {
+inst_hook shutdown 40 "$moddir/wipe.sh"
+}
+
+installkernel() {
+return 0
+}
+

--- a/modules.d/40sdmem/wipe.sh
+++ b/modules.d/40sdmem/wipe.sh
@@ -1,0 +1,5 @@
+echo "Checking for mounted disks..."
+dmsetup ls --target crypt
+echo "WIPE RAM!"
+/bin/sdmem -f
+echo "WIPE DONE!"


### PR DESCRIPTION
Purpose of this pull request: Receiving some early feedback if this approach looks acceptable.

* Work in progress.
* Console output are yet to be improved and documentation written.
* Untested by me. Will test soon.
* Tests I am not sure yet how this could realistically be tested.

## Changes

* Confirm in console output if encrypted mounts (root disk) is unmounted. (Because that is a pre-condition for wiping the LUKS full disk encryption key from RAM.)
* Wipe LUKS Disk Encryption Key for Root Disk from RAM during Shutdown to defeat Cold Boot Attacks.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #997
