### PR TITLE
fix(dracut): allow to set persistent policy based on /dev/mapper device names

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -198,8 +198,9 @@ Creates initial ramdisk images for preloading modules
                          necessary network drivers.
   --persistent-policy [POLICY]
                         Use [POLICY] to address disks and partitions.
-                         POLICY can be any directory name found in /dev/disk.
-                         E.g. "by-uuid", "by-label"
+                         POLICY can be any directory name found in /dev/disk
+                         (e.g. "by-uuid", "by-label"), or "mapper" to use
+                         /dev/mapper device names (default).
   --fstab               Use /etc/fstab to determine the root device.
   --add-fstab [FILE]    Add file to the initramfs fstab.
   --mount "[DEV] [MP] [FSTYPE] [FSOPTS]"
@@ -1293,6 +1294,13 @@ else
     printf "%s\n" "dracut: Are you running from a git checkout?" >&2
     printf "%s\n" "dracut: Try passing -l as an argument to $dracut_cmd" >&2
     exit 1
+fi
+
+if [[ $persistent_policy == "mapper" ]]; then
+    unset persistent_policy
+elif [[ -n $persistent_policy && ! -d "/dev/disk/${persistent_policy}" ]]; then
+    dwarn "Invalid persistent policy, your system does not have a /dev/disk/${persistent_policy} directory."
+    unset persistent_policy
 fi
 
 if [[ $enhanced_cpio == "yes" ]]; then

--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -391,8 +391,8 @@ Default:
 
 **--persistent-policy** _<policy>_::
     Use _<policy>_ to address disks and partitions.
-    _<policy>_ can be any directory name found in /dev/disk.
-    E.g. "by-uuid", "by-label"
+    _<policy>_ can be any directory name found in /dev/disk (e.g. "by-uuid",
+    "by-label"), or "mapper" to use /dev/mapper device names (default).
 
 **--fstab**::
     Use _/etc/fstab_ instead of _/proc/self/mountinfo_.

--- a/man/dracut.conf.5.asc
+++ b/man/dracut.conf.5.asc
@@ -142,8 +142,8 @@ Configuration files must have the extension .conf; other extensions are ignored.
 
 *persistent_policy=*"__<policy>__"::
     Use _<policy>_ to address disks and partitions.
-    _<policy>_ can be any directory name found in /dev/disk.
-    E.g. "by-uuid", "by-label"
+    _<policy>_ can be any directory name found in /dev/disk (e.g. "by-uuid",
+    "by-label"), or "mapper" to use /dev/mapper device names (default=mapper).
 
 *tmpdir=*"__<temporary directory>__"::
     Specify temporary directory to use.


### PR DESCRIPTION
Currently, dracut only allows to configure the persistent policy to address
disks and partitions using any directory name found in `/dev/disk`, but there is
no defined way to set the default policy based on `/dev/mapper` device names. So,
for example, if the persistent policy is set by the distribution in any
configuration file, the user cannot set the default if he wants to.

The current workaround is to set `persistent_policy=""` in a conf file or pass
`--persistent-policy " "` (white space) as an argument. This patch aims to
establish a specific value for this case.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
