### PR TITLE
refactor(url-lib): write curl output directly to file

### DIFF
--- a/modules.d/45url-lib/url-lib.sh
+++ b/modules.d/45url-lib/url-lib.sh
@@ -67,7 +67,7 @@ curl_fetch_url() {
     echo "$url" > /proc/self/fd/0
     if [ -n "$outloc" ]; then
         # shellcheck disable=SC2086
-        curl $curl_args --output - -- "$url" > "$outloc" || return $?
+        curl $curl_args --output "$outloc" -- "$url" || return $?
     else
         local outdir
         outdir="$(mkuniqdir /tmp curl_fetch_url)"
@@ -101,7 +101,7 @@ ctorrent_fetch_url() {
     echo "$url" > /proc/self/fd/0
     if [ -n "$outloc" ]; then
         # shellcheck disable=SC2086
-        curl $curl_args --output - -- "$url" > "$torrent_outloc" || return $?
+        curl $curl_args --output "$torrent_outloc" -- "$url" || return $?
     else
         local outdir
         outdir="$(mkuniqdir /tmp torrent_fetch_url)"


### PR DESCRIPTION
This pull request makes curl write directly to a file instead of using redirection via stdout. The redirection was originally added in 5c274467d6a4959b7f451f9a211ffbb38d69b641 to workaround https://bugzilla.redhat.com/show_bug.cgi?id=989133 (curl would create no file if the source was empty), but I don't see that problem with current curl.

A nice side-effect of this change is that curl shows download progress.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it