### PR TITLE
chore(udev-rules): remove obsolete code

### DIFF
--- a/modules.d/95udev-rules/load-modules.sh
+++ b/modules.d/95udev-rules/load-modules.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-# Implement blacklisting for udev-loaded modules
-
-modprobe -b "$@"

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -93,9 +93,6 @@ install() {
 
     inst_multiple -o /etc/pcmcia/config.opts
 
-    [[ -f $dracutsysrootdir/etc/arch-release ]] \
-        && inst_script "$moddir/load-modules.sh" /lib/udev/load-modules.sh
-
     inst_libdir_file "libnss_files*"
 
 }


### PR DESCRIPTION
Arch linux no longer needs a special load-modules.sh file.

Seems this is one of those temporary workarounds from 2010 that for a long time no longer needed - https://github.com/dracutdevs/dracut/commit/5a4bbf1bda2a93452bba254f5adbb4c1c5276230

