### PR TITLE
nm-run.sh should check interfaces repeatedly until they are up

### DIFF
--- a/modules.d/35network-manager/nm-lib.sh
+++ b/modules.d/35network-manager/nm-lib.sh
@@ -15,16 +15,20 @@ nm_generate_connections() {
     fi
 
     if getargbool 0 rd.neednet; then
+        mkdir -p /tmp/nm.want.d
         for i in /usr/lib/NetworkManager/system-connections/* \
             /run/NetworkManager/system-connections/* \
             /etc/NetworkManager/system-connections/* \
             /etc/sysconfig/network-scripts/ifcfg-*; do
             [ -f "$i" ] || continue
+            connection_uuid=$(grep '^uuid' "$i" | cut -d = -f 2)
+            : > /tmp/nm.want.d/"$connection_uuid"
+            [ ! -e /run/NetworkManager/initrd/neednet ] || continue
+
             mkdir -p "$hookdir"/initqueue/finished
             echo '[ -f /tmp/nm.done ]' > "$hookdir"/initqueue/finished/nm.sh
             mkdir -p /run/NetworkManager/initrd
             : > /run/NetworkManager/initrd/neednet # activate NM services
-            break
         done
     fi
 }


### PR DESCRIPTION
Currently, `nm-wait-online-initrd.service` only waits for NetworkManager to activate all devices; it doesn't wait for NetworkManager to reach a connected state. Because the `settled` hook `nm-run.sh` only provides one opportunity for the connection to be up, when DHCP loses to `nm-run.sh`, the `online` hooks are not run and the boot fails.

[Here's](https://gist.github.com/scottcwang/c8793dfa6804bc47429a13a01670807f) an example of the journal illustrating the issue. I've patched `warn "$(nmcli)" ; warn "$(cat /run/NetworkManager/system-connections/default_connection.nmconnection))"` into `nm-run.sh` to show that DHCP loses out to `nm-run.sh`:

1. `nm-wait-online-initrd.service` executes `nm-online -s` (line 5967).
2. `nm-online -s` [waits for NetworkManager client startup, skipping the `CONNECTED_*` state check](https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/main/src/nm-online/nm-online.c#L113-124).
3. The device activates, so NetworkManager reports `startup complete` (line 15681) and `nm-online -s` returns; but DHCP isn't done yet (in fact it hasn't actually started).
4. `dracut-initqueue` begins and runs the `nm-run.sh` `settled` hook (line 17173).
5. `nm-run.sh` sees that the device has no UUID yet, so [skips](https://github.com/dracutdevs/dracut/blob/master/modules.d/35network-manager/nm-run.sh#L65) executing the `online` hooks for the device (line 17278). (NB setting `may-fail=false`, line 17219, doesn't affect `-s`.)
6. `nm-run.sh` [writes](https://github.com/dracutdevs/dracut/blob/master/modules.d/35network-manager/nm-run.sh#L72) `/tmp/nm.done` (line 17287).
7. DHCP finally finishes (line 20510, interspersed NetworkManager logs).
8. On every subsequent run, `nm-run.sh` [sees](https://github.com/dracutdevs/dracut/blob/master/modules.d/35network-manager/nm-run.sh#L5-L6) `/tmp/nm.done` and exits without running the `online` hooks for the now online device (line 20628).

## Changes

There are several possible solutions:

- (This PR) Remove the `-s` option from the `nm-online` invocation in `nm-wait-online-initrd.service`, so that `nm-online` waits for `CONNECTED_*`, including DHCP being done. [Here's](https://gist.github.com/scottcwang/ce0a02e7f7fac535e097ded375d70d54) an example of the journal with this PR in place, showing the `nm-run.sh` waiting for DHCP and successfully running the `online` hooks.
- Make `nm-run.sh` not write `/tmp/nm.done` unless it has confirmed NetworkManager's state is `CONNECTED_*`
- Make `nm-run.sh` keep track of which devices it hasn't yet run the `online` hooks for, and retry them on the next run

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
