### PR TITLE
feat(systemd-portabled): introducing the systemd-portabled module

### DIFF
--- a/modules.d/01systemd-portabled/module-setup.sh
+++ b/modules.d/01systemd-portabled/module-setup.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Prerequisite check(s) for module.
+check() {
+
+    # If the binary(s) requirements are not fulfilled the module can't be installed.
+    require_binaries \
+        portablectl \
+        "$systemdutildir"/systemd-portabled \
+        || return 1
+
+    # Return 255 to only include the module, if another module requires it.
+    return 255
+
+}
+
+# Module dependency requirements.
+depends() {
+
+    # This module has external dependency on other module(s).
+    echo dbus
+    # Return 0 to include the dependent module(s) in the initramfs.
+    return 0
+
+}
+
+# Install kernel module(s).
+installkernel() {
+    instmods loop squashfs
+}
+
+# Install the required file(s) and directories for the module in the initramfs.
+install() {
+
+    # It's intended to work only with raw binary disk images contained in
+    # regular files, but not with directory trees.
+    local _nonraw
+    _nonraw=$(portablectl --no-pager --no-legend list | grep -v " raw " | cut -d ' ' -f1 | tr '\n' ' ')
+    if [ -n "$_nonraw" ]; then
+        dwarn "systemd-portabled: this module only installs raw disk images in the initramfs; skipping: $_nonraw"
+    fi
+
+    inst_multiple -o \
+        "/var/lib/portables/*.raw" \
+        "/usr/lib/portables/*.raw" \
+        "$tmpfilesdir/portables.conf" \
+        "$dbussystem"/org.freedesktop.portable1.conf \
+        "$dbussystemservices"/org.freedesktop.portable1.service \
+        "$systemdutildir"/systemd-portabled \
+        "$systemdutildir/portable/profile/default/*.conf" \
+        "$systemdutildir/portable/profile/nonetwork/*.conf" \
+        "$systemdutildir/portable/profile/strict/*.conf" \
+        "$systemdutildir/portable/profile/trusted/*.conf" \
+        "$systemdsystemunitdir"/systemd-portabled.service \
+        "$systemdsystemunitdir/systemd-portabled.service.d/*.conf" \
+        "$systemdsystemunitdir"/dbus-org.freedesktop.portable1.service \
+        portablectl
+
+    # The existence of this file is required
+    touch "$initdir"/etc/resolv.conf
+
+    # Enable systemd type unit(s)
+    $SYSTEMCTL -q --root "$initdir" add-wants initrd.target systemd-portabled.service
+    $SYSTEMCTL -q --root "$initdir" enable systemd-portabled.service
+
+    # Install the hosts local user configurations if enabled.
+    if [[ $hostonly ]]; then
+        inst_multiple -H -o \
+            "/etc/portables/*.raw" \
+            "$systemdutilconfdir/system.attached/*" \
+            "$systemdutilconfdir/system.attached/*/*" \
+            "$systemdutilconfdir/portable/profile/default/*.conf" \
+            "$systemdutilconfdir/portable/profile/nonetwork/*.conf" \
+            "$systemdutilconfdir/portable/profile/strict/*.conf" \
+            "$systemdutilconfdir/portable/profile/trusted/*.conf" \
+            "$systemdsystemconfdir"/systemd-portabled.service \
+            "$systemdsystemconfdir/systemd-portabled.service.d/*.conf"
+    fi
+
+}

--- a/modules.d/01systemd-tmpfiles/module-setup.sh
+++ b/modules.d/01systemd-tmpfiles/module-setup.sh
@@ -25,7 +25,6 @@ depends() {
 install() {
 
     # Excluding "$tmpfilesdir/home.conf", sets up /home /srv
-    # Excluding "$tmpfilesdir/portables.conf", belongs in seperated portables module
     # Excluding "$tmpfilesdir/journal-nocow.conf", requires spesific btrfs setup
     # Excluding "$tmpfilesdir/legacy.conf", belongs in seperated legacy module
     # Excluding "$tmpfilesdir/systemd-nologin.conf", belongs in seperated pam module

--- a/pkgbuild/dracut.spec
+++ b/pkgbuild/dracut.spec
@@ -329,6 +329,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/modules.d/01systemd-journald
 %{dracutlibdir}/modules.d/01systemd-ldconfig
 %{dracutlibdir}/modules.d/01systemd-modules-load
+%{dracutlibdir}/modules.d/01systemd-portabled
 %{dracutlibdir}/modules.d/01systemd-pstore
 %{dracutlibdir}/modules.d/01systemd-repart
 %{dracutlibdir}/modules.d/01systemd-resolved


### PR DESCRIPTION
Introducing the `systemd-portabled` module.

It works with raw binary disk images contained in regular files, but it's not intended to work with directory trees, like the `systemd-sysext` module.

## Checklist
- [X] I have tested it locally with minimal squashfs images (see https://systemd.io/PORTABLE_SERVICES/#requirements-on-images) and images created with mkosi (e.g. https://github.com/systemd/portable-walkthrough).
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
