### PR TITLE
refactor(dmsquash-live): move ntfs-3g code to dmsquash-live-ntfs

### DIFF
--- a/modules.d/90dmsquash-live-ntfs/module-setup.sh
+++ b/modules.d/90dmsquash-live-ntfs/module-setup.sh
@@ -14,6 +14,7 @@ depends() {
 
 install() {
     inst_multiple fusermount mount.fuse ntfs-3g
+    inst_script "$moddir/mount-ntfs-3g.sh" "/sbin/mount-ntfs-3g"
     dracut_need_initqueue
 }
 

--- a/modules.d/90dmsquash-live-ntfs/mount-ntfs-3g.sh
+++ b/modules.d/90dmsquash-live-ntfs/mount-ntfs-3g.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+type vwarn > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+# Symlinking /usr/bin/ntfs-3g as /sbin/mount.ntfs seems to boot
+# at the first glance, but ends with lots and lots of squashfs
+# errors, because systemd attempts to kill the ntfs-3g process?!
+# See https://systemd.io/ROOT_STORAGE_DAEMONS/
+if [ -x "/usr/bin/ntfs-3g" ]; then
+    (
+        ln -s /usr/bin/ntfs-3g /run/@ntfs-3g
+        (sleep 1 && rm /run/@ntfs-3g) &
+        # shellcheck disable=SC2123
+        PATH=/run
+        exec @ntfs-3g "$@"
+    ) | vwarn
+else
+    die "Failed to mount block device of live image: Missing NTFS support"
+    exit 1
+fi

--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -120,22 +120,7 @@ else
             exit 1
         fi
     else
-        # Symlinking /usr/bin/ntfs-3g as /sbin/mount.ntfs seems to boot
-        # at the first glance, but ends with lots and lots of squashfs
-        # errors, because systemd attempts to kill the ntfs-3g process?!
-        # See https://systemd.io/ROOT_STORAGE_DAEMONS/
-        if [ -x "/usr/bin/ntfs-3g" ]; then
-            (
-                ln -s /usr/bin/ntfs-3g /run/@ntfs-3g
-                (sleep 1 && rm /run/@ntfs-3g) &
-                # shellcheck disable=SC2123
-                PATH=/run
-                exec @ntfs-3g -o "${liverw:-ro}" "$livedev" /run/initramfs/live
-            ) | vwarn
-        else
-            die "Failed to mount block device of live image: Missing NTFS support"
-            exit 1
-        fi
+        [ -x "/sbin/mount-ntfs-3g" ] && /sbin/mount-ntfs-3g -o "${liverw:-ro}" "$livedev" /run/initramfs/live
     fi
 fi
 


### PR DESCRIPTION
Since the installation of ntfs-3g binary is in the
dmsquash-live-ntfs module, calling ntfs-3g from dmsquash-live fails
when dmsquash-live-ntfs module is not installed anyways.

## Checklist
- [X] I have tested it locally
