### PR TITLE
fix(drm): add video drivers needed on hyper-v and similar

### DIFF
--- a/modules.d/50drm/module-setup.sh
+++ b/modules.d/50drm/module-setup.sh
@@ -31,7 +31,7 @@ installkernel() {
     if [[ $hostonly ]]; then
         local i modlink modname
 
-        for i in /sys/bus/{pci/devices,platform/devices,virtio/devices,soc/devices/soc?}/*/modalias; do
+        for i in /sys/bus/{pci/devices,platform/devices,virtio/devices,soc/devices/soc?,vmbus/devices}/*/modalias; do
             [[ -e $i ]] || continue
             [[ -n $(< "$i") ]] || continue
             # shellcheck disable=SC2046


### PR DESCRIPTION
Due to non-availability of Hyper-V video driver hyperv_drm in kdump
initramfs, the console seems to be in hang state with no text over it.

We should also go through the /sys/bus/vmbus/devices and include drivers
referenced there.

For reference: https://bugzilla.redhat.com/show_bug.cgi?id=2099502
