### PR TITLE
fix(systemd): add missing modprobe@.service

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -81,6 +81,7 @@ install() {
         \
         "$systemdsystemunitdir"/sys-kernel-config.mount \
         \
+        "$systemdsystemunitdir"/modprobe@.service \
         "$systemdsystemunitdir"/kmod-static-nodes.service \
         "$systemdsystemunitdir"/systemd-tmpfiles-setup.service \
         "$systemdsystemunitdir"/systemd-tmpfiles-setup-dev.service \
@@ -174,6 +175,8 @@ install() {
             /etc/systemd/journald.conf.d/*.conf \
             /etc/systemd/system.conf \
             /etc/systemd/system.conf.d/*.conf \
+            "$systemdsystemconfdir"/modprobe@.service \
+            "$systemdsystemconfdir/modprobe@.service.d/*.conf" \
             /etc/hosts \
             /etc/hostname \
             /etc/nsswitch.conf \


### PR DESCRIPTION
`sys-kernel-config.mount` needs `modprobe@configfs.service` since systemd v246.7 (https://github.com/systemd/systemd/commit/42cc2855), so the kernel configfs fails to mount in the initrd.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
