### PR TITLE
refactor(build): enable isolated compilation for each binary tool

### DIFF
--- a/src/install/Makefile
+++ b/src/install/Makefile
@@ -1,7 +1,29 @@
-all:
-	$(MAKE) -C ..
+CC ?= cc
+CFLAGS ?= -O2 -g -Wall -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
+LDFLAGS ?=
+LDLIBS ?=
+
+-include ../../Makefile.inc
+
+DRACUT_INSTALL_OBJECTS = dracut-install.o hashmap.o log.o strv.o util.o
+DRACUT_INSTALL_SOURCES = dracut-install.c hashmap.c log.c strv.c util.c
+DRACUT_INSTALL_HEADERS = hashmap.h log.h strv.h util.h macro.h
+
+%.o : %.c
+	$(CC) -c $(CFLAGS) $(KMOD_CFLAGS) $< -o $@
+
+all: dracut-install
+
+dracut-install: $(DRACUT_INSTALL_OBJECTS)
+	$(CC) $(LDFLAGS) -o $@ $(DRACUT_INSTALL_OBJECTS) $(LDLIBS) $(FTS_LIBS) $(KMOD_LIBS)
 
 clean:
-	$(MAKE) -C .. clean
+	$(RM) dracut-install $(DRACUT_INSTALL_OBJECTS)
 
 .PHONY: all clean
+
+dracut-install.o: dracut-install.c log.h macro.h hashmap.h util.h
+hashmap.o: hashmap.c util.h macro.h log.h hashmap.h
+log.o: log.c log.h macro.h util.h
+util.o: util.c util.h macro.h log.h
+strv.o: strv.c strv.h util.h macro.h log.h

--- a/src/logtee/Makefile
+++ b/src/logtee/Makefile
@@ -1,0 +1,21 @@
+CC ?= cc
+CFLAGS ?= -O2 -g -Wall -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
+LDFLAGS ?= 
+
+LOGTEE_OBJECTS = logtee.o
+LOGTEE_SOURCES = logtee.c
+
+%.o : %.c
+	$(CC) -c $(CFLAGS) $< -o $@
+
+all: logtee
+
+logtee: $(LOGTEE_OBJECTS)
+	$(CC) $(LDFLAGS) $< -o $@
+
+clean:
+	$(RM) logtee $(LOGTEE_OBJECTS)
+
+.PHONY: all clean
+
+logtee.o: logtee.c

--- a/src/skipcpio/Makefile
+++ b/src/skipcpio/Makefile
@@ -1,0 +1,21 @@
+CC ?= cc
+CFLAGS ?= -O2 -g -Wall -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
+LDFLAGS ?= 
+
+SKIPCPIO_OBJECTS = skipcpio.o
+SKIPCPIO_SOURCES = skipcpio.c
+
+%.o : %.c
+	$(CC) -c $(CFLAGS) $< -o $@
+
+all: skipcpio
+
+skipcpio: $(SKIPCPIO_OBJECTS)
+	$(CC) $(LDFLAGS) $< -o $@
+
+clean:
+	$(RM) skipcpio $(SKIPCPIO_OBJECTS)
+
+.PHONY: all clean
+
+skipcpio.o: skipcpio.c

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -1,0 +1,21 @@
+CC ?= cc
+CFLAGS ?= -O2 -g -Wall -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
+LDFLAGS ?= 
+
+UTIL_OBJECTS = util.o
+UTIL_SOURCES = util.c
+
+%.o : %.c
+	$(CC) -c $(CFLAGS) $< -o $@
+
+all: util
+
+util: $(UTIL_OBJECTS)
+	$(CC) $(LDFLAGS) $< -o $@
+
+clean:
+	$(RM) util $(UTIL_OBJECTS)
+
+.PHONY: all clean
+
+util.o: util.c


### PR DESCRIPTION
Encapsulate the specific compilation process into the individual binary tool directories for "dracut-install", "logtee", "skipcpio" and "dracut-util".

This pull request changes...

## Changes
During building process, enter specific binary tool directory and
run "make" individually.

## Checklist
- [x] I have tested it locally
