### PR TITLE
fix(zipl): remove trailing spaces from zipl boot device name

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -37,6 +37,13 @@ str_starts() { [ "${1#"$2"*}" != "$1" ]; }
 # returns OK if $1 contains literal string $2 at the end, and isn't empty
 str_ends() { [ "${1%*"$2"}" != "$1" ]; }
 
+trim() {
+    local var="$*"
+    var="${var#"${var%%[![:space:]]*}"}" # remove leading whitespace characters
+    var="${var%"${var##*[![:space:]]}"}" # remove trailing whitespace characters
+    printf "%s" "$var"
+}
+
 # find a binary.  If we were not passed the full path directly,
 # search in the usual places to find the binary.
 find_binary() {

--- a/modules.d/91zipl/module-setup.sh
+++ b/modules.d/91zipl/module-setup.sh
@@ -2,6 +2,12 @@
 # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
+get_boot_zipl_dev() {
+    local _boot_zipl
+    _boot_zipl=$(sed -n -e '/^[[:space:]]*#/d' -e 's/\(.*\)\w*\/boot\/zipl.*/\1/p' "$dracutsysrootdir"/etc/fstab)
+    printf "%s" "$(trim "$_boot_zipl")"
+}
+
 # called by dracut
 check() {
     local _arch=${DRACUT_ARCH:-$(uname -m)}
@@ -21,7 +27,7 @@ depends() {
 installkernel() {
     local _boot_zipl
 
-    _boot_zipl=$(sed -n -e '/^[[:space:]]*#/d' -e 's/\(.*\)\w*\/boot\/zipl.*/\1/p' /etc/fstab)
+    _boot_zipl=$(get_boot_zipl_dev)
     if [ -n "$_boot_zipl" ]; then
         eval "$(blkid -s TYPE -o udev "${_boot_zipl}")"
         if [ -n "$ID_FS_TYPE" ]; then
@@ -39,9 +45,9 @@ installkernel() {
 cmdline() {
     local _boot_zipl
 
-    _boot_zipl=$(sed -n -e '/^[[:space:]]*#/d' -e 's/\(.*\)\w*\/boot\/zipl.*/\1/p' /etc/fstab)
+    _boot_zipl=$(get_boot_zipl_dev)
     if [ -n "$_boot_zipl" ]; then
-        echo "rd.zipl=${_boot_zipl}"
+        printf "%s" " rd.zipl=${_boot_zipl}"
     fi
 }
 


### PR DESCRIPTION
Trailing spaces are misleading blkid input after fixes for shellcheck were introduced in https://github.com/dracutdevs/dracut/commit/d75b029a

Test showing the wrong output:

```
localhost:~ # _boot_zipl=$(sed -n -e '/^[[:space:]]*#/d' -e 's/\(.*\)\w*\/boot\/zipl.*/\1/p' /etc/fstab)
localhost:~ # echo "[${_boot_zipl}]"
[/dev/disk/by-path/ccw-0.0.0000-part1  ]
localhost:~ # blkid -s TYPE -o udev "${_boot_zipl}"
localhost:~ # blkid -s TYPE -o udev ${_boot_zipl}
ID_FS_TYPE=ext2
```

Also, remove duplicate code by creating a function to get the zipl boot device, prepend `$dracutsysrootdir` to /etc/fstab and print cmdline properly: start with a space and do not print a newline.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
