### PR TITLE
fix(90kernel-modules): add (nonstandard) NVMe drivers

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -60,7 +60,7 @@ installkernel() {
 
         if [[ ${DRACUT_ARCH:-$(uname -m)} == arm* || ${DRACUT_ARCH:-$(uname -m)} == aarch64 || ${DRACUT_ARCH:-$(uname -m)} == riscv* ]]; then
             # arm/aarch64 specific modules
-            _blockfuncs+='|dw_mc_probe|dw_mci_pltfm_register'
+            _blockfuncs+='|dw_mc_probe|dw_mci_pltfm_register|nvme_init_ctrl'
             instmods \
                 "=drivers/clk" \
                 "=drivers/devfreq" \


### PR DESCRIPTION
The M1/etc hardware has an quirky NVMe disk controller that needs a dedicated NVMe driver. Rather than picking up just that bit of hardware pick up drivers that register NVMe controllers.

This also picks up NVMe-OF style drivers, but seems like a better long term solution on Arm platforms which tend to have a lot of odd hardware.

Signed-off-by: Jeremy Linton <jlinton@redhat.com>

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
