### PR TITLE
refactor(shutdown): move module specific code out of base module

### DIFF
--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -956,11 +956,6 @@ emergency_shell() {
         _rdshell_name=$2
         action="Shutdown"
         hook="shutdown-emergency"
-        if type plymouth > /dev/null 2>&1; then
-            plymouth --hide-splash
-        elif [ -x /oldroot/bin/plymouth ]; then
-            /oldroot/bin/plymouth --hide-splash
-        fi
         shift 2
     fi
 

--- a/modules.d/99shutdown/shutdown.sh
+++ b/modules.d/99shutdown/shutdown.sh
@@ -149,6 +149,12 @@ while [ $_cnt -le 40 ]; do
 done
 [ $_cnt -ge 40 ] && _check_shutdown final
 
+if type plymouth > /dev/null 2>&1; then
+    plymouth --hide-splash
+elif [ -x /oldroot/bin/plymouth ]; then
+    /oldroot/bin/plymouth --hide-splash
+fi
+
 getarg 'rd.break=shutdown' && emergency_shell --shutdown shutdown "Break before shutdown"
 
 case "$ACTION" in


### PR DESCRIPTION
dracut-lib.sh and the base module now does not have a knowledge
of oldroot and plymouth.

It improves the separation of concerns between the base module
and the shutdown module.

## Checklist
- [X] I have tested it locally
