### PR TITLE
fix(dracut-logger.sh): fix check for /dev/log

### DIFF
--- a/dracut-logger.sh
+++ b/dracut-logger.sh
@@ -151,7 +151,7 @@ dlog_init() {
             readonly _dlogfd=15
             systemd-cat -t 'dracut' --level-prefix=true < "$_systemdcatfile" &
             exec 15> "$_systemdcatfile"
-        elif ! [[ -S /dev/log ]] && [[ -w /dev/log ]] || ! command -v logger > /dev/null; then
+        elif ! ([[ -S /dev/log ]] && [[ -w /dev/log ]] && command -v logger > /dev/null); then
             # We cannot log to syslog, so turn this facility off.
             kmsgloglvl=$sysloglvl
             sysloglvl=0


### PR DESCRIPTION
The /dev/log check was not correct, it would continue working if /dev/log was a broken symlink. This changes the logic to be more clear -- /dev/log needs to be a socket, and writable, and logger needs to be available. If any of those conditions fail, turn off syslog and only use console logging.

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

