### PR TITLE
ci: add ntfs tools to test containers

### DIFF
--- a/test/container/Dockerfile-Arch
+++ b/test/container/Dockerfile-Arch
@@ -12,7 +12,7 @@ RUN pacman --noconfirm -Syu \
     linux dash strace dhclient asciidoc cpio pigz squashfs-tools \
     qemu btrfs-progs mdadm dmraid nfs-utils nfsidmap lvm2 nbd \
     dhcp networkmanager multipath-tools vi tcpdump open-iscsi \
-    git shfmt shellcheck astyle which base-devel glibc parted && yes | pacman -Scc
+    git shfmt shellcheck astyle which base-devel glibc parted ntfs-3g && yes | pacman -Scc
 
 RUN useradd -m build
 RUN su build -c 'cd && git clone https://aur.archlinux.org/perl-config-general.git && cd perl-config-general && makepkg -s --noconfirm'

--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -43,6 +43,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && DEBIAN_FRONTEND=nonintera
     nbd-client \
     network-manager \
     nfs-kernel-server \
+    ntfs-3g \
     open-iscsi \
     parted \
     pigz \

--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -50,6 +50,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     ShellCheck \
     shfmt \
     parted \
+    ntfsprogs \
     && dnf -y update && dnf clean all
 
 # Set default command

--- a/test/container/Dockerfile-Gentoo
+++ b/test/container/Dockerfile-Gentoo
@@ -29,6 +29,7 @@ RUN emerge -qv \
     sys-block/parted \
     sys-fs/btrfs-progs \
     sys-fs/lvm2 \
+    sys-fs/ntfs3g \
     sys-fs/squashfs-tools \
     && rm -rf /var/cache/* /usr/share/doc/* /usr/share/man/* /var/db/repos/gentoo
 

--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -13,7 +13,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     strace libkmod-devel gcc bzip2 xz tar wget rpm-build make git bash-completion \
     sudo kernel dhcp-client qemu-kvm /usr/bin/qemu-system-$(uname -m) e2fsprogs \
     tcpdump iproute iputils kbd NetworkManager btrfsprogs tgt dbus-broker \
-    iscsiuio open-iscsi which ShellCheck procps pigz parted squashfs \
+    iscsiuio open-iscsi which ShellCheck procps pigz parted squashfs ntfsprogs \
     && dnf -y update && dnf clean all
 
 RUN shfmt_version=3.2.4; wget "https://github.com/mvdan/sh/releases/download/v${shfmt_version}/shfmt_v${shfmt_version}_linux_amd64" -O /usr/local/bin/shfmt \


### PR DESCRIPTION
mkfs.ntfs is needed to test dmsquash-live-ntfs
