### PR TITLE
chore(base): remove dead code

### DIFF
--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -302,7 +302,7 @@ debug_off # Turn off debugging for this section
 # unexport some vars
 export_n root rflags fstype netroot NEWROOT
 unset CMDLINE
-export RD_TIMESTAMP
+
 # Clean up the environment
 for i in $(export -p); do
     i=${i#declare -x}

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -56,7 +56,6 @@ install() {
     if ! dracut_module_included "systemd"; then
         inst_multiple switch_root || dfatal "Failed to install switch_root"
         inst_hook cmdline 10 "$moddir/parse-root-opts.sh"
-        inst_multiple -o "$systemdutildir"/systemd-timestamp
     fi
 
     if [[ $realinitpath ]]; then


### PR DESCRIPTION
RD_TIMESTAMP is no longer used.
systemd-timestamp is not used.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

