### PR TITLE
ci: fix Arch container

### DIFF
--- a/test/container/Dockerfile-Arch
+++ b/test/container/Dockerfile-Arch
@@ -8,7 +8,7 @@ LABEL RUN="docker run -it --name NAME --privileged --ipc=host --net=host --pid=h
 RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)' > /etc/profile.d/dracut-test.sh
 
 # Install needed packages for the dracut CI container
-RUN pacman --noconfirm -Sy \
+RUN pacman --noconfirm -Syu \
     linux dash strace dhclient asciidoc cpio pigz squashfs-tools \
     qemu btrfs-progs mdadm dmraid nfs-utils nfsidmap lvm2 nbd \
     dhcp networkmanager multipath-tools vi tcpdump open-iscsi \


### PR DESCRIPTION
packages should be installed with -Syu instead of -Sy.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
