### PR TITLE
ci: use CodeQL instead of LGTM

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+---
+# vi: ts=2 sw=2 et:
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-22.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.language }}-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      actions: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['cpp', 'python']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-extended,security-and-quality
+
+      - name: Install dependencies
+        run: |
+          sudo apt -y update
+          sudo apt -y install gcc libsystemd-dev pkgconfig
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
As LGTM is going to be shut down by EOY[0], let's move the code scanning to CodeQL as recommended. Thanks to GH integration the results from such scans will be shown both in the respective PR and in the Security -> Code Scanning tab[1].

[0] https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/
[1] https://github.com/dracutdevs/dracut/security/code-scanning

---

Going through my LGTM dashboard I noticed that dracut has LGTM enabled[0] but without the PR integration[1], hence I'm not sure to what degree you actually utilize the LGTM alerts. In other words - if you don't find LGTM/CodeQL useful, feel free to disregard this PR and just close it.

[0] https://lgtm.com/projects/g/dracutdevs/dracut/
[1] https://lgtm.com/projects/g/dracutdevs/dracut/ci/