### PR TITLE
fix(dmsquash-live-root): check kernel for built-in `overlay` drivers

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -177,7 +177,7 @@ do_live_overlay() {
         fi
     fi
     if [ -n "$overlayfs" ]; then
-        if ! modprobe overlay; then
+        if ! { strstr "$(< /proc/filesystems)" overlay || modprobe overlay; }; then
             if [ "$overlayfs" = required ]; then
                 die "OverlayFS is required but not available."
                 exit 1


### PR DESCRIPTION
Do not assume that `overlay` is always a module.  Check first for
`overlay` in `/proc/filesystems`.

Signed-off-by: Federico Vaga <federico.vaga@cern.ch>

See this discussion thread:
https://www.spinics.net/lists/linux-initramfs/msg04900.html