### PR TITLE
feat(dracut): remove old dracut.conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,6 @@ install: all
 	install -m 0755 dracut.sh $(DESTDIR)$(bindir)/dracut
 	install -m 0755 dracut-catimages.sh $(DESTDIR)$(bindir)/dracut-catimages
 	install -m 0755 lsinitrd.sh $(DESTDIR)$(bindir)/lsinitrd
-	install -m 0644 dracut.conf $(DESTDIR)$(sysconfdir)/dracut.conf
 	mkdir -p $(DESTDIR)$(sysconfdir)/dracut.conf.d
 	mkdir -p $(DESTDIR)$(pkglibdir)/dracut.conf.d
 	install -m 0755 dracut-init.sh $(DESTDIR)$(pkglibdir)/dracut-init.sh

--- a/dracut.conf
+++ b/dracut.conf
@@ -1,3 +1,0 @@
-# PUT YOUR CONFIG IN separate files
-# in /etc/dracut.conf.d named "<name>.conf"
-# SEE man dracut.conf(5) for options

--- a/dracut.sh
+++ b/dracut.sh
@@ -152,8 +152,6 @@ Creates initial ramdisk images for preloading modules
                          6 - trace info (and even more)
   -v, --verbose         Increase verbosity level.
   -q, --quiet           Decrease verbosity level.
-  -c, --conf [FILE]     Specify configuration file to use.
-                         Default: /etc/dracut.conf
   --confdir [DIR]       Specify configuration directory to use *.conf files
                          from. Default: /etc/dracut.conf.d
   --tmpdir [DIR]        Temporary directory to be used instead of default
