### PR TITLE
tpm2-tools is required for crypt module to work

### DIFF
--- a/pkgbuild/dracut.spec
+++ b/pkgbuild/dracut.spec
@@ -77,6 +77,7 @@ Recommends: memstrack
 Recommends: hardlink
 Recommends: pigz
 Recommends: kpartx
+Recommends: (tpm2-tools if tpm2-tss)
 Requires: util-linux >= 2.21
 Requires: systemd >= 219
 Requires: systemd-udev >= 219


### PR DESCRIPTION
tpm2-tools dependency can be can be pulled in case tmp2-tss package is installed, using a soft conditional dependency.

https://bugzilla.redhat.com/show_bug.cgi?id=2077697