### PR TITLE
fix(dracut-functions.sh): suppress the findmnt error message when /etc/fstab not exist

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -383,6 +383,7 @@ find_block_device() {
         } && return 0
     fi
     # fall back to /etc/fstab
+    [[ ! -f "$dracutsysrootdir"/etc/fstab ]] && return 1
 
     findmnt -e --fstab -v -n -o 'MAJ:MIN,SOURCE' --target "$_find_mpt" | {
         while read -r _majmin _dev || [ -n "$_dev" ]; do
@@ -433,6 +434,8 @@ find_mp_fstype() {
         } && return 0
     fi
 
+    [[ ! -f "$dracutsysrootdir"/etc/fstab ]] && return 1
+
     findmnt --fstab -e -v -n -o 'FSTYPE' --target "$1" | {
         while read -r _fs || [ -n "$_fs" ]; do
             [[ $_fs ]] || continue
@@ -473,6 +476,8 @@ find_dev_fstype() {
         } && return 0
     fi
 
+    [[ ! -f "$dracutsysrootdir"/etc/fstab ]] && return 1
+
     findmnt --fstab -e -v -n -o 'FSTYPE' --source "$_find_dev" | {
         while read -r _fs || [ -n "$_fs" ]; do
             [[ $_fs ]] || continue
@@ -499,6 +504,8 @@ find_mp_fsopts() {
         findmnt -e -v -n -o 'OPTIONS' --target "$1" 2> /dev/null && return 0
     fi
 
+    [[ ! -f "$dracutsysrootdir"/etc/fstab ]] && return 1
+
     findmnt --fstab -e -v -n -o 'OPTIONS' --target "$1"
 }
 
@@ -521,6 +528,8 @@ find_dev_fsopts() {
     if [[ $use_fstab != yes ]]; then
         findmnt -e -v -n -o 'OPTIONS' --source "$_find_dev" 2> /dev/null && return 0
     fi
+
+    [[ ! -f "$dracutsysrootdir"/etc/fstab ]] && return 1
 
     findmnt --fstab -e -v -n -o 'OPTIONS' --source "$_find_dev"
 }


### PR DESCRIPTION
When the rootfs of a virtual machine is virtiofs shared folder, the /etc/fstab file may not exist. As a result, the "findmnt --fstab" will complain "findmnt: can't read (null): No such file or directory" when trying to rebuild kdump initramfs within the vm.

This patch checks if /etc/fstab exist before calling "findmnt --fstab" to suppress the error message.

Before:
$ kdumpctl rebuild
kdump: Rebuilding /boot/initramfs-5.14.0-182.el9.x86_64kdump.img
findmnt: can't read (null): No such file or directory
findmnt: can't read (null): No such file or directory
findmnt: can't read (null): No such file or directory

After:
$ kdumpctl rebuild
kdump: Rebuilding /boot/initramfs-5.14.0-182.el9.x86_64kdump.img

Signed-off-by: Tao Liu <ltao@redhat.com>

## Changes

## Checklist
- [Y] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
