### PR TITLE
ci: add glibc to the Arch Linux container

### DIFF
--- a/test/container/Dockerfile-Arch
+++ b/test/container/Dockerfile-Arch
@@ -12,12 +12,12 @@ RUN pacman --noconfirm -Sy \
     linux dash strace dhclient asciidoc cpio pigz \
     qemu btrfs-progs mdadm dmraid nfs-utils nfsidmap lvm2 nbd \
     dhcp networkmanager multipath-tools vi tcpdump open-iscsi \
-    git shfmt shellcheck astyle which base-devel && yes | pacman  -Scc
+    git shfmt shellcheck astyle which base-devel glibc && yes | pacman -Scc
 
 RUN useradd -m build
 RUN su build -c 'cd && git clone https://aur.archlinux.org/perl-config-general.git && cd perl-config-general && makepkg -s --noconfirm'
 RUN pacman -U --noconfirm ~build/perl-config-general/*.pkg.tar.*
-RUN su build -c 'cd && git clone https://aur.archlinux.org/tgt.git && cd tgt && echo "CFLAGS=-Wno-error=stringop-truncation" >> PKGBUILD && makepkg -s --noconfirm'
+RUN su build -c 'cd && git clone https://aur.archlinux.org/tgt.git && cd tgt && makepkg -s --noconfirm'
 RUN pacman -U --noconfirm ~build/tgt/*.pkg.tar.*
 RUN rm -fr ~build
 


### PR DESCRIPTION
tgt has a dependency on glibc

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes  https://github.com/dracutdevs/dracut/issues/1890
