### PR TITLE
fix(dracut.sh): correct wrong systemd variable paths

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1833,7 +1833,7 @@ fi
 [[ -d $dracutsysrootdir$systemdnetworkconfdir ]] \
     || systemdnetworkconfdir=$(pkg-config systemd --variable=systemdnetworkconfdir 2> /dev/null)
 
-[[ -d $dracutsysrootdir$systemdnetworkconfdir ]] || systemdnetworkconfdir=${systemdsystemconfdir}/network
+[[ -d $dracutsysrootdir$systemdnetworkconfdir ]] || systemdnetworkconfdir=${systemdutilconfdir}/network
 
 [[ -d $dracutsysrootdir$systemdntpunits ]] \
     || systemdntpunits=$(pkg-config systemd --variable=systemdntpunits 2> /dev/null)
@@ -1843,7 +1843,7 @@ fi
 [[ -d $dracutsysrootdir$systemdntpunitsconfdir ]] \
     || systemdntpunitsconfdir=$(pkg-config systemd --variable=systemdntpunitsconfdir 2> /dev/null)
 
-[[ -d $dracutsysrootdir$systemdntpunitsconfdir ]] || systemdntpunitsconfdir=${systemdsystemconfdir}/ntp-units.d
+[[ -d $dracutsysrootdir$systemdntpunitsconfdir ]] || systemdntpunitsconfdir=${systemdutilconfdir}/ntp-units.d
 
 [[ -d $dracutsysrootdir$systemdportable ]] \
     || systemdportable=$(pkg-config systemd --variable=systemdportable 2> /dev/null)
@@ -1853,7 +1853,7 @@ fi
 [[ -d $dracutsysrootdir$systemdportableconfdir ]] \
     || systemdportableconfdir=$(pkg-config systemd --variable=systemdportableconfdir 2> /dev/null)
 
-[[ -d "$dracutsysrootdir$systemdportableconfdir" ]] || systemdportableconfdir=${systemdsystemconfdir}/portable
+[[ -d "$dracutsysrootdir$systemdportableconfdir" ]] || systemdportableconfdir=${systemdutilconfdir}/portable
 
 [[ -d $dracutsysrootdir$systemdsystemunitdir ]] \
     || systemdsystemunitdir=$(pkg-config systemd --variable=systemdsystemunitdir 2> /dev/null)
@@ -1868,7 +1868,7 @@ fi
 [[ -d $dracutsysrootdir$systemduserconfdir ]] \
     || systemduserconfdir=$(pkg-config systemd --variable=systemduserconfdir 2> /dev/null)
 
-[[ -d $dracutsysrootdir$systemduserconfdir ]] || systemduserconfdir=${systemdsystemconfdir}/user
+[[ -d $dracutsysrootdir$systemduserconfdir ]] || systemduserconfdir=${systemdutilconfdir}/user
 
 [[ -d $dracutsysrootdir$systemdsystemconfdir ]] \
     || systemdsystemconfdir=$(pkg-config systemd --variable=systemdsystemconfdir 2> /dev/null)
@@ -1922,8 +1922,10 @@ export initdir dracutbasedir \
     dbussessionconfdir dbussystem dbussystemconfdir dbussystemservices \
     dbussystemservicesconfdir environment environmentconfdir modulesload \
     modulesloadconfdir sysctld sysctlconfdir sysusers sysusersconfdir \
-    systemdutildir systemdutilconfdir systemdcatalog systemdntpunits \
-    systemdntpunitsconfdir systemdsystemunitdir systemdsystemconfdir \
+    systemdutildir systemdutilconfdir systemdcatalog systemdnetwork \
+    systemdnetworkconfdir systemdntpunits systemdntpunitsconfdir \
+    systemdportable systemdportableconfdir systemdsystemunitdir \
+    systemdsystemconfdir systemduser systemduserconfdir \
     hostonly_cmdline loginstall tmpfilesdir tmpfilesconfdir depmodd \
     depmodconfdir
 

