### PR TITLE
ci: dependencies for testing nfs module for Debian

### DIFF
--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -28,8 +28,10 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && DEBIAN_FRONTEND=nonintera
     fdisk \
     g++ \
     git \
+    iputils-arping \
     iputils-ping \
     isc-dhcp-client \
+    isc-dhcp-server \
     kmod \
     less \
     libkmod-dev \
@@ -40,7 +42,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && DEBIAN_FRONTEND=nonintera
     multipath-tools \
     nbd-client \
     network-manager \
-    nfs-common \
+    nfs-kernel-server \
     open-iscsi \
     pigz \
     pkg-config \


### PR DESCRIPTION
This change allows executing TEST-20-NFS on Debian.

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
