### PR TITLE
fix(nfs,virtiofs): check kernel for builtin fs drivers

### DIFF
--- a/modules.d/95nfs/nfs-start-rpc.sh
+++ b/modules.d/95nfs/nfs-start-rpc.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if modprobe sunrpc || strstr "$(cat /proc/filesystems)" rpc_pipefs; then
+if load_fstype sunrpc rpc_pipefs; then
     [ ! -d /var/lib/nfs/rpc_pipefs/nfs ] \
         && mount -t rpc_pipefs rpc_pipefs /var/lib/nfs/rpc_pipefs
 

--- a/modules.d/95virtiofs/mount-virtiofs.sh
+++ b/modules.d/95virtiofs/mount-virtiofs.sh
@@ -3,7 +3,7 @@
 type ismounted > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 if [ "${fstype}" = "virtiofs" -o "${root%%:*}" = "virtiofs" ]; then
-    if ! { modprobe virtiofs || strstr "$(cat /proc/filesystems)" virtiofs; }; then
+    if ! load_fstype virtiofs; then
         die "virtiofs is required but not available."
     fi
 

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -1153,9 +1153,12 @@ remove_hostonly_files() {
     fi
 }
 
-# parameter: kernel_module filesystem_name
+# parameter: kernel_module [filesystem_name]
 # returns OK if kernel_module is loaded
 # modprobe fails if /lib/modules is not available (--no-kernel use case)
 load_fstype() {
-    strstr "$(cat /proc/filesystems)" "$1" || modprobe "$1"
+    if [ -z "$2" ]; then
+        set -- "$1" "$2"
+    fi
+    strstr "$(cat /proc/filesystems)" "$2" || modprobe "$1"
 }


### PR DESCRIPTION
Check first for fs support in `/proc/filesystems` before attempting
to load the kernel module.

This is needed in the --no-kernel use case to avoid the error:
modprobe: FATAL: Module overlay not found in directory /lib/modules/<kver>

