### PR TITLE
feat(dracut.sh): populate uefi_cmdline if no other cmdline is given

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2598,14 +2598,18 @@ umask 077
 if [[ $uefi == yes ]]; then
     if [[ $kernel_cmdline ]]; then
         echo -n "$kernel_cmdline" > "$uefi_outdir/cmdline.txt"
-    elif [[ $hostonly_cmdline == yes ]] && [ -d "$initdir/etc/cmdline.d" ]; then
-        for conf in "$initdir"/etc/cmdline.d/*.conf; do
-            [ -e "$conf" ] || continue
-            printf "%s " "$(< "$conf")" >> "$uefi_outdir/cmdline.txt"
-        done
+    elif [[ $hostonly_cmdline == yes ]]; then
+        if [ -d "$initdir/etc/cmdline.d" ]; then
+            for conf in "$initdir"/etc/cmdline.d/*.conf; do
+                [ -e "$conf" ] || continue
+                printf "%s " "$(< "$conf")" >> "$uefi_outdir/cmdline.txt"
+            done
+        elif [ -e "/proc/cmdline" ]; then
+            printf "%s " "$(< "/proc/cmdline")" > "$uefi_outdir/cmdline.txt"
+        fi
     fi
 
-    if [[ $kernel_cmdline ]] || [[ $hostonly_cmdline == yes && -d "$initdir/etc/cmdline.d" ]]; then
+    if [[ $kernel_cmdline ]] || [[ $hostonly_cmdline == yes && -e "${uefi_outdir}/cmdline.txt" ]]; then
         echo -ne "\x00" >> "$uefi_outdir/cmdline.txt"
         dinfo "Using UEFI kernel cmdline:"
         dinfo "$(tr -d '\000' < "$uefi_outdir/cmdline.txt")"


### PR DESCRIPTION

    feat(dracut.sh): populate uefi_cmdline if no other cmdline is given

    When creating uefi image in hostonly mode (with using --hostonly-cmdline),
    it makes sense to copy current kernel commandline from /proc/cmdline,
    in case there are no other options specified.

    Usually, the cmdline.d/*.conf file is generated by module rootfs-block
    (or other modules), but it might, not handle all cases correctly,
    and specifying --kernel-cmdline every time is not much user-friendly.

## Changes

`/proc/cmdline` will be used as a last option for for uefi `.cmdline` entry.

## Checklist
- [ ] I have tested it locally:
__TBD__

- [ ] I have reviewed and updated any documentation if relevant
**TODO: document this**

- [ ] I am providing new code and test(s) for it

Shouldn't be probably needed/desired to test this, as the host `/proc/cmdline` would need to be remounted.