### PR TITLE
fix(dracut-initramfs-restore.sh): fix initramfs path detection

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -27,14 +27,14 @@ fi
 
 mount -o ro /boot &> /dev/null || true
 
-if [[ -d /efi/loader/entries ]] || [[ -L /efi/loader/entries ]] \
-    || [[ -d /efi/$MACHINE_ID ]] || [[ -L /efi/$MACHINE_ID ]]; then
+if [[ -d /efi/loader/entries || -L /efi/loader/entries ]] \
+    && [[ -d /efi/$MACHINE_ID || -L /efi/$MACHINE_ID ]]; then
     IMG="/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
-elif [[ -d /boot/loader/entries ]] || [[ -L /boot/loader/entries ]] \
-    || [[ -d /boot/$MACHINE_ID ]] || [[ -L /boot/$MACHINE_ID ]]; then
+elif [[ -d /boot/loader/entries || -L /boot/loader/entries ]] \
+    && [[ -d /boot/$MACHINE_ID || -L /boot/$MACHINE_ID ]]; then
     IMG="/boot/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
-elif [[ -d /boot/efi/loader/entries ]] || [[ -L /boot/efi/loader/entries ]] \
-    || [[ -d /boot/efi/$MACHINE_ID ]] || [[ -L /boot/efi/$MACHINE_ID ]]; then
+elif [[ -d /boot/efi/loader/entries || -L /boot/efi/loader/entries ]] \
+    && [[ -d /boot/efi/$MACHINE_ID || -L /boot/efi/$MACHINE_ID ]]; then
     IMG="/boot/efi/$MACHINE_ID/$KERNEL_VERSION/initrd"
 elif [[ -f /lib/modules/${KERNEL_VERSION}/initrd ]]; then
     IMG="/lib/modules/${KERNEL_VERSION}/initrd"


### PR DESCRIPTION
The path detection is not working on latest Fedora and some other distros, and fails to extract the initramfs. It seems the if statement is broken by a previous commit, so let's fix it.

Fixes: 3d8e1ad ('fix(dracut-initramfs-restore.sh): add missing default paths')
Signed-off-by: Kairui Song <kasong@tencent.com>


## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes commit 3d8e1ad
