### PR TITLE
Add new dmsquash-live-autooverlay module

### DIFF
--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -27,7 +27,7 @@ jobs:
             options: "--privileged -v /dev:/dev"
         steps:
             -   name: "Checkout Repository"
-                uses: actions/checkout@v2
+                uses: actions/checkout@v1
                 with:
                     fetch-depth: 0
 

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -142,7 +142,7 @@ dracut_install_dir/modules.d/
 	 This function of module-setup.sh is called to install all
 	 non-kernel files. dracut supplies several install functions that are
 	 specialized for different file types.  Browse through dracut-functions
-	 fore more details.  dracut also provides a $moddir variable if you
+	 for more details.  dracut also provides a $moddir variable if you
 	 need to install a file from the module directory, such as an initrd
 	 hook, a udev rule, or a specialized executable.
 

--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1171,6 +1171,10 @@ rd.live.overlay=/dev/sdb1:persistent-overlay.img
 rd.live.overlay=UUID=99440c1f-8daa-41bf-b965-b7240a8996f4
 --
 
+**rd.live.overlay.cowfs=**__[btrfs|ext4|xfs]__::
+Specifies the filesystem to use when formatting the overlay partition.
+The default is ext4.
+
 **rd.live.overlay.size=**__<size_MiB>__::
 Specifies a non-persistent Device-mapper overlay size in MiB.  The default is
 _32768_.

--- a/modules.d/90dmsquash-live-autooverlay/create-overlay-genrules.sh
+++ b/modules.d/90dmsquash-live-autooverlay/create-overlay-genrules.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# shellcheck disable=SC2154
+case "$root" in
+    live:/dev/*)
+        printf 'SYMLINK=="%s", RUN+="/sbin/initqueue --settled --onetime --unique /sbin/create-overlay %s"\n' \
+            "${root#live:/dev/}" "${root#live:}" >> /etc/udev/rules.d/95-create-overlay.rules
+        wait_for_dev -n "${root#live:}"
+        ;;
+esac

--- a/modules.d/90dmsquash-live-autooverlay/create-overlay.sh
+++ b/modules.d/90dmsquash-live-autooverlay/create-overlay.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+
+type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if getargbool 0 rd.live.debug -n -y rdlivedebug; then
+    exec > /tmp/create-overlay.$$.out
+    exec 2>> /tmp/create-overlay.$$.out
+    set -x
+fi
+
+gatherData() {
+    overlay=$(getarg rd.live.overlay)
+    if [ -z "$overlay" ]; then
+        info "Skipping overlay creation: kernel command line parameter 'rd.live.overlay' is not set"
+        exit 0
+    fi
+    # shellcheck disable=SC2086
+    if ! str_starts ${overlay} LABEL=; then
+        die "Overlay creation failed: the partition must be set by LABEL in the 'rd.live.overlay' kernel parameter"
+    fi
+
+    overlayLabel=${overlay#LABEL=}
+    # shellcheck disable=SC2086
+    if [ -b /dev/disk/by-label/${overlayLabel} ]; then
+        info "Skipping overlay creation: overlay already exists"
+        exit 0
+    fi
+
+    filesystem=$(getarg rd.live.overlay.cowfs)
+    [ -z "$filesystem" ] && filesystem="ext4"
+    if [ "$filesystem" != "ext4" ] && [ "$filesystem" != "xfs" ] && [ "$filesystem" != "btrfs" ]; then
+        die "Overlay creation failed: only ext4, xfs, and btrfs are supported in the 'rd.live.overlay.cowfs' kernel parameter"
+    fi
+
+    live_dir=$(getarg rd.live.dir)
+    [ -z "$live_dir" ] && live_dir="LiveOS"
+
+    [ -z "$1" ] && exit 1
+    rootDevice=$1
+
+    # The kernel command line's 'root=' parameter was parsed into the $root variable by the dmsquash-live module.
+    # $root contains the path to a symlink within /dev/disk/by-label, which points to a partition.
+    # This script needs that partition's parent block device.
+    # shellcheck disable=SC2046
+    # shellcheck disable=SC2086
+    rootDeviceAbsolutePath=$(readlink -f ${rootDevice})
+    rootDeviceSysfsPath=/sys/class/block/${rootDeviceAbsolutePath##*/}
+    if [ -f "${rootDeviceSysfsPath}/partition" ]; then
+        # shellcheck disable=SC2086
+        partition=$(cat ${rootDeviceSysfsPath}/partition)
+    else
+        partition=0
+    fi
+    # shellcheck disable=SC2086
+    readonly=$(cat ${rootDeviceSysfsPath}/ro)
+    # shellcheck disable=SC2086
+    if [ "$partition" != "1" ] || [ "$readonly" != "0" ]; then
+        info "Skipping overlay creation: unpartitioned or read-only media detected"
+        exit 0
+    fi
+    # shellcheck disable=SC2046
+    # shellcheck disable=SC2086
+    fullDriveSysfsPath=$(readlink -f ${rootDeviceSysfsPath}/..)
+    blockDevice=/dev/${fullDriveSysfsPath##*/}
+    currentPartitionCount=$(grep --count -E "${blockDevice#/dev/}[0-9]+" /proc/partitions)
+
+    # shellcheck disable=SC2086
+    freeSpaceStart=$(parted --script ${blockDevice} unit % print free \
+        | awk -v x=${currentPartitionCount} '$1 == x {getline; print $1}')
+    if [ -z "$freeSpaceStart" ]; then
+        info "Skipping overlay creation: there is no free space after the last partition"
+        exit 0
+    fi
+    partitionStart=$((${freeSpaceStart%.*} + 1))
+    if [ $partitionStart -eq 100 ]; then
+        info "Skipping overlay creation: there is not enough free space after the last partition"
+        exit 0
+    fi
+
+    overlayPartition=${blockDevice}$((currentPartitionCount + 1))
+
+    label=$(blkid --match-tag LABEL --output value "$rootDevice")
+    uuid=$(blkid --match-tag UUID --output value "$rootDevice")
+    if [ -z "$label" ] || [ -z "$uuid" ]; then
+        die "Overlay creation failed: failed to look up root device label and UUID"
+    fi
+}
+
+createPartition() {
+    # shellcheck disable=SC2086
+    parted --script --align optimal ${blockDevice} mkpart primary ${partitionStart}% 100%
+}
+
+createFilesystem() {
+    # shellcheck disable=SC2086
+    mkfs.${filesystem} -L ${overlayLabel} ${overlayPartition}
+
+    baseDir=/run/initramfs/create-overlayfs
+    mkdir -p ${baseDir}
+    # shellcheck disable=SC2086
+    mount -t auto ${overlayPartition} ${baseDir}
+
+    mkdir -p ${baseDir}/${live_dir}/ovlwork
+    # shellcheck disable=SC2086
+    mkdir ${baseDir}/${live_dir}/overlay-${label}-${uuid}
+
+    umount ${baseDir}
+    rm -r ${baseDir}
+}
+
+main() {
+    gatherData "$1"
+    createPartition
+    udevsettle
+    createFilesystem
+    udevsettle
+}
+
+main "$1"

