### PR TITLE
fix(dracut.sh): do not fail on irregular files

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -905,7 +905,7 @@ if [[ -z $conffile ]]; then
     else
         conffile="$dracutsysrootdir/etc/dracut.conf"
     fi
-elif [[ ! -f $conffile ]]; then
+elif [[ ! -e $conffile ]]; then
     printf "%s\n" "dracut: Configuration file '$conffile' not found." >&2
     exit 1
 fi


### PR DESCRIPTION
If file is not a regular file (test -f), dracut.sh fails,
which is unexpected change of behaviour.
The workaround would be to create an empty file.

## Changes

The following example currently fails:
```
dracut --conf /dev/null
```

After the change 

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: #1835