### PR TITLE
chore: remove editor configuration files from subdirectories

### DIFF
--- a/.kateconfig
+++ b/.kateconfig
@@ -1,1 +1,2 @@
 kate: space-indent on; tab-width 4; indent-width 4; replace-tabs on; eol unix;
+kate-mimetype(text/x-c): tab-width 8; indent-width 8;

--- a/src/install/.kateconfig
+++ b/src/install/.kateconfig
@@ -1,1 +1,0 @@
-kate: space-indent on; tab-width 8; indent-width 8; replace-tabs on; eol unix;

--- a/src/skipcpio/.dir-locals.el
+++ b/src/skipcpio/.dir-locals.el
@@ -1,2 +1,0 @@
-(setq c-basic-offset 8)
-(setq indent-tabs-mode nil)

--- a/src/skipcpio/.kateconfig
+++ b/src/skipcpio/.kateconfig
@@ -1,1 +1,0 @@
-kate: space-indent on; tab-width 8; indent-width 8; replace-tabs on; eol unix;


### PR DESCRIPTION
I do not use Kate/KDE.

https://docs.kde.org/trunk5/en/kate/katepart/config-variables.html

says we can use MIME type.

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