--- a/modules.d/90dmsquash-live-autooverlay/module-setup.sh
+++ b/modules.d/90dmsquash-live-autooverlay/module-setup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+check() {
+    # including a module dedicated to live environments in a host-only initrd doesn't make sense
+    [[ $hostonly ]] && return 1
+    return 255
+}
+
+depends() {
+    echo dmsquash-live
+    return 0
+}
+
+installkernel() {
+    instmods btrfs ext4 xfs
+}
+
+install() {
+    inst_multiple awk blkid cat grep mkdir mount parted readlink rmdir tr umount
+    inst_multiple -o mkfs.btrfs mkfs.ext4 mkfs.xfs
+    # shellcheck disable=SC2154
+    inst_hook pre-udev 25 "$moddir/create-overlay-genrules.sh"
+    inst_script "$moddir/create-overlay.sh" "/sbin/create-overlay"
+    dracut_need_initqueue
+}

--- a/pkgbuild/dracut.spec
+++ b/pkgbuild/dracut.spec
@@ -142,7 +142,7 @@ Requires: %{name} >= %{version}-%{dist_free_release}
 Requires: %{name} = %{version}-%{release}
 %endif
 Requires: %{name}-network = %{version}-%{release}
-Requires: tar gzip coreutils bash device-mapper curl
+Requires: tar gzip coreutils bash device-mapper curl parted
 %if 0%{?fedora}
 Requires: fuse ntfs-3g
 %endif
@@ -466,6 +466,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %files live
 %{dracutlibdir}/modules.d/99img-lib
 %{dracutlibdir}/modules.d/90dmsquash-live
+%{dracutlibdir}/modules.d/90dmsquash-live-autooverlay
 %{dracutlibdir}/modules.d/90dmsquash-live-ntfs
 %{dracutlibdir}/modules.d/90livenet
 

--- a/test/TEST-16-DMSQUASH/create-root.sh
+++ b/test/TEST-16-DMSQUASH/create-root.sh
@@ -11,9 +11,17 @@ udevadm control --reload
 set -e
 
 udevadm settle
