### PR TITLE
ci: improve CI for containers

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -37,17 +37,17 @@ jobs:
                 uses: actions/checkout@v2
             -   name: Set up Docker Buildx
                 uses: docker/setup-buildx-action@v1
-#                with:
-#                    buildkitd-flags: --debug
             -   name: Login to GitHub Container Registry
-                uses: docker/login-action@v1
+                uses: docker/login-action@v2
                 with:
                     registry: ghcr.io
-                    username: ${{ github.repository_owner }}
+                    username: ${{ github.actor }}
                     password: ${{ secrets.GITHUB_TOKEN }}
+            -   name: Set up env.actor
+                run: echo "actor=${GITHUB_ACTOR,,}" >>${GITHUB_ENV}
             -   name: Build and Push Container
-                uses: docker/build-push-action@v2
+                uses: docker/build-push-action@v3
                 with:
                     file: test/container/${{ matrix.config.dockerfile }}
-                    tags: ghcr.io/dracutdevs/${{ matrix.config.tag }}
+                    tags: ghcr.io/${{env.actor}}/${{ matrix.config.tag }}
                     push: ${{ github.event_name == 'push' ||  github.event_name == 'schedule' }}


### PR DESCRIPTION
Login to GitHub Container Registry as the actor instead of the repository owner.
Upgrade to login-action@v2 and build-push-action@v3 Github Actions.

Fixes: #1865