### PR TITLE
Drop dmeventd from initramfs

### DIFF
--- a/modules.d/90dm/module-setup.sh
+++ b/modules.d/90dm/module-setup.sh
@@ -22,9 +22,6 @@ install() {
         && inst_hook pre-udev 30 "$moddir/dm-pre-udev.sh"
 
     inst_multiple dmsetup
-    inst_multiple -o dmeventd
-
-    inst_libdir_file "libdevmapper-event.so*"
 
     inst_rules 10-dm.rules 13-dm-disk.rules 95-dm-notify.rules
     # Gentoo ebuild for LVM2 prior to 2.02.63-r1 doesn't install above rules

--- a/modules.d/90lvm/module-setup.sh
+++ b/modules.d/90lvm/module-setup.sh
@@ -89,8 +89,6 @@ install() {
     inst_script "$moddir/lvm_scan.sh" /sbin/lvm_scan
     inst_hook cmdline 30 "$moddir/parse-lvm.sh"
 
-    inst_libdir_file "libdevmapper-event-lvm*.so"
-
     if [[ $hostonly ]] && find_binary lvs &> /dev/null; then
         for dev in "${!host_fs_types[@]}"; do
             [[ -e /sys/block/${dev#/dev/}/dm/name ]] || continue

--- a/test/TEST-17-LVM-THIN/create-root.sh
+++ b/test/TEST-17-LVM-THIN/create-root.sh
@@ -16,9 +16,9 @@ for dev in /dev/disk/by-id/ata-disk_disk[123]; do
 done
 
 lvm vgcreate dracut /dev/disk/by-id/ata-disk_disk[123]
-lvm lvcreate -l 17 -T dracut/mythinpool
-lvm lvcreate -V1G -T dracut/mythinpool -n root
-lvm vgchange -ay
+lvm lvcreate --ignoremonitoring -l 17 -T dracut/mythinpool
+lvm lvcreate --ignoremonitoring -V1G -T dracut/mythinpool -n root
+lvm vgchange --ignoremonitoring -ay
 mke2fs /dev/dracut/root
 mkdir -p /sysroot
 mount /dev/dracut/root /sysroot


### PR DESCRIPTION
devicemapper in the initramfs built on at least Ubuntu 20.04 will currently warn about

  libdevmapper-event-lvm2thin.so dlopen failed:
     libdevmapper-event-lvm2.so.2.03:
       cannot open shared object file: No such file or directory

libdevmapper-event-lvm2.so.2.03 does not have a .so link pointing to it, so it gets missed by the existing
'inst_libdir_file "libdevmapper-event-lvm*.so"'

liblvm2cmd.so.2.03 is a dependency of libdevmapper-event-lvm2.so.2.03. It must be added directly because dracut-install does not resolve library dependencies, it only works for executables. Since dm-eventd dlopen's everything there
is no executable that would cause dracut-install to resolve this.

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [X] I am providing new code and test(s) for it

Fixes #
