### PR TITLE
docs: correct "rd.blacklist"

### DIFF
--- a/man/dracut.usage.asc
+++ b/man/dracut.usage.asc
@@ -165,8 +165,8 @@ a modern init system, like systemd.
 
 ==== Blacklisting Kernel Modules
 Sometimes it is required to prevent the automatic kernel module loading of a
-specific kernel module. To do this, just add rd.blacklist=_++<kernel module
-name>++_, with _++<kernel module name>++_ not containing the _.ko_
+specific kernel module. To do this, just add rd.driver.blacklist=_++<kernel
+module name>++_, with _++<kernel module name>++_ not containing the _.ko_
 suffix, to the kernel command line. For example:
 ----
 rd.driver.blacklist=mptsas rd.driver.blacklist=nouveau


### PR DESCRIPTION
There's a deprecated option `rdblacklist` but no `rd.blacklist` as far as I could tell, so this pull request changes the statement of the option name to match the examples given immediately after.
