### PR TITLE
fix(github): dependabot remove ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,11 @@ version: 2
   updates:
     - package-ecosystem: "github-actions"
       directory: "/"
-      schedule: 
-       interval: weekly
-       day: "tuesday"
+      schedule:
+        interval: weekly
+        day: "tuesday"
       commit-message:
         prefix: "chore(github):"
         include: "scope"
-      ignore:
-        - dependency-name: "Manual test"
+          #ignore:
+          ##- dependency-name: "Manual test"


### PR DESCRIPTION
That's rather unhelpful error msg dependabot...
Removed the ignore line since I suspect it's the name matching that is failing and dependabot files PR for changes so we can just nack those that we dont want to update.
