### PR TITLE
perf(90kernel-modules): use AWK instead of shell monster

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -5,16 +5,6 @@ installkernel() {
     local _blockfuncs='ahci_platform_get_resources|ata_scsi_ioctl|scsi_add_host|blk_cleanup_queue|register_mtd_blktrans|scsi_esp_register|register_virtio_device|usb_stor_disconnect|mmc_add_host|sdhci_add_host|scsi_add_host_with_dma|blk_mq_alloc_disk|blk_cleanup_disk'
     local -A _hostonly_drvs
 
-    find_kernel_modules_external() {
-        local a
-
-        [[ -f "$srcmods/modules.dep" ]] || return 0
-
-        while IFS=: read -r a _ || [[ $a ]]; do
-            [[ $a =~ ^/ ]] && printf "%s\n" "$a"
-        done < "$srcmods/modules.dep"
-    }
-
     record_block_dev_drv() {
 
         for _mod in $(get_dev_module /dev/block/"$1"); do
@@ -105,7 +95,7 @@ installkernel() {
                 "=drivers/scsi/hisi_sas"
         fi
 
-        find_kernel_modules_external | instmods
+        awk -F: '/^\// {print $1}' "$srcmods/modules.dep" 2> /dev/null | instmods
 
         # if not on hostonly mode, or there are hostonly block device
         # install block drivers


### PR DESCRIPTION
Paraphrasing Debian#1017411:

In searching for low-hanging time fruit, I found that 90kernel-modules does
```bash
find_kernel_modules_external() {
    local a

    [[ -f "$srcmods/modules.dep" ]] || return 0

    while IFS=: read -r a _ || [[ $a ]]; do
        [[ $a =~ ^/ ]] && printf "%s\n" "$a"
    done < "$srcmods/modules.dep"
}

find_kernel_modules_external | instmods
```
which after shedding the bashisms is
```sh
grep ^/ "$srcmods/modules.dep" 2> /dev/null | cut -d: -f1 | instmods
```
or
```sh
awk -F: '/^\// {print $1}'  "$srcmods/modules.dep" 2> /dev/null | instmods
```
so
```sh
$ find_kernel_modules_external() {
>     local a
> 
>     [[ -f "$srcmods/modules.dep" ]] || return 0
> 
>     while IFS=: read -r a _ || [[ $a ]]; do
>         [[ $a =~ ^/ ]] && printf "%s\n" "$a"
>     done < "$srcmods/modules.dep"
> }
$ export -f find_kernel_modules_external
$ export srcmods=/lib/modules/5.10.0-17-amd64
$ hyperfine -S'bash --norc' 'find_kernel_modules_external' 'grep ^/ "$srcmods/modules.dep" 2> /dev/null | cut -d: -f1' 'mawk -F: '\''/^\// {print $1}'\''  "$srcmods/modules.dep" 2> /dev/null' 'gawk -F: '\''/^\// {print $1}'\''  "$srcmods/modules.dep" 2> /dev/null'
Benchmark 1: find_kernel_modules_external
  Time (mean ± σ):     121.2 ms ±   4.8 ms    [User: 92.9 ms, System: 28.3 ms]
  Range (min … max):   115.8 ms … 131.2 ms    22 runs

Benchmark 2: grep ^/ "$srcmods/modules.dep" 2> /dev/null | cut -d: -f1
  Time (mean ± σ):       4.0 ms ±   0.3 ms    [User: 3.7 ms, System: 2.0 ms]
  Range (min … max):     2.5 ms …   4.6 ms    648 runs

Benchmark 3: mawk -F: '/^\// {print $1}'  "$srcmods/modules.dep" 2> /dev/null
  Time (mean ± σ):       2.8 ms ±   0.5 ms    [User: 1.8 ms, System: 1.3 ms]
  Range (min … max):     1.3 ms …   3.4 ms    596 runs

Benchmark 4: gawk -F: '/^\// {print $1}'  "$srcmods/modules.dep" 2> /dev/null
  Time (mean ± σ):       6.0 ms ±   0.4 ms    [User: 4.4 ms, System: 2.0 ms]
  Range (min … max):     4.0 ms …   6.9 ms    333 runs

Summary
  'mawk -F: '/^\// {print $1}'  "$srcmods/modules.dep" 2> /dev/null' ran
    1.43 ± 0.29 times faster than 'grep ^/ "$srcmods/modules.dep" 2> /dev/null | cut -d: -f1'
    2.16 ± 0.44 times faster than 'gawk -F: '/^\// {print $1}'  "$srcmods/modules.dep" 2> /dev/null'
   43.53 ± 8.51 times faster than 'find_kernel_modules_external'
```

So on GAWK systems grep|cut is faster and on MAWK systems awk is faster.
Not that it's by much, so it's editor's choice, really.

## Checklist
- [x] I have tested it locally – I've had this on my system since I reported the Debian bug
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it