### PR TITLE
refactor(fs-lib.sh): udevadm info --query=property instead of --query…

### DIFF
--- a/modules.d/90btrfs/btrfs_device_ready.sh
+++ b/modules.d/90btrfs/btrfs_device_ready.sh
@@ -6,7 +6,7 @@ btrfs_check_complete() {
     local _rootinfo _dev
     _dev="${1:-/dev/root}"
     [ -e "$_dev" ] || return 0
-    _rootinfo=$(udevadm info --query=env "--name=$_dev" 2> /dev/null)
+    _rootinfo=$(udevadm info --query=property "--name=$_dev" 2> /dev/null)
     if strstr "$_rootinfo" "ID_FS_TYPE=btrfs"; then
         info "Checking, if btrfs device complete"
         btrfs device ready "$_dev" > /dev/null 2>&1

--- a/modules.d/90btrfs/btrfs_finished.sh
+++ b/modules.d/90btrfs/btrfs_finished.sh
@@ -6,7 +6,7 @@ btrfs_check_complete() {
     local _rootinfo _dev
     _dev="${1:-/dev/root}"
     [ -e "$_dev" ] || return 0
-    _rootinfo=$(udevadm info --query=env "--name=$_dev" 2> /dev/null)
+    _rootinfo=$(udevadm info --query=property "--name=$_dev" 2> /dev/null)
     if strstr "$_rootinfo" "ID_FS_TYPE=btrfs"; then
         info "Checking, if btrfs device complete"
         unset __btrfs_mount

--- a/modules.d/90mdraid/mdraid-cleanup.sh
+++ b/modules.d/90mdraid/mdraid-cleanup.sh
@@ -5,7 +5,7 @@ type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 containers=""
 for md in /dev/md[0-9_]*; do
     [ -b "$md" ] || continue
-    udevinfo="$(udevadm info --query=env --name="$md")"
+    udevinfo="$(udevadm info --query=property --name="$md")"
     strstr "$udevinfo" "DEVTYPE=partition" && continue
     if strstr "$udevinfo" "MD_LEVEL=container"; then
         containers="$containers $md"

--- a/modules.d/90mdraid/mdraid-waitclean.sh
+++ b/modules.d/90mdraid/mdraid-waitclean.sh
@@ -5,7 +5,7 @@ if getargbool 0 rd.md.waitclean; then
     containers=""
     for md in /dev/md[0-9_]*; do
         [ -b "$md" ] || continue
-        udevinfo="$(udevadm info --query=env --name="$md")"
+        udevinfo="$(udevadm info --query=property --name="$md")"
         strstr "$udevinfo" "DEVTYPE=partition" && continue
         if strstr "$udevinfo" "MD_LEVEL=container"; then
             containers="$containers $md"

--- a/modules.d/90mdraid/mdraid_start.sh
+++ b/modules.d/90mdraid/mdraid_start.sh
@@ -8,7 +8,7 @@ _md_start() {
     local _path_d
     local _md="$1"
 
-    _udevinfo="$(udevadm info --query=env --name="${_md}")"
+    _udevinfo="$(udevadm info --query=property --name="${_md}")"
     strstr "$_udevinfo" "MD_LEVEL=container" && return 0
     strstr "$_udevinfo" "DEVTYPE=partition" && return 0
 

--- a/modules.d/98pollcdrom/pollcdrom.sh
+++ b/modules.d/98pollcdrom/pollcdrom.sh
@@ -14,7 +14,7 @@ if [ ! -e /sys/module/block/parameters/events_dfl_poll_msecs ]; then
     for cdrom in /sys/block/sr*; do
         [ -e "$cdrom" ] || continue
         # skip, if cdrom medium was already found
-        strstr "$(udevadm info --query=env --path="${cdrom##/sys}")" \
+        strstr "$(udevadm info --query=property --path="${cdrom##/sys}")" \
             ID_CDROM_MEDIA && continue
         echo change > "$cdrom/uevent"
     done

--- a/modules.d/99fs-lib/fs-lib.sh
+++ b/modules.d/99fs-lib/fs-lib.sh
@@ -194,7 +194,7 @@ det_fs() {
     local _orig="${2:-auto}"
     local _fs
 
-    _fs=$(udevadm info --query=env --name="$_dev" \
+    _fs=$(udevadm info --query=property --name="$_dev" \
         | while read -r line || [ -n "$line" ]; do
             if str_starts "$line" "ID_FS_TYPE="; then
                 echo "${line#ID_FS_TYPE=}"

--- a/test/TEST-10-RAID/create-root.sh
+++ b/test/TEST-10-RAID/create-root.sh
@@ -37,7 +37,7 @@ udevadm settle
 mdadm --detail --export /dev/md0 | grep -F MD_UUID > /tmp/mduuid
 . /tmp/mduuid
 udevadm settle
-eval "$(udevadm info --query=env --name=/dev/md0 | while read -r line || [ -n "$line" ]; do [ "$line" != "${line#*ID_FS_UUID*}" ] && echo "$line"; done)"
+eval "$(udevadm info --query=property --name=/dev/md0 | while read -r line || [ -n "$line" ]; do [ "$line" != "${line#*ID_FS_UUID*}" ] && echo "$line"; done)"
 {
     echo "dracut-root-block-created"
     echo MD_UUID="$MD_UUID"

--- a/test/TEST-12-RAID-DEG/create-root.sh
+++ b/test/TEST-12-RAID-DEG/create-root.sh
@@ -37,7 +37,7 @@ udevadm settle
 mdadm --detail --export /dev/md0 | grep -F MD_UUID > /tmp/mduuid
 . /tmp/mduuid
 udevadm settle
-eval "$(udevadm info --query=env --name=/dev/md0 | while read -r line || [ -n "$line" ]; do [ "$line" != "${line#*ID_FS_UUID*}" ] && echo "$line"; done)"
+eval "$(udevadm info --query=property --name=/dev/md0 | while read -r line || [ -n "$line" ]; do [ "$line" != "${line#*ID_FS_UUID*}" ] && echo "$line"; done)"
 {
     echo "dracut-root-block-created"
     echo MD_UUID="$MD_UUID"

--- a/test/TEST-13-ENC-RAID-LVM/create-root.sh
+++ b/test/TEST-13-ENC-RAID-LVM/create-root.sh
@@ -43,7 +43,7 @@ cryptsetup luksClose /dev/mapper/dracut_disk3
 {
     echo "dracut-root-block-created"
     for i in /dev/disk/by-id/ata-disk_disk[123]; do
-        udevadm info --query=env --name="$i" | grep -F 'ID_FS_UUID='
+        udevadm info --query=property --name="$i" | grep -F 'ID_FS_UUID='
     done
 } | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 sync

--- a/test/TEST-40-NBD/create-encrypted-root.sh
+++ b/test/TEST-40-NBD/create-encrypted-root.sh
@@ -32,7 +32,7 @@ udevadm settle
 cryptsetup luksClose /dev/mapper/dracut_crypt_test
 udevadm settle
 sleep 1
-eval "$(udevadm info --query=env --name=/dev/disk/by-id/ata-disk_root | while read -r line || [ -n "$line" ]; do [ "$line" != "${line#*ID_FS_UUID*}" ] && echo "$line"; done)"
+eval "$(udevadm info --query=property --name=/dev/disk/by-id/ata-disk_root | while read -r line || [ -n "$line" ]; do [ "$line" != "${line#*ID_FS_UUID*}" ] && echo "$line"; done)"
 {
     echo "dracut-root-block-created"
     echo "ID_FS_UUID=$ID_FS_UUID"


### PR DESCRIPTION
…=env

env is a long time deprecated alias to property, not listed in the man page for more than a decade.

While at it, add TODO for udevadm info's --property and --value options.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
