### PR TITLE
fix(dmsquash-live-ntfs): remove unnecessary command

### DIFF
--- a/modules.d/90dmsquash-live-ntfs/module-setup.sh
+++ b/modules.d/90dmsquash-live-ntfs/module-setup.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-command -v
-
 check() {
     require_binaries ntfs-3g || return 1
     return 255


### PR DESCRIPTION
Remove unnecessary `command -v` called outside of any functions in dmsquash-live-ntfs/module-setup.sh.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it