### PR TITLE
kernel install plugins: several fixlets

### DIFF
--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -34,7 +34,11 @@ case "$COMMAND" in
                 && exit 0
         fi
 
-        if [[ -f /etc/kernel/cmdline ]]; then
+        if [ -n "$KERNEL_INSTALL_CONF_ROOT" ]; then
+            if [ -f "$KERNEL_INSTALL_CONF_ROOT/cmdline" ]; then
+                read -r -d '' -a BOOT_OPTIONS < "$KERNEL_INSTALL_CONF_ROOT/cmdline"
+            fi
+        elif [[ -f /etc/kernel/cmdline ]]; then
             read -r -d '' -a BOOT_OPTIONS < /etc/kernel/cmdline
         elif [[ -f /usr/lib/kernel/cmdline ]]; then
             read -r -d '' -a BOOT_OPTIONS < /usr/lib/kernel/cmdline

--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -26,6 +26,8 @@ case "$COMMAND" in
         if [[ -f ${INITRD_IMAGE_PREGENERATED} ]]; then
             # we found an initrd at the same place as the kernel
             # use this and don't generate a new one
+            [[ $KERNEL_INSTALL_VERBOSE == 1 ]] \
+                && echo "There is an initrd image at the same place as the kernel, skipping generating a new one"
             cp --reflink=auto "$INITRD_IMAGE_PREGENERATED" "$BOOT_DIR_ABS/$INITRD" \
                 && chown root:root "$BOOT_DIR_ABS/$INITRD" \
                 && chmod 0600 "$BOOT_DIR_ABS/$INITRD" \

--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -58,7 +58,7 @@ case "$COMMAND" in
 
         dracut -f \
             ${noimageifnotneeded:+--noimageifnotneeded} \
