### PR TITLE
ci: login and push containers as repository_owner

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -42,13 +42,13 @@ jobs:
                 uses: docker/login-action@v2
                 with:
                     registry: ghcr.io
-                    username: ${{ github.actor }}
+                    username: ${{ github.repository_owner }}
                     password: ${{ secrets.GITHUB_TOKEN }}
-            -   name: Set up env.actor
-                run: echo "actor=${GITHUB_ACTOR,,}" >>${GITHUB_ENV}
+            -   name: Set up env
+                run: echo "repository_owner=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
             -   name: Build and Push Container
                 uses: docker/build-push-action@v3
                 with:
                     file: test/container/${{ matrix.config.dockerfile }}
-                    tags: ghcr.io/${{env.actor}}/${{ matrix.config.tag }}
+                    tags: ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}
                     push: ${{ github.event_name == 'push' ||  github.event_name == 'schedule' }}


### PR DESCRIPTION
After https://github.com/dracutdevs/dracut/commit/b96f1afa4de8d5e4892a96a5047ab7de1f70924d the scheduled container builds (CI jobs) are running under haraldh. I was expecting that these scheduled runs would run under "dracutdevs" as the github.actor instead of haraldh

CI jobs should login in and push containers as github.repository_owner instead of github.actor.
