### PR TITLE
90crypt: Look for dm-crypt devices in by-uuid

### DIFF
--- a/modules.d/90crypt/parse-crypt.sh
+++ b/modules.d/90crypt/parse-crypt.sh
@@ -166,7 +166,7 @@ else
             if [ $is_keysource -eq 0 ]; then
                 uuid=$luksid
                 while [ "$uuid" != "${uuid#*-}" ]; do uuid=${uuid%%-*}${uuid#*-}; done
-                printf -- '[ -e /dev/disk/by-id/dm-uuid-CRYPT-LUKS?-*%s*-* ] || exit 1\n' "$uuid" \
+                printf -- '[ -e /dev/disk/by-uuid/*%s* ] || exit 1\n' "$uuid" \
                     >> "$hookdir/initqueue/finished/90-crypt.sh"
                 {
                     printf -- '[ -e /dev/disk/by-uuid/*%s* ] || ' "$luksid"


### PR DESCRIPTION
## Changes

I know very little about Dracut, so I'm not even sure this is remotely sane.  I was just poking around trying to get my setup, which is dm-crypt/LUKS + BTRFS (in a subvolume) working.  I ended up with a grub.cfg that looks sane to me

````
linux   /vmlinuz-5.15.32-gentoo-dist root=/dev/mapper/luks-9924a2f1 ro rootflags=subvol=roots/gentoo crypt_root=UUID=cdeb23b3-62f8-4497-85f5-7a965f41b9e3 rd.luks.uuid=9924a2f1 rd.debug
````

but despite a bunch of attempts at messing around with it I couldn't get anything that would both run cryptsetup and find the resulting LUKS device.  I tried a handful of things like `partuuid` that were indicated to work on the internet, but didn't have any luck.

Happy to provide more information here, I just figured I'd send along the patch as I'm not even sure this is a bug or just a PEBKAC.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
