### PR TITLE
test: explicitly check if systemctl is available for systemd tests

### DIFF
--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -2,6 +2,10 @@
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on a ext3 filesystem"
 
+test_check() {
+    command -v systemctl &> /dev/null
+}
+
 KVERSION="${KVERSION-$(uname -r)}"
 
 # Uncomment this to debug failures

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -3,6 +3,10 @@
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="Full systemd serialization/deserialization test with /usr mount"
 
+test_check() {
+    command -v systemctl &> /dev/null
+}
+
 export KVERSION=${KVERSION-$(uname -r)}
 
 # Uncomment this to debug failures


### PR DESCRIPTION
Dracut tests already do similar checks for test 40, 62, 63 and 98.

This is useful when the full testsuite is run and systemd is not available.

Run with this PR on Gentoo: https://github.com/LaszloGombos/dracut/actions/runs/3455893330/jobs/5768235202

make[1]: Entering directory '/__w/dracut/dracut/test/TEST-04-FULL-SYSTEMD'
TEST: Full systemd serialization/deserialization test with /usr mount   [SKIPPED] 
make[1]: Leaving directory '/__w/dracut/dracut/test/TEST-04-FULL-SYSTEMD'

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
