### PR TITLE
fix(dracut-systemd): set Environment=DRACUT_SYSTEMD=1 environment variable in dracut-shutdown.service

### DIFF
--- a/modules.d/98dracut-systemd/dracut-shutdown.service
+++ b/modules.d/98dracut-systemd/dracut-shutdown.service
@@ -9,6 +9,7 @@ ConditionPathExists=!/run/initramfs/bin/sh
 OnFailure=dracut-shutdown-onfailure.service
 
 [Service]
+Environment=DRACUT_SYSTEMD=1
 RemainAfterExit=yes
 Type=oneshot
 ExecStart=/bin/true


### PR DESCRIPTION
## Changes

* set Environment=DRACUT_SYSTEMD=1 environment variable in dracut-shutdown.service

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant: none required
- [x] I am providing new code and test(s) for it: none required

Fixes #1862
