### PR TITLE
feat(dracut): add `regenerate` configuration option

### DIFF
--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -557,6 +557,7 @@ will not be able to boot. Equivalent to "--compress=zstd -15 -q -T0".
 **--regenerate-all**::
     Regenerate all initramfs images at the default location with the kernel
     versions found on the system. Additional parameters are passed through.
+    This is overridden by the **regenerate** configuration option.
 
 **-p, --parallel**::
     Try to execute tasks in parallel. Currently only supported with
@@ -565,7 +566,7 @@ will not be able to boot. Equivalent to "--compress=zstd -15 -q -T0".
 
 **--noimageifnotneeded**::
     Do not create an image in host-only mode, if no kernel driver is needed
-and no /etc/cmdline/*.conf will be generated into the initramfs.
+    and no /etc/cmdline/*.conf will be generated into the initramfs.
 
 **--loginstall _<directory>_**::
     Log all files installed from the host to _<directory>_.

--- a/man/dracut.conf.5.asc
+++ b/man/dracut.conf.5.asc
@@ -28,7 +28,8 @@ set in _/etc/dracut.conf_. Each line specifies an attribute and a value. A '#'
 indicates the beginning of a comment; following characters, up to the end of the
 line are not interpreted.
 
-dracut command line options will override any values set here.
+dracut command line options will override any values set here, except
+**regenerate**.
 
 Configuration files must have the extension .conf; other extensions are ignored.
 
@@ -257,6 +258,20 @@ Logging levels:
 *reproducible=*"__{yes|no}__"::
     Create reproducible images (default=no).
 
+*regenerate=*"__{yes|all|no}__"::
+    Specify what initramfs images must be regenerated when calling dracut. This
+    configuration option overrides the _--regenerate-all_ command line argument.
+    If set to _yes_, regenerate only the image passed as command line argument,
+    or if omitted, the initramfs image of the actual running kernel.
+    If set to _all_, regenerate all initramfs images at the default location
+    with the kernel versions found on the system. Additional parameters are
+    passed through.
+    If set to _no_, do not regenerate any initramfs image.
+
+*parallel=*"__{yes|no}__"::
+   If set to _yes_, try to execute tasks in parallel (currently only supported
+   for **regenerate="all"**).
+
 *noimageifnotneeded=*"__{yes|no}__"::
     Do not create an image in host-only mode, if no kernel driver is needed
     and no /etc/cmdline/*.conf will be generated into the initramfs
@@ -310,10 +325,6 @@ Logging levels:
     this should be used alongside the **compress="cat"** and **do_strip="no"**
     parameters, with initramfs source files, **tmpdir** staging area and
     destination all on the same copy-on-write capable filesystem.
-
-*parallel=*"__{yes|no}__"::
-   If set to _yes_, try to execute tasks in parallel (currently only supported
-   for _--regenerate-all_).
 
 Files
 -----


### PR DESCRIPTION
Rationale: there is a recurring requested feature demanding that the user can opt out of automatic rebuilding of current or all initrds through some configuration option. Package dependencies often trigger regeneration of initrds, which can be a waste of time and CPU resources depending on the use case.

For example, this is implemented in `initramfs-tools` using the `update_initramfs` variable in [/etc/initramfs-tools/update-initramfs.conf](https://manpages.ubuntu.com/manpages/focal/man5/update-initramfs.conf.5.html)

The `regenerate` configuration option allows to specify what initramfs images must be rebuilt when calling dracut.
Possible values:
- `"yes"`: regenerate only the image passed as command line argument, or if omitted, the initramfs image of the actual running kernel.
- `"all"`: regenerate all initramfs images at the default location with the kernel versions found on the system.
- `"no"`: do not regenerate any initramfs image.

This configuration option is optional (if unset, the behavior is the same as before) and it overrides the `--regenerate-all` command line argument.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
