### PR TITLE
fix(dracut): replace invalid lzo command with lzop for LZO compression

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -805,7 +805,7 @@ while :; do
         --bzip2) compress_l="bzip2" ;;
         --lzma) compress_l="lzma" ;;
         --xz) compress_l="xz" ;;
-        --lzo) compress_l="lzo" ;;
+        --lzo) compress_l="lzop" ;;
         --lz4) compress_l="lz4" ;;
         --zstd) compress_l="zstd" ;;
         --no-compress) _no_compress_l="cat" ;;

--- a/man/dracut.conf.5.asc
+++ b/man/dracut.conf.5.asc
@@ -89,7 +89,7 @@ Configuration files must have the extension .conf; other extensions are ignored.
     Specify additional files to include in the initramfs, separated by spaces,
     if they exist.
 
-*compress=*"__{cat|bzip2|lzma|xz|gzip|lzo|lz4|zstd|<compressor [args ...]>}__"::
+*compress=*"__{cat|bzip2|lzma|xz|gzip|lzop|lz4|zstd|<compressor [args ...]>}__"::
     Compress the generated initramfs using the passed compression program. If
     you pass it just the name of a compression program, it will call that
     program with known-working arguments. If you pass arguments, it will be


### PR DESCRIPTION
Replace invalid lzo command with `lzop` for LZO compression.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1999
