### PR TITLE
feat(systemd): install systemd-sysroot-fstab-check

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -43,6 +43,7 @@ install() {
         "$systemdutildir"/systemd-modules-load \
         "$systemdutildir"/systemd-vconsole-setup \
         "$systemdutildir"/systemd-volatile-root \
+        "$systemdutildir"/systemd-sysroot-fstab-check \
         "$systemdutildir"/system-generators/systemd-debug-generator \
         "$systemdutildir"/system-generators/systemd-fstab-generator \
         "$systemdutildir"/system-generators/systemd-gpt-auto-generator \


### PR DESCRIPTION
`systemd-sysroot-fstab-check` is a symlink to `systemd-fstab-generator` added in
systemd commit https://github.com/systemd/systemd/commit/cd7ad0cb

systemd has a temporary patch until dracut installs it (https://github.com/systemd/systemd/commit/db527621)