-            $([[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo --verbose) \
+            "$([[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo --verbose)" \
             "$BOOT_DIR_ABS/$INITRD" \
             "$KERNEL_VERSION"
         ret=$?

--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -11,7 +11,7 @@ if ! [[ ${KERNEL_INSTALL_MACHINE_ID-x} ]]; then
     exit 0
 fi
 
-if [[ -d "$BOOT_DIR_ABS" ]]; then
+if [[ -d $BOOT_DIR_ABS ]]; then
     INITRD="initrd"
 else
     BOOT_DIR_ABS="/boot"
@@ -19,6 +19,7 @@ else
 fi
 
 ret=0
+
 case "$COMMAND" in
     add)
         INITRD_IMAGE_PREGENERATED=${KERNEL_IMAGE%/*}/initrd
@@ -40,14 +41,14 @@ case "$COMMAND" in
 
             read -r -d '' -a line < /proc/cmdline
             for i in "${line[@]}"; do
-                [[ "${i#initrd=*}" != "$i" ]] && continue
+                [[ ${i#initrd=*} != "$i" ]] && continue
                 BOOT_OPTIONS+=("$i")
             done
         fi
 
         unset noimageifnotneeded
 
-        for ((i=0; i < "${#BOOT_OPTIONS[@]}"; i++)); do
+        for ((i = 0; i < "${#BOOT_OPTIONS[@]}"; i++)); do
             # shellcheck disable=SC1001
             if [[ ${BOOT_OPTIONS[$i]} == root\=PARTUUID\=* ]]; then
                 noimageifnotneeded="yes"
@@ -57,14 +58,16 @@ case "$COMMAND" in
 
         dracut -f \
             ${noimageifnotneeded:+--noimageifnotneeded} \
-            $([[ "$KERNEL_INSTALL_VERBOSE" == 1 ]] && echo --verbose) \
+            $([[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo --verbose) \
             "$BOOT_DIR_ABS/$INITRD" \
             "$KERNEL_VERSION"
         ret=$?
-	;;
+        ;;
+
     remove)
         rm -f -- "$BOOT_DIR_ABS/$INITRD"
         ret=$?
-	;;
+        ;;
 esac
+
 exit $ret

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -30,7 +30,13 @@ dropindirs_sort() {
     done
 }
 
-[[ -f /etc/os-release ]] && . /etc/os-release
+if [[ -f /etc/os-release ]]; then
+    . /etc/os-release
+elif [[ -f /usr/lib/os-release ]]; then
+    . /usr/lib/os-release
+fi
+
+[[ -n $PRETTY_NAME ]] || PRETTY_NAME="Linux $KERNEL_VERSION"
 
 if [[ ${KERNEL_INSTALL_MACHINE_ID+x} ]]; then
     MACHINE_ID=$KERNEL_INSTALL_MACHINE_ID

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -123,11 +123,6 @@ case "$COMMAND" in
     remove)
         exit 0
         ;;
-
-    *)
-        usage
-        ret=1
-        ;;
 esac
 
 exit $ret

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -74,8 +74,12 @@ ret=0
 
 case "$COMMAND" in
     add)
-        [[ -f $LOADER_ENTRY ]] && [[ -f "$BOOT_DIR_ABS/$KERNEL" ]] \
-            && [[ -f "$BOOT_DIR_ABS/$INITRD" ]] && exit 0
+        if [[ -f $LOADER_ENTRY ]] && [[ -f "$BOOT_DIR_ABS/$KERNEL" ]] \
+            && [[ -f "$BOOT_DIR_ABS/$INITRD" ]]; then
+            [[ $KERNEL_INSTALL_VERBOSE == 1 ]] \
+                && echo "Skipping, there is already a rescue image generated with the same input parameters"
+            exit 0
+        fi
 
         # source our config dir
         for f in $(dropindirs_sort ".conf" "/etc/dracut.conf.d" "/usr/lib/dracut/dracut.conf.d"); do
@@ -86,7 +90,11 @@ case "$COMMAND" in
         done
 
         # shellcheck disable=SC2154
-        [[ $dracut_rescue_image != "yes" ]] && exit 0
+        if [[ $dracut_rescue_image != "yes" ]]; then
+            [[ $KERNEL_INSTALL_VERBOSE == 1 ]] \
+                && echo "Skipping, 'dracut_rescue_image' not set to 'yes' in any dracut configuration file"
+            exit 0
+        fi
 
         [[ -d $BOOT_DIR_ABS ]] || mkdir -p "$BOOT_DIR_ABS"
 
@@ -95,10 +103,15 @@ case "$COMMAND" in
         fi
 
         if [[ ! -f "$BOOT_DIR_ABS/$INITRD" ]]; then
-            dracut -f --no-hostonly -a "rescue" "$BOOT_DIR_ABS/$INITRD" "$KERNEL_VERSION"
+            dracut -f --no-hostonly \
+                -a "rescue" \
+                "$([[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo --verbose)" \
+                "$BOOT_DIR_ABS/$INITRD" \
+                "$KERNEL_VERSION"
             ((ret += $?))
         fi
 
+        [[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo "Creating $LOADER_ENTRY"
         if [[ ${BOOT_DIR_ABS} != "/boot" ]]; then
             {
                 echo "title      $PRETTY_NAME - Rescue Image"

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -7,13 +7,12 @@ KERNEL_VERSION="$2"
 BOOT_DIR_ABS="${3%/*}/0-rescue"
 KERNEL_IMAGE="$4"
 
-
-dropindirs_sort()
-{
-    suffix=$1; shift
+dropindirs_sort() {
+    suffix=$1
+    shift
     args=("$@")
     files=$(
-        while (( $# > 0 )); do
+        while (($# > 0)); do
             for i in "${1}"/*"${suffix}"; do
                 [[ -f $i ]] && echo "${i##*/}"
             done
@@ -35,7 +34,7 @@ dropindirs_sort()
 
 if [[ ${KERNEL_INSTALL_MACHINE_ID+x} ]]; then
     MACHINE_ID=$KERNEL_INSTALL_MACHINE_ID
-elif [[ -f /etc/machine-id ]] ; then
+elif [[ -f /etc/machine-id ]]; then
     read -r MACHINE_ID < /etc/machine-id
 fi
 
@@ -52,12 +51,12 @@ else
 
     read -r -d '' -a line < /proc/cmdline
     for i in "${line[@]}"; do
-        [[ "${i#initrd=*}" != "$i" ]] && continue
+        [[ ${i#initrd=*} != "$i" ]] && continue
         BOOT_OPTIONS+=("$i")
     done
 fi
 
-if [[ -d "${BOOT_DIR_ABS%/*}" ]]; then
+if [[ -d ${BOOT_DIR_ABS%/*} ]]; then
     BOOT_DIR="/${MACHINE_ID}/0-rescue"
     BOOT_ROOT=${BOOT_DIR_ABS%$BOOT_DIR}
     LOADER_ENTRY="$BOOT_ROOT/loader/entries/${MACHINE_ID}-0-rescue.conf"
@@ -75,7 +74,7 @@ ret=0
 
 case "$COMMAND" in
     add)
-        [[ -f "$LOADER_ENTRY" ]] && [[ -f "$BOOT_DIR_ABS/$KERNEL" ]] \
+        [[ -f $LOADER_ENTRY ]] && [[ -f "$BOOT_DIR_ABS/$KERNEL" ]] \
             && [[ -f "$BOOT_DIR_ABS/$INITRD" ]] && exit 0
 
         # source our config dir
@@ -89,7 +88,7 @@ case "$COMMAND" in
         # shellcheck disable=SC2154
         [[ $dracut_rescue_image != "yes" ]] && exit 0
 
-        [[ -d "$BOOT_DIR_ABS" ]] || mkdir -p "$BOOT_DIR_ABS"
+        [[ -d $BOOT_DIR_ABS ]] || mkdir -p "$BOOT_DIR_ABS"
 
         if ! cp --reflink=auto "$KERNEL_IMAGE" "$BOOT_DIR_ABS/$KERNEL"; then
             echo "Can't copy '$KERNEL_IMAGE to '$BOOT_DIR_ABS/$KERNEL'!" >&2
@@ -97,10 +96,10 @@ case "$COMMAND" in
 
         if [[ ! -f "$BOOT_DIR_ABS/$INITRD" ]]; then
             dracut -f --no-hostonly -a "rescue" "$BOOT_DIR_ABS/$INITRD" "$KERNEL_VERSION"
-            ((ret+=$?))
+            ((ret += $?))
         fi
 
-        if [[ "${BOOT_DIR_ABS}" != "/boot" ]]; then
+        if [[ ${BOOT_DIR_ABS} != "/boot" ]]; then
             {
                 echo "title      $PRETTY_NAME - Rescue Image"
                 echo "version    $KERNEL_VERSION"
@@ -118,7 +117,7 @@ case "$COMMAND" in
             sed -i "s/${KERNEL_VERSION}/0-rescue-${MACHINE_ID}/" "$LOADER_ENTRY"
         fi
 
-        ((ret+=$?))
+        ((ret += $?))
         ;;
 
     remove)
@@ -127,7 +126,8 @@ case "$COMMAND" in
 
     *)
         usage
-        ret=1;;
+        ret=1
+        ;;
 esac
 
 exit $ret

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -48,7 +48,11 @@ if ! [[ $MACHINE_ID ]]; then
     exit 0
 fi
 
-if [[ -f /etc/kernel/cmdline ]]; then
+if [ -n "$KERNEL_INSTALL_CONF_ROOT" ]; then
+    if [ -f "$KERNEL_INSTALL_CONF_ROOT/cmdline" ]; then
+        read -r -d '' -a BOOT_OPTIONS < "$KERNEL_INSTALL_CONF_ROOT/cmdline"
+    fi
+elif [[ -f /etc/kernel/cmdline ]]; then
     read -r -d '' -a BOOT_OPTIONS < /etc/kernel/cmdline
 elif [[ -f /usr/lib/kernel/cmdline ]]; then
     read -r -d '' -a BOOT_OPTIONS < /usr/lib/kernel/cmdline

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -58,7 +58,7 @@ fi
 
 if [[ -d ${BOOT_DIR_ABS%/*} ]]; then
     BOOT_DIR="/${MACHINE_ID}/0-rescue"
-    BOOT_ROOT=${BOOT_DIR_ABS%$BOOT_DIR}
+    BOOT_ROOT=${BOOT_DIR_ABS%"$BOOT_DIR"}
     LOADER_ENTRY="$BOOT_ROOT/loader/entries/${MACHINE_ID}-0-rescue.conf"
     KERNEL="linux"
     INITRD="initrd"


### PR DESCRIPTION
- `shfmt -s` reformat
- `shellcheck`
- Remove call to undefined `usage` function in `dracut-rescue.install`
- Honor `KERNEL_INSTALL_VERBOSE=1`
- Minor improvements related to `/etc/os-release` in `dracut-rescue.install`
- Honor `KERNEL_INSTALL_CONF_ROOT`

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
