### PR TITLE
test(DMSQUASH): add test for overlay on top of a block device

### DIFF
--- a/test/TEST-16-DMSQUASH/create-root.sh
+++ b/test/TEST-16-DMSQUASH/create-root.sh
@@ -15,6 +15,7 @@ mkfs.ext4 -q -L dracut /dev/disk/by-id/ata-disk_root
 mkdir -p /root
 mount /dev/disk/by-id/ata-disk_root /root
 mkdir -p /root/run /root/testdir
+cp -a -t /root /source/*
 echo "Creating squashfs"
 mksquashfs /source /root/testdir/rootfs.img -quiet
 umount /root

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -19,6 +19,12 @@ test_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -boot order=d \
+        -append "rd.live.image rd.live.overlay.overlayfs=1 root=LABEL=dracut console=ttyS0,115200n81 quiet selinux=0 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 $DEBUGFAIL" \
+        -initrd "$TESTDIR"/initramfs.testing
+
+    "$testdir"/run-qemu \
+        "${disk_args[@]}" \
+        -boot order=d \
         -append "rd.live.image rd.live.overlay.overlayfs=1 rd.live.dir=testdir root=LABEL=dracut console=ttyS0,115200n81 quiet selinux=0 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing
 
@@ -103,7 +109,7 @@ test_setup() {
         export initdir="$TESTDIR"/overlay
         # shellcheck disable=SC1090
         . "$basedir"/dracut-init.sh
-        inst_multiple poweroff shutdown mkfs.ext4 find
+        inst_multiple poweroff shutdown mkfs.ext4
         inst_hook shutdown-emergency 000 ./hard-off.sh
         inst_hook emergency 000 ./hard-off.sh
     )


### PR DESCRIPTION
Add a test for mounting root filesystem with overlay for /dev/sdb.

The existing test was testing mounting root filesystem with overlay
from a squashfs image file.
