### PR TITLE
Add `efi-secret` to qemu driver list

### DIFF
--- a/modules.d/90qemu/module-setup.sh
+++ b/modules.d/90qemu/module-setup.sh
@@ -18,5 +18,6 @@ installkernel() {
         virtio_blk virtio virtio_ring virtio_pci \
         virtio_scsi virtio_console virtio_rng virtio_mem \
         spapr-vscsi \
-        qemu_fw_cfg
+        qemu_fw_cfg \
+        efi_secret
 }


### PR DESCRIPTION
## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it

This adds a couple 'confidential computing' kernel modules to the qemu driver list. They have generic sounding names, but they are VM specific, and they are used in attestation flows which typical end with unlocking the luks encrypted rootfs, so they need to be available at boot time.