### PR TITLE
fix(kernel-modules): Add sysctl to initramfs to handle modprobe files

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -147,4 +147,5 @@ install() {
         inst_hook cmdline 01 "$moddir/parse-kernel.sh"
     fi
     inst_simple "$moddir/insmodpost.sh" /sbin/insmodpost.sh
+    inst_multiple -o sysctl
 }


### PR DESCRIPTION
This pull request changes...

## Changes
`dracut-systemd` module now will incorporate `sysctl` into initramfs so that modprobe configuration files that call sysctl will function properly.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it