--- a/modules.d/01systemd-networkd/module-setup.sh
+++ b/modules.d/01systemd-networkd/module-setup.sh
@@ -39,12 +39,12 @@ install() {
         "$systemdutildir"/systemd-networkd \
         "$systemdutildir"/systemd-network-generator \
         "$systemdutildir"/systemd-networkd-wait-online \
-        "$systemdutildir"/network/80-container-host0.network \
-        "$systemdutildir"/network/80-container-ve.network \
-        "$systemdutildir"/network/80-container-vz.network \
-        "$systemdutildir"/network/80-vm-vt.network \
-        "$systemdutildir"/network/80-wifi-adhoc.network \
-        "$systemdutildir"/network/99-default.link \
+        "$systemdnetwork"/80-container-host0.network \
+        "$systemdnetwork"/80-container-ve.network \
+        "$systemdnetwork"/80-container-vz.network \
+        "$systemdnetwork"/80-vm-vt.network \
+        "$systemdnetwork"/80-wifi-adhoc.network \
+        "$systemdnetwork"/99-default.link \
         "$systemdsystemunitdir"/systemd-networkd.service \
         "$systemdsystemunitdir"/systemd-networkd.socket \
         "$systemdsystemunitdir"/systemd-network-generator.service \
@@ -67,7 +67,7 @@ install() {
         inst_multiple -H -o \
             "$systemdutilconfdir"/networkd.conf \
             "$systemdutilconfdir/networkd.conf.d/*.conf" \
-            "$systemdutilconfdir/network/*" \
+            "$systemdnetworkconfdir/*" \
             "$systemdsystemconfdir"/systemd-networkd.service \
             "$systemdsystemconfdir/systemd-networkd.service/*.conf" \
             "$systemdsystemunitdir"/systemd-networkd.socket \

--- a/modules.d/01systemd-timesyncd/module-setup.sh
+++ b/modules.d/01systemd-timesyncd/module-setup.sh
@@ -35,7 +35,7 @@ install() {
     inst_multiple -o \
         "$dbussystem"/org.freedesktop.timesync1.conf \
         "$dbussystemservices"/org.freedesktop.timesync1.service \
-        "$systemdutildir/ntp-units.d/*.list" \
+        "$systemdntpunits/*.list" \
         "$systemdutildir"/systemd-timesyncd \
         "$systemdutildir"/systemd-time-wait-sync \
         "$systemdutildir/timesyncd.conf.d/*.conf" \
@@ -55,7 +55,7 @@ install() {
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
-            "$systemdutilconfdir/ntp-units.d/*.list" \
+            "$systemdntpunitsconfdir/*.list" \
             "$systemdutilconfdir"/timesyncd.conf \
             "$systemdutilconfdir/timesyncd.conf.d/*.conf" \
             "$systemdsystemconfdir"/systemd-timesyncd.service \

--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -24,7 +24,7 @@ install() {
 
     #Adding default link
     if dracut_module_included "systemd"; then
-        inst_multiple -o "${systemdutildir}/network/99-default.link"
+        inst_multiple -o "${systemdnetwork}/99-default.link"
         [[ $hostonly ]] && inst_multiple -H -o "${systemdnetworkconfdir}/*.link"
     fi
 

--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -25,7 +25,7 @@ install() {
     #Adding default link
     if dracut_module_included "systemd"; then
         inst_multiple -o "${systemdutildir}/network/99-default.link"
-        [[ $hostonly ]] && inst_multiple -H -o "${systemdsystemconfdir}/network/*.link"
+        [[ $hostonly ]] && inst_multiple -H -o "${systemdnetworkconfdir}/*.link"
     fi
 
     inst_multiple ip dhclient sed awk grep pgrep tr expr

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -53,7 +53,7 @@ install() {
 
         # Adding default link
         inst_multiple -o "${systemdutildir}/network/99-default.link"
-        [[ $hostonly ]] && inst_multiple -H -o "${systemdsystemconfdir}/network/*.link"
+        [[ $hostonly ]] && inst_multiple -H -o "${systemdnetworkconfdir}/*.link"
 
         $SYSTEMCTL -q --root "$initdir" enable nm-initrd.service
     fi

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -52,7 +52,7 @@ install() {
         inst_simple "$moddir"/nm-wait-online-initrd.service "$systemdsystemunitdir"/nm-wait-online-initrd.service
 
         # Adding default link
-        inst_multiple -o "${systemdutildir}/network/99-default.link"
+        inst_multiple -o "${systemdnetwork}/99-default.link"
         [[ $hostonly ]] && inst_multiple -H -o "${systemdnetworkconfdir}/*.link"
 
         $SYSTEMCTL -q --root "$initdir" enable nm-initrd.service


### PR DESCRIPTION
`systemdsystemconfdir` usually expands to /etc/systemd/system, but the local
configuration of systemd-networkd, systemd-timesyncd, portablectl and systemd
users is saved into directories whose parent is /etc/systemd
(`systemdutilconfdir`).

This error went unnoticed because these four variables are not being used anywhere in the code.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