@@ -371,7 +369,7 @@ rearrange_params() {
     TEMP=$(
         unset POSIXLY_CORRECT
         getopt \
-            -o "a:m:o:d:I:k:c:r:L:fvqlHhMNp" \
+            -o "a:m:o:d:I:k:r:L:fvqlHhMNp" \
             --long kver: \
             --long add: \
             --long force-add: \
@@ -394,7 +392,6 @@ rearrange_params() {
             --long nofscks \
             --long ro-mnt \
             --long kmoddir: \
-            --long conf: \
             --long confdir: \
             --long tmpdir: \
             --long sysroot: \
@@ -661,11 +658,6 @@ while :; do
             PARMS_TO_STORE+=" '$2'"
             shift
             ;;
-        -c | --conf)
-            conffile="$2"
-            PARMS_TO_STORE+=" '$2'"
-            shift
-            ;;
         --confdir)
             confdir="$2"
             PARMS_TO_STORE+=" '$2'"
@@ -898,18 +890,6 @@ export DRACUT_LOG_LEVEL=warning
 
 [[ $dracutbasedir ]] || dracutbasedir="$dracutsysrootdir"/usr/lib/dracut
 
-# if we were not passed a config file, try the default one
-if [[ -z $conffile ]]; then
-    if [[ $allowlocal ]]; then
-        conffile="$dracutbasedir/dracut.conf"
-    else
-        conffile="$dracutsysrootdir/etc/dracut.conf"
-    fi
-elif [[ ! -e $conffile ]]; then
-    printf "%s\n" "dracut: Configuration file '$conffile' not found." >&2
-    exit 1
-fi
-
 if [[ -z $confdir ]]; then
     if [[ $allowlocal ]]; then
         confdir="$dracutbasedir/dracut.conf.d"
@@ -919,13 +899,6 @@ if [[ -z $confdir ]]; then
 elif [[ ! -d $confdir ]]; then
     printf "%s\n" "dracut: Configuration directory '$confdir' not found." >&2
     exit 1
-fi
-
-# source our config file
-if [[ -f $conffile ]]; then
-    check_conf_file "$conffile"
-    # shellcheck disable=SC1090
-    . "$conffile"
 fi
 
 # source our config dir

--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -299,12 +299,6 @@ example:
 **-q, --quiet**::
     Decrease verbosity level (default is info(4)).
 
-**-c, --conf** _<dracut configuration file>_::
-    Specify configuration file to use.
-+
-Default:
-   _/etc/dracut.conf_
-
 **--confdir** _<configuration directory>_::
     Specify configuration directory to use.
 +
@@ -716,14 +710,11 @@ _/tmp/dracut.log_::
     logfile of initramfs image creation, if _/var/log/dracut.log_ is not
     writable
 
-_/etc/dracut.conf_::
-    see dracut.conf5
-
 _/etc/dracut.conf.d/*.conf_::
-    see dracut.conf5
+    see *dracut.conf*(5)
 
 _/usr/lib/dracut/dracut.conf.d/*.conf_::
-    see dracut.conf5
+    see *dracut.conf*(5)
 
 Configuration in the initramfs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/man/dracut.conf.5.asc
+++ b/man/dracut.conf.5.asc
@@ -11,20 +11,18 @@ dracut.conf - configuration file(s) for dracut
 
 SYNOPSIS
 --------
-_/etc/dracut.conf_
 _/etc/dracut.conf.d/\*.conf_
 _/usr/lib/dracut/dracut.conf.d/*.conf_
 
 Description
 -----------
 _dracut.conf_ is loaded during the initialisation phase of dracut. Command line
-parameter will override any values set here.
+parameters will override any values set here.
 
 _*.conf_ files are read from /usr/lib/dracut/dracut.conf.d and
 /etc/dracut.conf.d. Files with the same name in /etc/dracut.conf.d will replace
-files in /usr/lib/dracut/dracut.conf.d.
-The files are then read in alphanumerical order and will override parameters
-set in _/etc/dracut.conf_. Each line specifies an attribute and a value. A '#'
+files in /usr/lib/dracut/dracut.conf.d. The files are then read in
+alphanumerical order. Each line specifies an attribute and a value. A '#'
 indicates the beginning of a comment; following characters, up to the end of the
 line are not interpreted.
 
@@ -317,13 +315,8 @@ Logging levels:
 
 Files
 -----
-_/etc/dracut.conf_::
-    Old configuration file. You better use your own file in
-    _/etc/dracut.conf.d/_.
-
 _/etc/dracut.conf.d/_::
-    Any _/etc/dracut.conf.d/*.conf_ file can override the values in
-    _/etc/dracut.conf_. The configuration files are read in alphanumerical
+    Configuration files _/etc/dracut.conf.d/*.conf_ are read in alphanumerical
     order.
 
 AUTHOR

--- a/man/dracut.usage.asc
+++ b/man/dracut.usage.asc
@@ -62,7 +62,7 @@ include ld.so.conf.d/*.conf
 === Adding dracut Modules
 Some dracut modules are turned off by default and have to be activated manually.
 You can do this by adding the dracut modules to the configuration file
-_/etc/dracut.conf_ or _/etc/dracut.conf.d/myconf.conf_. See *dracut.conf*(5).
+_/etc/dracut.conf.d/myconf.conf_. See *dracut.conf*(5).
 You can also add dracut modules on the command line
 by using the -a or --add option:
 ----
@@ -77,7 +77,7 @@ To see a list of available dracut modules, use the --list-modules option:
 === Omitting dracut Modules
 Sometimes you don't want a dracut module to be included for reasons of speed,
 size or functionality. To do this, either specify the omit_dracutmodules
-variable in the _dracut.conf_ or _/etc/dracut.conf.d/myconf.conf_ configuration
+variable in the _/etc/dracut.conf.d/myconf.conf_ configuration
 file (see *dracut.conf*(5)), or use the -o or --omit option
 on the command line:
 ----
@@ -87,8 +87,8 @@ on the command line:
 === Adding Kernel Modules
 If you need a special kernel module in the initramfs, which is not
 automatically picked up by dracut, you have the use the --add-drivers option
-on the command line or  the drivers variable in  the _/etc/dracut.conf_
-or _/etc/dracut.conf.d/myconf.conf_ configuration file (see *dracut.conf*(5)):
+on the command line or the drivers variable in the
+_/etc/dracut.conf.d/myconf.conf_ configuration file (see *dracut.conf*(5)):
 ----
 # dracut --add-drivers mymod initramfs-with-mymod.img
 ----
@@ -312,7 +312,7 @@ configuration file (e.g. _/boot/grub2/grub.cfg_) or from _/proc/cmdline_.
 obtained booting an old working initramfs or a rescue medium.
 * Turn on dracut debugging (see _the 'debugging dracut' section_), and attach
 the file /run/initramfs/rdsosreport.txt.
-* If you use a dracut configuration file, please include _/etc/dracut.conf_ and
+* If you use a dracut configuration file, please include
 all files in _/etc/dracut.conf.d/*.conf_
 
 [[network-root-device-related-problems]]

--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -10,7 +10,6 @@ provides=('dracut=9999' 'mkinitcpio=9999')
 depends=('bash')
 optdepends=('cryptsetup' 'lvm2')
 makedepends=('libxslt')
-backup=(etc/dracut.conf)
 source=()
 md5sums=()
 

--- a/pkgbuild/dracut.spec
+++ b/pkgbuild/dracut.spec
@@ -287,7 +287,6 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/dracut-install
 %{dracutlibdir}/dracut-util
 %{dracutlibdir}/skipcpio
-%config(noreplace) %{_sysconfdir}/dracut.conf
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?rhel}
 %{dracutlibdir}/dracut.conf.d/01-dist.conf
 %endif

--- a/shell-completion/bash/dracut
+++ b/shell-completion/bash/dracut
@@ -38,11 +38,11 @@ _dracut() {
             --hostonly-i18n --no-hostonly-i18n --lzo --lz4 --no-reproducible
             --no-uefi --no-machineid --version --parallel
             '
-        [ARG]='-a -m -o -d -I -k -c -L -r -i
+        [ARG]='-a -m -o -d -I -k -L -r -i
             --kver --add --force-add --add-drivers --force-drivers
             --omit-drivers --modules --omit --drivers --filesystems --install
             --fwdir --libdirs --fscks --add-fstab --mount --device
-            --kmoddir --conf --confdir --tmpdir --stdlog --compress --prefix
+            --kmoddir --confdir --tmpdir --stdlog --compress --prefix
             --kernel-cmdline --sshkey --persistent-policy --install-optional
             --loginstall --uefi-stub --kernel-image --squash-compressor
             --sysroot --hostonly-mode --hostonly-nics --include --logfile
@@ -57,7 +57,7 @@ _dracut() {
                 comps=$(compgen -d -- "$cur")
                 compopt -o filenames
                 ;;
-            -c | --conf | --sshkey | --add-fstab | --add-device | -I | \
+            --sshkey | --add-fstab | --add-device | -I | \
                 --install | --install-optional | --uefi-splash-image)
                 comps=$(compgen -f -- "$cur")
                 compopt -o filenames


### PR DESCRIPTION
The configuration parameters in `/etc/dracut.conf` are being overridden by `/etc/dracut.conf.d` and `/usr/lib/dracut/dracut.conf.d`, which should be the opposite, the place for the user to override distribution/package configuration.

Since the user can set his own configuration in `/etc/dracut.conf.d/*.conf`, and this file only creates confusion (and bug reports in downstream distributions), we can get rid of it.

The other option would be to source it after all the dracut.conf.d snippets, but we should do something with it. This topic was already discussed a long time ago on the kernel mailing list:
- https://marc.info/?l=initramfs&m=129863757626118&w=2 
- https://marc.info/?l=initramfs&m=126882349907058&w=2

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
