### PR TITLE
dmsquash-live-root: Run checkisomd5 on correct device

### DIFF
--- a/modules.d/90dmsquash-live/module-setup.sh
+++ b/modules.d/90dmsquash-live/module-setup.sh
@@ -22,7 +22,7 @@ installkernel() {
 
 # called by dracut
 install() {
-    inst_multiple umount dmsetup blkid dd losetup blockdev find rmdir
+    inst_multiple umount dmsetup blkid dd losetup blockdev find rmdir grep
     inst_multiple -o checkisomd5
     inst_hook cmdline 30 "$moddir/parse-dmsquash-live.sh"
     inst_hook cmdline 31 "$moddir/parse-iso-scan.sh"


### PR DESCRIPTION
When the new grub2 iso is written to a usb drive the disk label points
to a partition that does not include the full iso image. This causes
checkisomd5 to run with the wrong data and it fails.

This patch adds a check that will test to see if there is a parent
device that is a disk, and to run checkisomd5 on it instead of on the
partition pointed to by the label.

When running from an iso this will return the original
/dev/disk/by-label/ path, and when running from a usb drive it will
return the parent device (eg. /dev/sda).

Resolves: rhbz#2107858

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [X] I am providing new code and test(s) for it
