### PR TITLE
chore(ci): bump docker/setup-buildx-action from 1 to 2

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -37,7 +37,7 @@ jobs:
             -   name: Check out the repo
                 uses: actions/checkout@v3
             -   name: Set up Docker Buildx
-                uses: docker/setup-buildx-action@v1
+                uses: docker/setup-buildx-action@v2
             -   name: Login to GitHub Container Registry
                 uses: docker/login-action@v2
                 with:


### PR DESCRIPTION
v2 has node 16 as default runtime.

