### PR TITLE
fix: correct skipcpio and dracut-install source path

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -180,8 +180,8 @@ fi
 
 if ! [[ $DRACUT_INSTALL ]] && [[ -x $dracutbasedir/dracut-install ]]; then
     DRACUT_INSTALL=$dracutbasedir/dracut-install
-elif ! [[ $DRACUT_INSTALL ]] && [[ -x $dracutbasedir/install/dracut-install ]]; then
-    DRACUT_INSTALL=$dracutbasedir/install/dracut-install
+elif ! [[ $DRACUT_INSTALL ]] && [[ -x $dracutbasedir/src/install/dracut-install ]]; then
+    DRACUT_INSTALL=$dracutbasedir/src/install/dracut-install
 fi
 
 # Test if dracut-install is a standalone executable with no options.

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -288,8 +288,8 @@ case $bin in
                 echo "Early CPIO image"
                 list_files
             fi
-            if [[ -d "$dracutbasedir/skipcpio" ]]; then
-                SKIP="$dracutbasedir/skipcpio/skipcpio"
+            if [[ -d "$dracutbasedir/src/skipcpio" ]]; then
+                SKIP="$dracutbasedir/src/skipcpio/skipcpio"
             else
                 SKIP="$dracutbasedir/skipcpio"
             fi


### PR DESCRIPTION
`skipcpio` source path has changed since https://github.com/dracutdevs/dracut/commit/9f9bf8a1
`dracut-install` source path has changed since https://github.com/dracutdevs/dracut/commit/3420a70d

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it