### PR TITLE
test: run less tests as part of Github Action integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -78,7 +78,7 @@ jobs:
                     fetch-depth: 0
 
             -   name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-                run: ./tools/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+                run: SMOKE_TESTING=1 ./tools/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
     openrc-musl:
         runs-on: ubuntu-latest
         timeout-minutes: 45

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -141,45 +141,48 @@ test_nfsv3() {
     client_test "NFSv3 Legacy root=/dev/nfs nfsroot=IP:path" 52:54:00:12:34:01 \
         "root=/dev/nfs nfsroot=192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096 || return 1
 
-    client_test "NFSv3 Legacy root=/dev/nfs DHCP path only" 52:54:00:12:34:00 \
-        "root=/dev/nfs" 192.168.50.1 -wsize=4096 || return 1
+    # Do not run the following tests during smoke testing, to speed up running the test suite and avoid timeouts
+    if [ -z "$SMOKE_TESTING" ]; then
+        client_test "NFSv3 Legacy root=/dev/nfs DHCP path only" 52:54:00:12:34:00 \
+            "root=/dev/nfs" 192.168.50.1 -wsize=4096 || return 1
 
-    client_test "NFSv3 Legacy root=/dev/nfs DHCP IP:path" 52:54:00:12:34:01 \
-        "root=/dev/nfs" 192.168.50.2 -wsize=4096 || return 1
+        client_test "NFSv3 Legacy root=/dev/nfs DHCP IP:path" 52:54:00:12:34:01 \
+            "root=/dev/nfs" 192.168.50.2 -wsize=4096 || return 1
 
-    client_test "NFSv3 root=dhcp DHCP IP:path" 52:54:00:12:34:01 \
-        "root=dhcp" 192.168.50.2 -wsize=4096 || return 1
+        client_test "NFSv3 root=dhcp DHCP IP:path" 52:54:00:12:34:01 \
+            "root=dhcp" 192.168.50.2 -wsize=4096 || return 1
 
-    client_test "NFSv3 root=dhcp DHCP proto:IP:path" 52:54:00:12:34:02 \
-        "root=dhcp" 192.168.50.3 -wsize=4096 || return 1
+        client_test "NFSv3 root=dhcp DHCP proto:IP:path" 52:54:00:12:34:02 \
+            "root=dhcp" 192.168.50.3 -wsize=4096 || return 1
 
-    client_test "NFSv3 root=dhcp DHCP proto:IP:path:options" 52:54:00:12:34:03 \
-        "root=dhcp" 192.168.50.3 wsize=4096 || return 1
+        client_test "NFSv3 root=dhcp DHCP proto:IP:path:options" 52:54:00:12:34:03 \
+            "root=dhcp" 192.168.50.3 wsize=4096 || return 1
 
-    client_test "NFSv3 root=nfs:..." 52:54:00:12:34:04 \
-        "root=nfs:192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096 || return 1
+        client_test "NFSv3 root=nfs:..." 52:54:00:12:34:04 \
+            "root=nfs:192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096 || return 1
 
-    client_test "NFSv3 Bridge root=nfs:..." 52:54:00:12:34:04 \
-        "root=nfs:192.168.50.1:/nfs/client bridge net.ifnames=0" 192.168.50.1 -wsize=4096 || return 1
+        client_test "NFSv3 Bridge root=nfs:..." 52:54:00:12:34:04 \
+            "root=nfs:192.168.50.1:/nfs/client bridge net.ifnames=0" 192.168.50.1 -wsize=4096 || return 1
 
-    client_test "NFSv3 Legacy root=IP:path" 52:54:00:12:34:04 \
-        "root=192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096 || return 1
+        client_test "NFSv3 Legacy root=IP:path" 52:54:00:12:34:04 \
+            "root=192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096 || return 1
 
-    # This test must fail: nfsroot= requires root=/dev/nfs
-    client_test "NFSv3 Invalid root=dhcp nfsroot=/nfs/client" 52:54:00:12:34:04 \
-        "root=dhcp nfsroot=/nfs/client failme" 192.168.50.1 -wsize=4096 && return 1
+        # This test must fail: nfsroot= requires root=/dev/nfs
+        client_test "NFSv3 Invalid root=dhcp nfsroot=/nfs/client" 52:54:00:12:34:04 \
+            "root=dhcp nfsroot=/nfs/client failme" 192.168.50.1 -wsize=4096 && return 1
 
-    client_test "NFSv3 root=dhcp DHCP path,options" 52:54:00:12:34:05 \
-        "root=dhcp" 192.168.50.1 wsize=4096 || return 1
+        client_test "NFSv3 root=dhcp DHCP path,options" 52:54:00:12:34:05 \
+            "root=dhcp" 192.168.50.1 wsize=4096 || return 1
 
-    client_test "NFSv3 Bridge Customized root=dhcp DHCP path,options" 52:54:00:12:34:05 \
-        "root=dhcp bridge=foobr0:enp0s1" 192.168.50.1 wsize=4096 || return 1
+        client_test "NFSv3 Bridge Customized root=dhcp DHCP path,options" 52:54:00:12:34:05 \
+            "root=dhcp bridge=foobr0:enp0s1" 192.168.50.1 wsize=4096 || return 1
 
-    client_test "NFSv3 root=dhcp DHCP IP:path,options" 52:54:00:12:34:06 \
-        "root=dhcp" 192.168.50.2 wsize=4096 || return 1
+        client_test "NFSv3 root=dhcp DHCP IP:path,options" 52:54:00:12:34:06 \
+            "root=dhcp" 192.168.50.2 wsize=4096 || return 1
 
-    client_test "NFSv3 root=dhcp DHCP proto:IP:path,options" 52:54:00:12:34:07 \
-        "root=dhcp" 192.168.50.3 wsize=4096 || return 1
+        client_test "NFSv3 root=dhcp DHCP proto:IP:path,options" 52:54:00:12:34:07 \
+            "root=dhcp" 192.168.50.3 wsize=4096 || return 1
+    fi
 
     client_test "NFSv3 Overlayfs root=nfs:..." 52:54:00:12:34:04 \
         "root=nfs:192.168.50.1:/nfs/client rd.live.overlay.overlayfs=1" \

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -152,34 +152,37 @@ test_client() {
         "root=dhcp BOOTIF=52-54-00-12-34-02" \
         "enp0s3" || return 1
 
-    # Multinic case, where only one nic works
-    client_test "MULTINIC root=nfs ip=dhcp" \
-        FF 00 FE \
-        "root=nfs:192.168.50.1:/nfs/client ip=dhcp" \
-        "enp0s2" || return 1
+    # Do not run the following tests during smoke testing
+    if [ -z "$SMOKE_TESTING" ]; then
+        # Multinic case, where only one nic works
+        client_test "MULTINIC root=nfs ip=dhcp" \
+            FF 00 FE \
+            "root=nfs:192.168.50.1:/nfs/client ip=dhcp" \
+            "enp0s2" || return 1
 
-    # Require two interfaces
-    client_test "MULTINIC root=nfs ip=enp0s2:dhcp ip=enp0s3:dhcp bootdev=enp0s2" \
-        00 01 02 \
-        "root=nfs:192.168.50.1:/nfs/client ip=enp0s2:dhcp ip=enp0s3:dhcp bootdev=enp0s2" \
-        "enp0s2 enp0s3" || return 1
+        # Require two interfaces
+        client_test "MULTINIC root=nfs ip=enp0s2:dhcp ip=enp0s3:dhcp bootdev=enp0s2" \
+            00 01 02 \
+            "root=nfs:192.168.50.1:/nfs/client ip=enp0s2:dhcp ip=enp0s3:dhcp bootdev=enp0s2" \
+            "enp0s2 enp0s3" || return 1
 
-    # Require three interfaces with dhcp root-path
-    client_test "MULTINIC root=dhcp ip=enp0s1:dhcp ip=enp0s2:dhcp ip=enp0s3:dhcp bootdev=enp0s3" \
-        00 01 02 \
-        "root=dhcp ip=enp0s1:dhcp ip=enp0s2:dhcp ip=enp0s3:dhcp bootdev=enp0s3" \
-        "enp0s1 enp0s2 enp0s3" || return 1
+        # Require three interfaces with dhcp root-path
+        client_test "MULTINIC root=dhcp ip=enp0s1:dhcp ip=enp0s2:dhcp ip=enp0s3:dhcp bootdev=enp0s3" \
+            00 01 02 \
+            "root=dhcp ip=enp0s1:dhcp ip=enp0s2:dhcp ip=enp0s3:dhcp bootdev=enp0s3" \
+            "enp0s1 enp0s2 enp0s3" || return 1
 
-    client_test "MULTINIC bonding" \
-        00 01 02 \
-        "root=nfs:192.168.50.1:/nfs/client ip=bond0:dhcp  bond=bond0:enp0s1,enp0s2,enp0s3:mode=balance-rr" \
-        "bond0" || return 1
+        client_test "MULTINIC bonding" \
+            00 01 02 \
+            "root=nfs:192.168.50.1:/nfs/client ip=bond0:dhcp  bond=bond0:enp0s1,enp0s2,enp0s3:mode=balance-rr" \
+            "bond0" || return 1
 
-    # bridge, where only one interface is actually connected
-    client_test "MULTINIC bridging" \
-        00 01 02 \
-        "root=nfs:192.168.50.1:/nfs/client ip=bridge0:dhcp  bridge=bridge0:enp0s1,enp0s5,enp0s6" \
-        "bridge0" || return 1
+        # bridge, where only one interface is actually connected
+        client_test "MULTINIC bridging" \
+            00 01 02 \
+            "root=nfs:192.168.50.1:/nfs/client ip=bridge0:dhcp  bridge=bridge0:enp0s1,enp0s5,enp0s6" \
+            "bridge0" || return 1
+    fi
     return 0
 }
 


### PR DESCRIPTION
Introduce a subset of tests for "smoke testing" - https://en.wikipedia.org/wiki/Smoke_testing_(software)
    
Most tests will continue to run as part of smoke testing, but some really time consuming tests will no longer be part of smoke testing.
    
Set SMOKE_TESTING env variable when running tests as part of Github Action.
Disable some subtests when SMOKE_TESTING is set to avoid timeouts.

Tests 20/21 and 50/51 times out on a regular basis as it does not finish in 45 minutes. 
One of the core value of integration test is that it is reliable and only fails if there is a legitimate regression.  To make a step toward this goal, disable some subtests. 

This brings running each subtests to around 20 minutes.

If the test is run locally or using the "Manual Tests" Github Action, the full test suite will run as before including all sub tests.