### PR TITLE
ci: upgrade to actions/checkout@v3

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -35,7 +35,7 @@ jobs:
                     - { dockerfile: 'Dockerfile-Gentoo',            tag: 'gentoo:latest' }
         steps:
             -   name: Check out the repo
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
             -   name: Set up Docker Buildx
                 uses: docker/setup-buildx-action@v1
             -   name: Login to GitHub Container Registry

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,7 +28,7 @@ jobs:
             options: "--privileged -v /dev:/dev"
         steps:
             -   name: "Checkout Repository"
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
                 with:
                     fetch-depth: 0
 
@@ -73,7 +73,7 @@ jobs:
             options: "--privileged -v /dev:/dev"
         steps:
             -   name: "Checkout Repository"
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
                 with:
                     fetch-depth: 0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install tools
         run: sudo apt-get install astyle
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: shfmt
         uses: luizm/action-sh-checker@v0.2.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check-out the repo under $GITHUB_WORKSPACE
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Run Commisery
       uses: dracutdevs/commisery-action@master


### PR DESCRIPTION
It resolves the following warning:
Please update the following actions to use Node.js 16: actions/checkout

