### PR TITLE
fix(network-manager): always install the library plugins directory

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -644,6 +644,22 @@ inst_any() {
     return 1
 }
 
+# inst_libdir_dir <dir> [<dir>...]
+# Install a <dir> located on a lib directory to the initramfs image
+inst_libdir_dir() {
+    local -a _dirs
+    for _dir in $libdirs; do
+        for _i in "$@"; do
+            for _d in "$dracutsysrootdir$_dir"/$_i; do
+                [[ -d $_d ]] && _dirs+=("${_d#"$dracutsysrootdir"}")
+            done
+        done
+    done
+    for _dir in "${_dirs[@]}"; do
+        inst_dir "$_dir"
+    done
+}
+
 # inst_libdir_file [-n <pattern>] <file> [<file>...]
 # Install a <file> located on a lib directory to the initramfs image
 # -n <pattern> install matching files

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -61,6 +61,7 @@ install() {
     inst_hook initqueue/settled 99 "$moddir/nm-run.sh"
 
     inst_rules 85-nm-unmanaged.rules
+    inst_libdir_dir "NetworkManager/$_nm_version"
     inst_libdir_file "NetworkManager/$_nm_version/libnm-device-plugin-team.so"
     inst_simple "$moddir/nm-lib.sh" "/lib/nm-lib.sh"
 


### PR DESCRIPTION
The library plugins directory is automatically added to the initrd if either
`libnm-device-plugin-team.so` or `libnm-settings-plugin-ifcfg-rh.so` are present on
the system, but both are optional libraries, and if it does not exist, the
NetworkManager issues a warning, e.g. in openSUSE TW:

```
Sep 28 16:55:29 localhost.localdomain NetworkManager[357]: <warn>  [1664376929.9511] device plugin: failed to open directory /usr/lib64/NetworkManager/1.40.0: Error opening directory “/usr/lib64/NetworkManager/1.40.0”: No such file or directory
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
