### PR TITLE
fix(dmsquash-live): check kernel for built-in squashfs drivers

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -89,7 +89,7 @@ det_img_fs() {
     blkid -s TYPE -u noraid -o value "$1"
 }
 
-modprobe squashfs
+load_fstype squashfs
 CMDLINE=$(getcmdline)
 for arg in $CMDLINE; do
     case $arg in
@@ -204,7 +204,7 @@ do_live_overlay() {
         fi
     fi
     if [ -n "$overlayfs" ]; then
-        if ! { strstr "$(< /proc/filesystems)" overlay || modprobe overlay; }; then
+        if ! load_fstype overlay; then
             if [ "$overlayfs" = required ]; then
                 die "OverlayFS is required but not available."
                 exit 1

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -1152,3 +1152,10 @@ remove_hostonly_files() {
         done < /lib/dracut/hostonly-files
     fi
 }
+
+# parameter: kernel_module filesystem_name
+# returns OK if kernel_module is loaded
+# modprobe fails if /lib/modules is not available (--no-kernel use case)
+load_fstype() {
+    strstr "$(cat /proc/filesystems)" "$1" || modprobe "$1"
+}


### PR DESCRIPTION
Check first for squashfs in `/proc/filesystems`.
This is needed in the --no-kernel use case to avoid the error:
modprobe: FATAL: Module overlay not found in directory /lib/modules/<kver>

Introduce load_fstype function to make it easier to check `/proc/filesystems`
before calling modprobe.

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
