### PR TITLE
pass optional --engine to sbsign to allow signing with hardware devices

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2631,6 +2631,7 @@ if [[ $uefi == yes ]]; then
         "$uefi_stub" "${uefi_outdir}/linux.efi"; then
         if [[ -n ${uefi_secureboot_key} && -n ${uefi_secureboot_cert} ]]; then
             if sbsign \
+                ${uefi_secureboot_engine:+--engine "$uefi_secureboot_engine"} \
                 --key "${uefi_secureboot_key}" \
                 --cert "${uefi_secureboot_cert}" \
                 --output "$outfile" "${uefi_outdir}/linux.efi"; then

--- a/man/dracut.conf.5.asc
+++ b/man/dracut.conf.5.asc
@@ -294,6 +294,9 @@ Logging levels:
     Requires both certificate and key need to be specified and _sbsign_ to be
     installed.
 
+*uefi_secureboot_engine=*"_parameter_"::
+    Specifies an engine to use when signing the created UEFI executable. E.g. "pkcs11"
+
 *kernel_image=*"_<file>_"::
     Specifies the kernel image, which to include in the UEFI executable. The
     default is _/lib/modules/<KERNEL-VERSION>/vmlinuz_ or


### PR DESCRIPTION
Defining dracut.conf variable 'uefi_secureboot_engine' is passed through to sbsign with --engine flag

## Changes
  dracut.sh

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
