### PR TITLE
fix(dracut-init.sh): instmods: wrong variable name

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -1138,7 +1138,7 @@ instmods() {
             -m "$@"
     fi
 
-    [[ "$optional" ]] && return 0
+    [[ "$_optional" ]] && return 0
     return $_ret
 }
 


### PR DESCRIPTION
It worked most of the time because `dracut-install -o` returns 0 in normal circumstances.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