-mkfs.ext4 -q -L dracut /dev/disk/by-id/ata-disk_root
+
+# create a single partition using 50% of the capacity of the image file created by test_setup() in test.sh
+sfdisk /dev/disk/by-id/ata-disk_root << EOF
+2048,161792
+EOF
+
+udevadm settle
+
+mkfs.ext4 -q -L dracut /dev/disk/by-id/ata-disk_root-part1
 mkdir -p /root
-mount /dev/disk/by-id/ata-disk_root /root
+mount /dev/disk/by-id/ata-disk_root-part1 /root
 mkdir -p /root/run /root/testdir
 cp -a -t /root /source/*
 echo "Creating squashfs"

--- a/test/TEST-16-DMSQUASH/test-init.sh
+++ b/test/TEST-16-DMSQUASH/test-init.sh
@@ -9,6 +9,12 @@ exec > /dev/console 2>&1
 
 echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 
+if grep -qF ' rd.live.overlay=LABEL=persist ' /proc/cmdline; then
+    # Writing to a file in the root filesystem lets test_run() verify that the autooverlay module successfully created
+    # and formatted the overlay partition and that the dmsquash-live module used it when setting up the rootfs overlay.
+    echo "dracut-autooverlay-success" > /overlay-marker
+fi
+
 export TERM=linux
 export PS1='initramfs-test:\w\$ '
 [ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab

--- a/test/container/Dockerfile-Arch
+++ b/test/container/Dockerfile-Arch
@@ -12,7 +12,7 @@ RUN pacman --noconfirm -Sy \
     linux dash strace dhclient asciidoc cpio pigz squashfs-tools \
     qemu btrfs-progs mdadm dmraid nfs-utils nfsidmap lvm2 nbd \
     dhcp networkmanager multipath-tools vi tcpdump open-iscsi \
-    git shfmt shellcheck astyle which base-devel glibc && yes | pacman -Scc
+    git shfmt shellcheck astyle which base-devel glibc parted && yes | pacman -Scc
 
 RUN useradd -m build
 RUN su build -c 'cd && git clone https://aur.archlinux.org/perl-config-general.git && cd perl-config-general && makepkg -s --noconfirm'

--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -44,6 +44,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && DEBIAN_FRONTEND=nonintera
     network-manager \
     nfs-kernel-server \
     open-iscsi \
+    parted \
     pigz \
     pkg-config \
     procps \

--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -49,6 +49,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     which \
     ShellCheck \
     shfmt \
+    parted \
     && dnf -y update && dnf clean all
 
 # Set default command

--- a/test/container/Dockerfile-Gentoo
+++ b/test/container/Dockerfile-Gentoo
@@ -17,13 +17,18 @@ LABEL RUN="docker run -it --name NAME --privileged --ipc=host --net=host --pid=h
 
 RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)' > /etc/profile.d/dracut-test.sh
 
+# Only install `dmsetup`: attempting to install all of lvm2 fails due to missing kernel headers.
+RUN echo 'sys-fs/lvm2 device-mapper-only -thin' > /etc/portage/package.use/lvm2
+
 # Install needed packages for the dracut CI container
 RUN emerge -qv \
     app-arch/cpio \
     app-emulation/qemu \
     app-shells/dash \
     sys-apps/busybox \
+    sys-block/parted \
     sys-fs/btrfs-progs \
+    sys-fs/lvm2 \
     sys-fs/squashfs-tools \
     && rm -rf /var/cache/* /usr/share/doc/* /usr/share/man/* /var/db/repos/gentoo
 

--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -13,7 +13,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     strace libkmod-devel gcc bzip2 xz tar wget rpm-build make git bash-completion \
     sudo kernel dhcp-client qemu-kvm /usr/bin/qemu-system-$(uname -m) e2fsprogs \
     tcpdump iproute iputils kbd NetworkManager btrfsprogs tgt dbus-broker \
-    iscsiuio open-iscsi which ShellCheck procps pigz \
+    iscsiuio open-iscsi which ShellCheck procps pigz parted squashfs \
     && dnf -y update && dnf clean all
 
 RUN shfmt_version=3.2.4; wget "https://github.com/mvdan/sh/releases/download/v${shfmt_version}/shfmt_v${shfmt_version}_linux_amd64" -O /usr/local/bin/shfmt \


### PR DESCRIPTION
This pull request introduces a new module that creates a partition for overlayfs usage in the free space on the root filesystem's parent block device.

Ubuntu 20.04 (the `main` branch) and Fedora 36 (the `fedora-36` branch) Kiwi image descriptions that produce ISO images that demonstrate this feature are available in this repository:
https://github.com/iammattcoleman/overlay-test

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [X] I am providing new code and test(s) for it
