### PR TITLE
fix(systemd): set right permissions for the machine-id file

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -192,6 +192,7 @@ install() {
 
     if ! [[ -e "$initdir/etc/machine-id" ]]; then
         : > "$initdir/etc/machine-id"
+        chmod 444 "$initdir/etc/machine-id"
     fi
 
     # install adm user/group for journald


### PR DESCRIPTION
Set the right permissions for the `/etc/machine-id` file.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1864
