### PR TITLE
fix(virtiofs): ismounted has a dependency on the base module

### DIFF
--- a/modules.d/95virtiofs/module-setup.sh
+++ b/modules.d/95virtiofs/module-setup.sh
@@ -16,7 +16,7 @@ check() {
 
 # called by dracut
 depends() {
-    return 0
+    echo base
 }
 
 # called by dracut

--- a/modules.d/95virtiofs/mount-virtiofs.sh
+++ b/modules.d/95virtiofs/mount-virtiofs.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/sh
 
+type ismounted > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
 if [ "${fstype}" = "virtiofs" -o "${root%%:*}" = "virtiofs" ]; then
     if ! { modprobe virtiofs || strstr "$(cat /proc/filesystems)" virtiofs; }; then
         die "virtiofs is required but not available."


### PR DESCRIPTION
When dracut.sh is called with "--modules virtiofs", make sure
dracut-lib.sh is installed by making the base module a dependency.

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
