### PR TITLE
test(NFS): remove a workaround for systemd v230

### DIFF
--- a/test/TEST-20-NFS/dhcpd.conf
+++ b/test/TEST-20-NFS/dhcpd.conf
@@ -14,12 +14,12 @@ option domain-name "other.com";
 # MAC numbering scheme:
 # NFSv3: last octect starts at 0x00 and works up
 
-    group {
-        # NFSv3 root=dhcp or root={/dev/,}nfs, use server-id
-        option root-path "/nfs/client";
+        group {
+                # NFSv3 root=dhcp or root={/dev/,}nfs, use server-id
+                option root-path "/nfs/client";
 
-        host nfs3-1 {
-            hardware ethernet 52:54:00:12:34:00;
+                host nfs3-1 {
+                        hardware ethernet 52:54:00:12:34:00;
                         fixed-address 192.168.50.101;
                 }
         }

--- a/test/TEST-20-NFS/hosts
+++ b/test/TEST-20-NFS/hosts
@@ -2,7 +2,4 @@
 192.168.50.1	server
 192.168.50.2	server-ip
 192.168.50.3	server-proto-ip
-192.168.50.100	workstation1
 192.168.50.101	workstation2
-192.168.50.102	workstation3
-192.168.50.103	workstation4

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -138,16 +138,14 @@ test_nfsv3() {
     client_test "NFSv3 root=dhcp DHCP path only" 52:54:00:12:34:00 \
         "root=dhcp" 192.168.50.1 -wsize=4096 || return 1
 
-    if [[ "$(systemctl --version)" != *"systemd 230"* ]] 2> /dev/null; then
-        client_test "NFSv3 Legacy root=/dev/nfs nfsroot=IP:path" 52:54:00:12:34:01 \
-            "root=/dev/nfs nfsroot=192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096 || return 1
+    client_test "NFSv3 Legacy root=/dev/nfs nfsroot=IP:path" 52:54:00:12:34:01 \
+        "root=/dev/nfs nfsroot=192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096 || return 1
 
-        client_test "NFSv3 Legacy root=/dev/nfs DHCP path only" 52:54:00:12:34:00 \
-            "root=/dev/nfs" 192.168.50.1 -wsize=4096 || return 1
+    client_test "NFSv3 Legacy root=/dev/nfs DHCP path only" 52:54:00:12:34:00 \
+        "root=/dev/nfs" 192.168.50.1 -wsize=4096 || return 1
 
-        client_test "NFSv3 Legacy root=/dev/nfs DHCP IP:path" 52:54:00:12:34:01 \
-            "root=/dev/nfs" 192.168.50.2 -wsize=4096 || return 1
-    fi
+    client_test "NFSv3 Legacy root=/dev/nfs DHCP IP:path" 52:54:00:12:34:01 \
+        "root=/dev/nfs" 192.168.50.2 -wsize=4096 || return 1
 
     client_test "NFSv3 root=dhcp DHCP IP:path" 52:54:00:12:34:01 \
         "root=dhcp" 192.168.50.2 -wsize=4096 || return 1
@@ -169,19 +167,19 @@ test_nfsv3() {
 
     # This test must fail: nfsroot= requires root=/dev/nfs
     client_test "NFSv3 Invalid root=dhcp nfsroot=/nfs/client" 52:54:00:12:34:04 \
-        "root=dhcp nfsroot=/nfs/client failme rd.debug" 192.168.50.1 -wsize=4096 && return 1
+        "root=dhcp nfsroot=/nfs/client failme" 192.168.50.1 -wsize=4096 && return 1
 
-    client_test "NFSv3 root=dhcp DHCP path,options" \
-        52:54:00:12:34:05 "root=dhcp" 192.168.50.1 wsize=4096 || return 1
+    client_test "NFSv3 root=dhcp DHCP path,options" 52:54:00:12:34:05 \
+        "root=dhcp" 192.168.50.1 wsize=4096 || return 1
 
-    client_test "NFSv3 Bridge Customized root=dhcp DHCP path,options" \
-        52:54:00:12:34:05 "root=dhcp bridge=foobr0:enp0s1" 192.168.50.1 wsize=4096 || return 1
+    client_test "NFSv3 Bridge Customized root=dhcp DHCP path,options" 52:54:00:12:34:05 \
+        "root=dhcp bridge=foobr0:enp0s1" 192.168.50.1 wsize=4096 || return 1
 
-    client_test "NFSv3 root=dhcp DHCP IP:path,options" \
-        52:54:00:12:34:06 "root=dhcp" 192.168.50.2 wsize=4096 || return 1
+    client_test "NFSv3 root=dhcp DHCP IP:path,options" 52:54:00:12:34:06 \
+        "root=dhcp" 192.168.50.2 wsize=4096 || return 1
 
-    client_test "NFSv3 root=dhcp DHCP proto:IP:path,options" \
-        52:54:00:12:34:07 "root=dhcp" 192.168.50.3 wsize=4096 || return 1
+    client_test "NFSv3 root=dhcp DHCP proto:IP:path,options" 52:54:00:12:34:07 \
+        "root=dhcp" 192.168.50.3 wsize=4096 || return 1
 
     return 0
 }
@@ -198,11 +196,10 @@ test_nfsv4() {
         "root=dhcp" 192.168.50.3 wsize=4096 || return 1
 
     client_test "NFSv4 root=nfs4:..." 52:54:00:12:34:84 \
-        "root=nfs4:192.168.50.1:/client" 192.168.50.1 \
-        -wsize=4096 || return 1
+        "root=nfs4:192.168.50.1:/client" 192.168.50.1 -wsize=4096 || return 1
 
-    client_test "NFSv4 root=dhcp DHCP proto:IP:path,options" \
-        52:54:00:12:34:87 "root=dhcp" 192.168.50.3 wsize=4096 || return 1
+    client_test "NFSv4 root=dhcp DHCP proto:IP:path,options" 52:54:00:12:34:87 \
+        "root=dhcp" 192.168.50.3 wsize=4096 || return 1
 
     return 0
 }
@@ -364,7 +361,7 @@ test_setup() {
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/server/overlay / \
-        -m "bash udev-rules base rootfs-block fs-lib kernel-modules fs-lib qemu" \
+        -m "bash rootfs-block kernel-modules qemu" \
         -d "piix ide-gd_mod ata_piix ext3 sd_mod" \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
@@ -418,7 +415,7 @@ test_setup() {
     )
     # Make server's dracut image
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -m "dash udev-rules base rootfs-block fs-lib debug kernel-modules watchdog qemu network network-legacy" \
+        -m "dash rootfs-block debug kernel-modules watchdog qemu network network-legacy" \
         -d "af_packet piix ide-gd_mod ata_piix ext3 sd_mod e1000 i6300esb" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1


### PR DESCRIPTION
Remove a workaround for systemd v230
Remove some more dead code.
Improve style and formatting.
Remove duplicated modules.
    