### PR TITLE
fix(dracut-fuctions.sh): correct wrong regex pattern for LVM dm devices

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -647,6 +647,16 @@ get_blockdev_drv_through_sys() {
     echo "$_block_mods"
 }
 
+# get_lvm_dm_dev <maj:min>
+# If $1 is an LVM device-mapper device, return the path to its dm directory
+get_lvm_dm_dev() {
+    local _majmin _dm
+    _majmin="$1"
+    _dm=/sys/dev/block/$_majmin/dm
+    [[ ! -f $_dm/uuid || $(< "$_dm"/uuid) != LVM-* ]] && return 1
+    printf "%s" "$_dm"
+}
+
 # ugly workaround for the lvm design
 # There is no volume group device,
 # so, there are no slave devices for volume groups.
@@ -654,10 +664,10 @@ get_blockdev_drv_through_sys() {
 # but you cannot create the logical volume without the volume group.
 # And the volume group might be bigger than the devices the LV needs.
 check_vol_slaves() {
-    local _vg _pv _dm _majmin
+    local _vg _pv _majmin _dm
     _majmin="$2"
-    _dm=/sys/dev/block/$_majmin/dm
-    [[ -f $_dm/uuid && $(< "$_dm"/uuid) =~ LVM-* ]] || return 1
+    _dm=$(get_lvm_dm_dev "$_majmin")
+    [[ -z $_dm ]] && return 1 # not an LVM device-mapper device
     _vg=$(dmsetup splitname --noheadings -o vg_name "$(< "$_dm/name")")
     # strip space
     _vg="${_vg//[[:space:]]/}"
@@ -670,10 +680,10 @@ check_vol_slaves() {
 }
 
 check_vol_slaves_all() {
-    local _vg _pv _majmin
+    local _vg _pv _majmin _dm
     _majmin="$2"
-    _dm="/sys/dev/block/$_majmin/dm"
-    [[ -f $_dm/uuid && $(< "$_dm"/uuid) =~ LVM-* ]] || return 1
+    _dm=$(get_lvm_dm_dev "$_majmin")
+    [[ -z $_dm ]] && return 1 # not an LVM device-mapper device
     _vg=$(dmsetup splitname --noheadings -o vg_name "$(< "$_dm/name")")
     # strip space
     _vg="${_vg//[[:space:]]/}"
@@ -771,10 +781,12 @@ get_ucode_file() {
 # Not every device in /dev/mapper should be examined.
 # If it is an LVM device, touch only devices which have /dev/VG/LV symlink.
 lvm_internal_dev() {
-    local dev_dm_dir=/sys/dev/block/$1/dm
-    [[ ! -f $dev_dm_dir/uuid || $(< "$dev_dm_dir"/uuid) != LVM-* ]] && return 1 # Not an LVM device
+    local _majmin _dm
+    _majmin="$1"
+    _dm=$(get_lvm_dm_dev "$_majmin")
+    [[ -z $_dm ]] && return 1 # not an LVM device-mapper device
     local DM_VG_NAME DM_LV_NAME DM_LV_LAYER
-    eval "$(dmsetup splitname --nameprefixes --noheadings --rows "$(< "$dev_dm_dir"/name)" 2> /dev/null)"
+    eval "$(dmsetup splitname --nameprefixes --noheadings --rows "$(< "$_dm/name")" 2> /dev/null)"
     [[ ${DM_VG_NAME} ]] && [[ ${DM_LV_NAME} ]] || return 0 # Better skip this!
     [[ ${DM_LV_LAYER} ]] || [[ ! -L /dev/${DM_VG_NAME}/${DM_LV_NAME} ]]
 }


### PR DESCRIPTION
The regex pattern to detect LVM device-mapper devices used in `check_vol_slaves` and `check_vol_slaves_all` is incorrect, as it matches any occurrence of the LVM string within dm/uuid, not just at the beggining.

A similar check is correctly implemented in `lvm_internal_dev`, so this patch creates a new `get_lvm_dm_dev` function using it to avoid duplicate code.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1149
