### PR TITLE
RFC: feat(dracut): create sysusers only when the initrd is generated

### DIFF
--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -610,6 +610,10 @@ and no /etc/cmdline/*.conf will be generated into the initramfs.
     staging area and destination all on the same copy-on-write capable
     filesystem.
 
+**--no-create-sysusers**::
+    Create system users on every boot, instead of creating them only when the
+    initramfs is generated.
+
 ENVIRONMENT
 -----------
 

--- a/man/dracut.conf.5.asc
+++ b/man/dracut.conf.5.asc
@@ -315,6 +315,10 @@ Logging levels:
    If set to _yes_, try to execute tasks in parallel (currently only supported
    for _--regenerate-all_).
 
+*create_sysusers=*"__{yes|no}__"::
+   If set to _yes_, create system users only when the initramfs is generated,
+   instead of creating them on every boot (default=yes).
+
 Files
 -----
 _/etc/dracut.conf_::

--- a/shell-completion/bash/dracut
+++ b/shell-completion/bash/dracut
@@ -36,7 +36,7 @@ _dracut() {
             --enhanced-cpio --rebuild --aggressive-strip --hostonly-cmdline
             --no-hostonly-cmdline --no-hostonly-default-device --nofscks
             --hostonly-i18n --no-hostonly-i18n --lzo --lz4 --no-reproducible
-            --no-uefi --no-machineid --version --parallel
+            --no-uefi --no-machineid --version --parallel --no-create-sysusers
             '
         [ARG]='-a -m -o -d -I -k -c -L -r -i
             --kver --add --force-add --add-drivers --force-drivers


### PR DESCRIPTION
When generating the initrd, dracut copies all the sysusers dropins provided by its modules to it, and systemd-sysusers runs at every boot to always create the same users.

This patch is intended to create the system users only when the initrd is generated, without including the systemd-sysusers stuff in the initrd, as it is not necessary.

To control this functionality and allow to use the old method, added the `create_sysusers` configuration option (default to yes) and the `--no-create-sysusers` parameter.

Trying to move forward @lnykryn's idea as it seems to be stalled. RFC:
- How to toggle the current functionality, via kernel command line or configuration? using a configuration option, all the sysusers stuff can be removed from the initrd, whereas adding `ConditionKernelCommandLine` to the service, we have to keep it, although it will not run on every boot, but it can be useful if the user wants to run systemd-sysusers from the emergency shell.
- By default, should we enable the new functionality or keep the old one?

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1830
