### PR TITLE
fix(shell-completion): add missing -p and --parallel options

### DIFF
--- a/shell-completion/bash/dracut
+++ b/shell-completion/bash/dracut
@@ -25,7 +25,7 @@ __contains_word() {
 _dracut() {
     local cur=${COMP_WORDS[COMP_CWORD]} prev=${COMP_WORDS[COMP_CWORD - 1]}
     local -A OPTS=(
-        [STANDALONE]='-f -v -q -l -H -h -M -N
+        [STANDALONE]='-f -v -q -l -H -h -M -N -p
             --ro-mnt --force --kernel-only --no-kernel --strip --nostrip
             --hardlink --nohardlink --noprefix --mdadmconf --nomdadmconf
             --lvmconf --nolvmconf --debug --profile --verbose --quiet
@@ -36,7 +36,7 @@ _dracut() {
             --enhanced-cpio --rebuild --aggressive-strip --hostonly-cmdline
             --no-hostonly-cmdline --no-hostonly-default-device --nofscks
             --hostonly-i18n --no-hostonly-i18n --lzo --lz4 --no-reproducible
-            --no-uefi --no-machineid --version
+            --no-uefi --no-machineid --version --parallel
             '
         [ARG]='-a -m -o -d -I -k -c -L -r -i
             --kver --add --force-add --add-drivers --force-drivers


### PR DESCRIPTION
Add missing `-p` and `--parallel` options introduced in commit https://github.com/dracutdevs/dracut/commit/6d92326201014cde9ab04b90367017f875d3b991

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it