### PR TITLE
refactor(multipath): do not install the pidof binary

### DIFF
--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -91,7 +91,6 @@ install() {
 
     inst_multiple \
         pkill \
-        pidof \
         kpartx \
         dmsetup \
         multipath \

--- a/modules.d/90multipath/multipathd-needshutdown.sh
+++ b/modules.d/90multipath/multipathd-needshutdown.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+type need_shutdown > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
 for i in $(multipath -l -v1); do
     if dmsetup table "$i" | sed -n '/.*queue_if_no_path.*/q1'; then
         need_shutdown

--- a/modules.d/90multipath/multipathd-stop.sh
+++ b/modules.d/90multipath/multipathd-stop.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+type pidof > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
 if [ -e /etc/multipath.conf ]; then
     pkill multipathd > /dev/null 2>&1
 

--- a/modules.d/90multipath/multipathd.sh
+++ b/modules.d/90multipath/multipathd.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
 if [ "$(getarg rd.multipath)" = "default" ] && [ ! -e /etc/multipath.conf ]; then
     # mpathconf requires /etc/multipath to already exist
     mkdir -p /etc/multipath


### PR DESCRIPTION
`dracut-lib.sh` provides a custom version of [pidof](https://github.com/dracutdevs/dracut/blob/master/modules.d/99base/dracut-lib.sh#L875), so there is no need to install the `pidof` binary. Also, source `dracut-lib.sh` in hook scripts when needed.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2027
