### PR TITLE
fix(systemd-networkd): typo in systemd-networkd.socket local conf path

### DIFF
--- a/modules.d/01systemd-networkd/module-setup.sh
+++ b/modules.d/01systemd-networkd/module-setup.sh
@@ -70,8 +70,8 @@ install() {
             "$systemdutilconfdir/network/*" \
             "$systemdsystemconfdir"/systemd-networkd.service \
             "$systemdsystemconfdir/systemd-networkd.service/*.conf" \
-            "$systemdsystemunitdir"/systemd-networkd.socket \
-            "$systemdsystemunitdir/systemd-networkd.socket/*.conf" \
+            "$systemdsystemconfdir"/systemd-networkd.socket \
+            "$systemdsystemconfdir/systemd-networkd.socket/*.conf" \
             "$systemdsystemconfdir"/systemd-network-generator.service \
             "$systemdsystemconfdir/systemd-network-generator.service/*.conf" \
             "$systemdsystemconfdir"/systemd-networkd-wait-online.service \


### PR DESCRIPTION
Typo in `systemd-networkd.socket` local configuration path.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
