### PR TITLE
feat(dmsquash-live): add support for dash

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-generator.sh
+++ b/modules.d/90dmsquash-live/dmsquash-generator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
@@ -68,7 +68,7 @@ ROOTFLAGS="$(getarg rootflags)"
     else
         echo "What=/dev/mapper/live-rw"
         [ -n "$ROOTFLAGS" ] && echo "Options=${ROOTFLAGS}"
-        _dev=$'dev-mapper-live\\x2drw'
+        _dev='dev-mapper-live\x2drw'
     fi
 } > "$GENERATOR_DIR"/sysroot.mount
 

--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
@@ -35,7 +35,7 @@ getargbool 0 rd.live.overlay.overlayfs && overlayfs="yes"
 
 # Take a path to a disk label and return the parent disk if it is a partition
 # Otherwise returns the original path
-function get_check_dev() {
+get_check_dev() {
     local _udevinfo
     dev_path="$(udevadm info -q path --name "$1")"
     _udevinfo="$(udevadm info -q property --path "${dev_path}")"
@@ -123,8 +123,15 @@ else
         # Symlinking /usr/bin/ntfs-3g as /sbin/mount.ntfs seems to boot
         # at the first glance, but ends with lots and lots of squashfs
         # errors, because systemd attempts to kill the ntfs-3g process?!
+        # See https://systemd.io/ROOT_STORAGE_DAEMONS/
         if [ -x "/usr/bin/ntfs-3g" ]; then
-            (exec -a @ntfs-3g ntfs-3g -o "${liverw:-ro}" "$livedev" /run/initramfs/live) | vwarn
+            (
+                ln -s /usr/bin/ntfs-3g /run/@ntfs-3g
+                (sleep 1 && rm /run/@ntfs-3g) &
+                # shellcheck disable=SC2123
+                PATH=/run
+                exec @ntfs-3g -o "${liverw:-ro}" "$livedev" /run/initramfs/live
+            ) | vwarn
         else
             die "Failed to mount block device of live image: Missing NTFS support"
             exit 1
@@ -222,25 +229,37 @@ do_live_overlay() {
         elif [ -n "$devspec" -a -n "$pathspec" ]; then
             [ -z "$m" ] \
                 && m='   Unable to find a persistent overlay; using a temporary one.'
-            m="$m"$'\n      All root filesystem changes will be lost on shutdown.'
-            m="$m"$'\n         Press [Enter] to continue.'
+            m="$m"'
+      All root filesystem changes will be lost on shutdown.
+         Press [Enter] to continue.'
             printf "\n\n\n\n%s\n\n\n" "${m}" > /dev/kmsg
             if [ -n "$DRACUT_SYSTEMD" ]; then
                 if type plymouth > /dev/null 2>&1 && plymouth --ping; then
                     if getargbool 0 rhgb || getargbool 0 splash; then
-                        m='>>>'$'\n''>>>'$'\n''>>>'$'\n\n\n'"$m"
-                        m="${m%n.*}"$'n.\n\n\n''<<<'$'\n''<<<'$'\n''<<<'
+                        m='>>>
+>>>
+>>>
+
+
+'"$m"
+                        m="${m%n.*}"'n.
+
+
+<<<
+<<<
+<<<'
                         plymouth display-message --text="${m}"
                     else
                         plymouth ask-question --prompt="${m}" --command=true
                     fi
                 else
-                    m=">>>${m//.[[:space:]]/.}  <<<"
+                    m=">>>$(printf '%s' "$m" | tr -d '\n')  <<<"
                     systemd-ask-password --timeout=0 "${m}"
                 fi
             else
                 type plymouth > /dev/null 2>&1 && plymouth --ping && plymouth --quit
-                read -s -r -p $'\n\n'"${m}" -n 1 _
+                printf '\n\n%s' "$m"
+                read -r _
             fi
         fi
         if [ -n "$overlayfs" ]; then

--- a/modules.d/90dmsquash-live/module-setup.sh
+++ b/modules.d/90dmsquash-live/module-setup.sh
@@ -11,7 +11,7 @@ check() {
 depends() {
     # if dmsetup is not installed, then we cannot support fedora/red hat
     # style live images
-    echo dm rootfs-block img-lib bash
+    echo dm rootfs-block img-lib
     return 0
 }
 

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -108,7 +108,7 @@ test_setup() {
         inst_hook emergency 000 ./hard-off.sh
     )
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        --modules "dmsquash-live qemu" \
+        --modules "dash dmsquash-live qemu" \
         --omit "rngd" \
         --drivers "ext4 sd_mod" \
         --no-hostonly --no-hostonly-cmdline \


### PR DESCRIPTION
Using dash instead of bash saves about 0.5M initramfs size.

## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [X] I am providing new code and test(s) for it

Fixes #1897
