### PR TITLE
feat(dracut.sh): allow setting output directory of UEFI executable

### DIFF
--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -573,11 +573,9 @@ and no /etc/cmdline/*.conf will be generated into the initramfs.
 **--uefi**::
     Instead of creating an initramfs image, dracut will create an UEFI
     executable, which can be executed by an UEFI BIOS. The default output
-    filename is _<EFI>/EFI/Linux/linux-$kernel$-<MACHINE_ID>-<BUILD_ID>.efi_.
-    <EFI> might be _/efi_, _/boot_ or _/boot/efi_ depending on where the ESP
-    partition is mounted. The <BUILD_ID> is taken from BUILD_ID in
-    _/usr/lib/os-release_ or if it exists _/etc/os-release_ and is left out,
-    if BUILD_ID is non-existant or empty.
+    filename is _linux-$kernel$-<MACHINE_ID>-<BUILD_ID>.efi_. The <BUILD_ID> is
+    taken from BUILD_ID in _/usr/lib/os-release_ or if it exists
+    _/etc/os-release_ and is left out, if BUILD_ID is non-existant or empty.
 
 **--no-uefi**::
     Disables UEFI mode.
@@ -585,6 +583,11 @@ and no /etc/cmdline/*.conf will be generated into the initramfs.
 **--no-machineid**::
     Affects the default output filename of **--uefi** and will discard the
     <MACHINE_ID> part.
+
+**--uefi-outdir _<directory>_**::
+    Create the UEFI executable in _<directory>_ (default=<EFI>/EFI/Linux, where
+    <EFI> might be _/efi_, _/boot_ or _/boot/efi_ depending on where the ESP
+    partition is mounted).
 
 **--uefi-stub _<file>_**::
     Specifies the UEFI stub loader, which will load the attached kernel,

--- a/man/dracut.conf.5.asc
+++ b/man/dracut.conf.5.asc
@@ -268,16 +268,19 @@ Logging levels:
 *uefi=*"__{yes|no}__"::
     Instead of creating an initramfs image, dracut will create an UEFI
     executable, which can be executed by an UEFI BIOS (default=no).
-    The default output filename is
-    _<EFI>/EFI/Linux/linux-$kernel$-<MACHINE_ID>-<BUILD_ID>.efi_.
-    <EFI> might be _/efi_, _/boot_ or _/boot/efi_ depending on where the ESP
-    partition is mounted. The <BUILD_ID> is taken from BUILD_ID in
-    _/usr/lib/os-release_ or if it exists _/etc/os-release_ and is left out,
-    if BUILD_ID is non-existant or empty.
+    The default output filename is _linux-$kernel$-<MACHINE_ID>-<BUILD_ID>.efi_.
+    The <BUILD_ID> is taken from BUILD_ID in _/usr/lib/os-release_ or if it
+    exists _/etc/os-release_ and is left out, if BUILD_ID is non-existant or
+    empty.
 
 *machine_id=*"__{yes|no}__"::
     Affects the default output filename of the UEFI executable, including the
     <MACHINE_ID> part (default=yes).
+
+*uefi_outdir=*"__<directory>__"::
+    Create the UEFI executable in _<directory>_ (default=<EFI>/EFI/Linux, where
+    <EFI> might be _/efi_, _/boot_ or _/boot/efi_ depending on where the ESP
+    partition is mounted).
 
 *uefi_stub=*"_<file>_"::
     Specifies the UEFI stub loader, which will load the attached kernel,

--- a/shell-completion/bash/dracut
+++ b/shell-completion/bash/dracut
@@ -46,7 +46,7 @@ _dracut() {
             --kernel-cmdline --sshkey --persistent-policy --install-optional
             --loginstall --uefi-stub --kernel-image --squash-compressor
             --sysroot --hostonly-mode --hostonly-nics --include --logfile
-            --uefi-splash-image
+            --uefi-splash-image --uefi-outdir
             '
     )
 


### PR DESCRIPTION
Instead of creating the UEFI executable in a hard-coded directory based on where the EFI partition is mounted, allow the output directory to be set using the `--uefi-outdir` command line option or the `uefi_outdir` configuration option.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1926
