### PR TITLE
test(SYSTEMD): make the man command succeed

### DIFF
--- a/test/TEST-02-SYSTEMD/systemd-analyze.sh
+++ b/test/TEST-02-SYSTEMD/systemd-analyze.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-cp /usr/bin/true /usr/bin/man
-
 for i in \
     sysinit.target \
     basic.target \

--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -104,9 +104,15 @@ test_setup() {
         export initdir=$TESTDIR/overlay
         # shellcheck disable=SC1090
         . "$basedir"/dracut-init.sh
-        inst_multiple poweroff shutdown dd
+        inst_multiple poweroff shutdown dd true
+
         inst_hook shutdown-emergency 000 ./hard-off.sh
+
+        # systemd-analyze.sh calls man indirectly
+        # make the man command succeed always
+        inst "$(find_binary true)" "/usr/bin/man"
         inst_hook pre-pivot 000 ./systemd-analyze.sh
+
         inst_hook emergency 000 ./hard-off.sh
     )
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \


### PR DESCRIPTION
Document the reason of the existing workaround.

Move the existing logic to the initramfs.testing generation phase
and make the steps more generic.

