### PR TITLE
90multipath: install multipathd.socket

### DIFF
--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -137,6 +137,7 @@ install() {
             inst_simple "${moddir}/multipathd-configure.service" "${systemdsystemunitdir}/multipathd-configure.service"
             $SYSTEMCTL -q --root "$initdir" enable multipathd-configure.service
         fi
+        inst_simple "${systemdsystemunitdir}/multipathd.socket"
         inst_simple "${moddir}/multipathd.service" "${systemdsystemunitdir}/multipathd.service"
         $SYSTEMCTL -q --root "$initdir" enable multipathd.service
     else


### PR DESCRIPTION
## Changes

This pull request makes `90multipath` module install `multipathd.socket` from system paths along side with the systemd service unit (which lists the socket as a dependency). Without the socket unit file, systemctl invoked by dracut may report `failed to enable unit` during generation, and the resulting initrd will not have a usable multipathd at early boot.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
