### PR TITLE
Nvmf fixes

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -895,7 +895,7 @@ NOTE: letters in the MAC-address must be lowercase!
 
 NVMf
 ~~~~
-**rd.nonvmf=0**::
+**rd.nonvmf**::
     Disable NVMf
 
 **rd.nvmf.hostnqn=**__<hostNQN>__::

--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -909,9 +909,19 @@ NVMf
     _<traddr>_ and the optionally _<host_traddr>_ or _<trsvcid>_.
     The first argument specifies the transport to use; currently only
     'rdma', 'fc', or 'tcp' are supported.
-    The _<traddr>_ parameter can be set to 'auto' to select
-    autodiscovery; in that case all other parameters are ignored.
     This parameter can be specified multiple times.
++
+[listing]
+.Examples
+--
+rd.nvmf.discover=tcp,192.168.10.10,,4420
+rd.nvmf.discover=fc,nn-0x201700a05634f5bf:pn-0x201900a05634f5bf,nn-0x200000109b579ef3:pn-0x100000109b579ef3
+--
+
+**rd.nvmf.discover=fc,auto**::
+    This special syntax determines that Fibre Channel autodiscovery
+    is to be used rather than regular NVMe discovery. It takes precedence
+    over all other _rd.nvmf.discover=_ arguments.
 
 NBD
 ~~~

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -222,6 +222,7 @@ set_ifname() {
     for n in $(getargs ifname=); do
         strstr "$n" "$mac" && echo "${n%%:*}" && return
     done
+    [ ! -f "/tmp/set_ifname_$name" ] || read -r num < "/tmp/set_ifname_$name"
     # otherwise, pick a new name and use that
     while :; do
         num=$((num + 1))
@@ -232,6 +233,7 @@ set_ifname() {
         break
     done
     echo "ifname=$name$num:$mac" >> /etc/cmdline.d/45-ifname.conf
+    echo "$num" > "/tmp/set_ifname_$name"
     echo "$name$num"
 }
 

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -307,7 +307,6 @@ ibft_to_cmdline() {
                 [ -e "${iface}"/hostname ] && read -r hostname < "${iface}"/hostname
                 if [ "$family" = "ipv6" ]; then
                     if [ -n "$ip" ]; then
-                        ip="[$ip]"
                         [ -n "$prefix" ] || prefix=64
                         ip="[${ip}/${prefix}]"
                         mask=

--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -128,7 +128,7 @@ install() {
     inst_script "${moddir}/nvmf-autoconnect.sh" /sbin/nvmf-autoconnect.sh
 
     inst_multiple nvme
-    inst_hook cmdline 99 "$moddir/parse-nvmf-boot-connections.sh"
+    inst_hook cmdline 92 "$moddir/parse-nvmf-boot-connections.sh"
     inst_simple "/etc/nvme/discovery.conf"
     inst_rules /usr/lib/udev/rules.d/71-nvmf-iopolicy-netapp.rules
     inst_rules "$moddir/95-nvmf-initqueue.rules"

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -105,6 +105,6 @@ if [ -f "/etc/nvme/discovery.conf" ]; then
 else
     # No nvme command line arguments present, try autodiscovery
     if [ "$trtype" = "fc" ]; then
-        /sbin/initqueue --finished --onetime --unique --name nvme-fc-autoconnect /sbin/nvmf-autoconnect.sh
+        /sbin/initqueue --settled --onetime --unique --name nvme-fc-autoconnect /sbin/nvmf-autoconnect.sh
     fi
 fi

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -102,9 +102,6 @@ done
 
 if [ -f "/etc/nvme/discovery.conf" ]; then
     /sbin/initqueue --settled --onetime --unique --name nvme-discover /usr/sbin/nvme connect-all
-    if [ "$trtype" = "tcp" ]; then
-        : > /tmp/net."$ifname".did-setup
-    fi
 else
     # No nvme command line arguments present, try autodiscovery
     if [ "$trtype" = "fc" ]; then

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -62,7 +62,9 @@ parse_nvmf_discover() {
         warn "traddr is mandatory for $trtype"
         return 0
     fi
-    if [ "$trtype" = "fc" ]; then
+    if [ "$trtype" = "tcp" ]; then
+        : > /tmp/nvmf_needs_network
+    elif [ "$trtype" = "fc" ]; then
         if [ "$traddr" = "auto" ]; then
             rm /etc/nvme/discovery.conf
             return 1
@@ -71,7 +73,7 @@ parse_nvmf_discover() {
             warn "host traddr is mandatory for fc"
             return 0
         fi
-    elif [ "$trtype" != "rdma" ] && [ "$trtype" != "tcp" ]; then
+    elif [ "$trtype" != "rdma" ]; then
         warn "unsupported transport $trtype"
         return 0
     fi
@@ -99,6 +101,11 @@ for d in $(getargs rd.nvmf.discover -d nvmf.discover=); do
         break
     }
 done
+
+if [ -e /tmp/nvmf_needs_network ]; then
+    echo "rd.neednet=1" > /etc/cmdline.d/nvmf-neednet.conf
+    rm -f /tmp/nvmf_needs_network
+fi
 
 # Host NQN and host id are mandatory for NVMe-oF
 if [ -f "/etc/nvme/hostnqn" ] && [ -f "/etc/nvme/hostid" ]; then

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -24,7 +24,7 @@ if getargbool 0 rd.nonvmf; then
     return 0
 fi
 
-initqueue --onetime modprobe --all -b -q nvme nvme_tcp nvme_core nvme_fabrics
+initqueue --onetime modprobe --all -b -q nvme_tcp nvme_core nvme_fabrics
 
 parse_nvmf_discover() {
     traddr="none"

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -101,12 +101,12 @@ for d in $(getargs rd.nvmf.discover -d nvmf.discover=); do
 done
 
 # Host NQN and host id are mandatory for NVMe-oF
-[ -f "/etc/nvme/hostnqn" ] || exit 0
-[ -f "/etc/nvme/hostid" ] || exit 0
+if [ -f "/etc/nvme/hostnqn" ] && [ -f "/etc/nvme/hostid" ]; then
 
-# If no nvme command line arguments present, try autodiscovery
-if [ $NVMF_FC_AUTO ] || [ ! -f "/etc/nvme/discovery.conf" ]; then
-    /sbin/initqueue --settled --onetime --unique --name nvme-fc-autoconnect /sbin/nvmf-autoconnect.sh
-else
-    /sbin/initqueue --settled --onetime --unique --name nvme-discover /usr/sbin/nvme connect-all
+    # If no nvme command line arguments present, try autodiscovery
+    if [ $NVMF_FC_AUTO ] || [ ! -f "/etc/nvme/discovery.conf" ]; then
+        /sbin/initqueue --settled --onetime --unique --name nvme-fc-autoconnect /sbin/nvmf-autoconnect.sh
+    else
+        /sbin/initqueue --settled --onetime --unique --name nvme-discover /usr/sbin/nvme connect-all
+    fi
 fi


### PR DESCRIPTION
A series of minor (but important) changes for NVMeoF boot. Re-spin of the previous PR.

## Changes

Antonio Alvarez Feijoo (1):
      fix(nvmf): nvme list-subsys prints the address using commas as separator

Martin Wilck (12):
      fix(nvmf): don't try to validate network connections in cmdline hook
      fix(nvmf): no need to load the nvme module
      fix(nvmf): don't create did-setup file
      fix(nvmf): don't use "finished" queue for autoconnect
      fix(nvmf): make sure "rd.nvmf.discover=fc,auto" takes precedence
      fix(nvmf): avoid calling "exit" in a cmdline hook
      fix(nvmf): run cmdline hook before parse-ip-opts.sh
      fix(network): don't use same ifname multiple times
      fix(man): dracut.cmdline(7): correct syntax for rd.nonvmf
      feat(nvmf): set rd.neednet=1 if tcp records encountered
      fix(network): avoid double brackets around IPv6 address
      fix(man): dracut.cmdline.7: clarify "rd.nvmf.discover=fc,auto"


## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
