### PR TITLE
fix(dracut-init.sh): add missing hostonly code in the inst_multiple function

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -271,8 +271,12 @@ inst_symlink() {
 }
 
 inst_multiple() {
-    local _ret
-    if "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${initdir:+-D "$initdir"} -a ${loginstall:+-L "$loginstall"} ${DRACUT_RESOLVE_DEPS:+-l} ${DRACUT_FIPS_MODE:+-f} "$@"; then
+    local _ret _hostonly_install
+    if [[ $1 == "-H" ]]; then
+        _hostonly_install="-H"
+        shift
+    fi
+    if "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${initdir:+-D "$initdir"} -a ${loginstall:+-L "$loginstall"} ${DRACUT_RESOLVE_DEPS:+-l} ${DRACUT_FIPS_MODE:+-f} ${_hostonly_install:+-H} "$@"; then
         return 0
     else
         _ret=$?


### PR DESCRIPTION
The `_hostonly_install` variable is declared local in some `inst` functions that
check for the existance of the source files, but not in the `inst_multiple`
function because it is not needed.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it