### PR TITLE
perf(dracut.sh): do not mkdir $initdir/lib/dracut within a loop

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2010,10 +2010,11 @@ else
     done
 fi
 
+mkdir -p "${initdir}"/lib/dracut
+
 if [[ $kernel_only != yes ]]; then
     mkdir -p "${initdir}/etc/cmdline.d"
-    # shellcheck disable=SC2174
-    mkdir -m 0755 -p "${initdir}"/lib "${initdir}"/lib/dracut "${initdir}"/lib/dracut/hooks
+    mkdir -m 0755 "${initdir}"/lib/dracut/hooks
     # shellcheck disable=SC2154
     for _d in $hookdirs; do
         # shellcheck disable=SC2174
@@ -2071,7 +2072,6 @@ done
 unset moddir
 
 for i in $modules_loaded; do
-    mkdir -p "$initdir"/lib/dracut
     printf "%s\n" "$i" >> "$initdir"/lib/dracut/modules.txt
 done
 


### PR DESCRIPTION
This directory is always needed to store files like `modules.txt` and `build-parameter.txt`, so always create it, but only in one place.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
