### PR TITLE
fix(i18n): do not fail if FONT in /etc/vconsole.conf has the file extension

### DIFF
--- a/modules.d/10i18n/module-setup.sh
+++ b/modules.d/10i18n/module-setup.sh
@@ -222,8 +222,12 @@ install() {
         inst_opt_decompress "${kbddir}"/consolefonts/"${DEFAULT_FONT}".*
 
         if [[ ${FONT} ]] && [[ ${FONT} != "${DEFAULT_FONT}" ]]; then
-            FONT=${FONT%.psf*}
-            inst_opt_decompress "${kbddir}"/consolefonts/"${FONT}".*
+            if [[ -f "${kbddir}"/consolefonts/"${FONT}" ]]; then
+                inst_opt_decompress "${kbddir}"/consolefonts/"${FONT}"
+            else
+                FONT=${FONT%.psf*}
+                inst_opt_decompress "${kbddir}"/consolefonts/"${FONT}".*
+            fi
         fi
 
         if [[ ${FONT_MAP} ]]; then


### PR DESCRIPTION
If the `FONT` option defined in `/etc/vconsole.conf` refers to a file with its
extension, not just the file name, dracut should not fail and install it. The
`systemd-vconsole-setup` service ends up calling `setfont`, which supports both file
names and files with extensions.

Example:
```
# grep -w FONT /etc/vconsole.conf
FONT=b.fnt
# ls -l /usr/share/kbd/consolefonts/b.fnt*
-rw-r--r-- 1 root root 4096 Aug 24 15:21 /usr/share/kbd/consolefonts/b.fnt
# dracut -f --stdlog 3
dracut-install: ERROR: installing '/usr/share/kbd/consolefonts/b.fnt.*'
dracut: FAILED: /usr/lib/dracut/dracut-install -D /var/tmp/dracut.K4WIyf/initramfs /usr/share/kbd/consolefonts/b.fnt.*
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
