### PR TITLE
fix(dracut-initramfs-restore.sh): hide unpack errors

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -51,13 +51,13 @@ fi
 
 cd /run/initramfs
 
-if $SKIP "$IMG" | zcat | cpio -id --no-absolute-filenames --quiet > /dev/null \
-    || $SKIP "$IMG" | bzcat | cpio -id --no-absolute-filenames --quiet > /dev/null \
-    || $SKIP "$IMG" | xzcat | cpio -id --no-absolute-filenames --quiet > /dev/null \
-    || $SKIP "$IMG" | lz4 -d -c | cpio -id --no-absolute-filenames --quiet > /dev/null \
-    || $SKIP "$IMG" | lzop -d -c | cpio -id --no-absolute-filenames --quiet > /dev/null \
-    || $SKIP "$IMG" | zstd -d -c | cpio -id --no-absolute-filenames --quiet > /dev/null \
-    || $SKIP "$IMG" | cpio -id --no-absolute-filenames --quiet > /dev/null; then
+if (command -v zcat > /dev/null && $SKIP "$IMG" 2> /dev/null | zcat 2> /dev/null | cpio -id --no-absolute-filenames --quiet > /dev/null 2>&1) \
+    || (command -v bzcat > /dev/null && $SKIP "$IMG" 2> /dev/null | bzcat 2> /dev/null | cpio -id --no-absolute-filenames --quiet > /dev/null 2>&1) \
+    || (command -v xzcat > /dev/null && $SKIP "$IMG" 2> /dev/null | xzcat 2> /dev/null | cpio -id --no-absolute-filenames --quiet > /dev/null 2>&1) \
+    || (command -v lz4 > /dev/null && $SKIP "$IMG" 2> /dev/null | lz4 -d -c 2> /dev/null | cpio -id --no-absolute-filenames --quiet > /dev/null 2>&1) \
+    || (command -v lzop > /dev/null && $SKIP "$IMG" 2> /dev/null | lzop -d -c 2> /dev/null | cpio -id --no-absolute-filenames --quiet > /dev/null 2>&1) \
+    || (command -v zstd > /dev/null && $SKIP "$IMG" 2> /dev/null | zstd -d -c 2> /dev/null | cpio -id --no-absolute-filenames --quiet > /dev/null 2>&1) \
+    || ($SKIP "$IMG" 2> /dev/null | cpio -id --no-absolute-filenames --quiet > /dev/null 2>&1); then
     rm -f -- .need_shutdown
 else
     # something failed, so we clean up


### PR DESCRIPTION
With the current "try and fail" approach, the system log contains errors until
the correct initrd compression is reached.

E.g. extra error log produced by a zstd compressed initrd, until the right option is reached:

```
Aug 17 09:42:18 localhost.localdomain dracut-initramfs-restore[6670]: gzip: stdin: not in gzip format
Aug 17 09:42:18 localhost.localdomain dracut-initramfs-restore[6671]: cpio: premature end of archive
Aug 17 09:42:18 localhost.localdomain dracut-initramfs-restore[6669]: ERROR: src/skipcpio/skipcpio.c:191:main(): fwrite
Aug 17 09:42:18 localhost.localdomain dracut-initramfs-restore[6675]: bzcat: (stdin) is not a bzip2 file.
Aug 17 09:42:18 localhost.localdomain dracut-initramfs-restore[6674]: ERROR: src/skipcpio/skipcpio.c:191:main(): fwrite
Aug 17 09:42:18 localhost.localdomain dracut-initramfs-restore[6676]: cpio: premature end of archive
Aug 17 09:42:18 localhost.localdomain dracut-initramfs-restore[6680]: xzcat: (stdin): File format not recognized
Aug 17 09:42:18 localhost.localdomain dracut-initramfs-restore[6681]: cpio: premature end of archive
Aug 17 09:42:18 localhost.localdomain dracut-initramfs-restore[6679]: ERROR: src/skipcpio/skipcpio.c:191:main(): fwrite
Aug 17 09:42:18 localhost.localdomain dracut-initramfs-restore[6686]: /usr/lib/dracut/dracut-initramfs-restore: line 57: lz4: command not found
Aug 17 09:42:18 localhost.localdomain dracut-initramfs-restore[6685]: ERROR: src/skipcpio/skipcpio.c:191:main(): fwrite
Aug 17 09:42:18 localhost.localdomain dracut-initramfs-restore[6687]: cpio: premature end of archive
Aug 17 09:42:18 localhost.localdomain dracut-initramfs-restore[6689]: /usr/lib/dracut/dracut-initramfs-restore: line 58: lzop: command not found
Aug 17 09:42:18 localhost.localdomain dracut-initramfs-restore[6688]: ERROR: src/skipcpio/skipcpio.c:191:main(): fwrite
Aug 17 09:42:18 localhost.localdomain dracut-initramfs-restore[6690]: cpio: premature end of archive
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it