### PR TITLE
fix: align shutdown action handling between modules

### DIFF
--- a/modules.d/98dracut-systemd/dracut-emergency.sh
+++ b/modules.d/98dracut-systemd/dracut-emergency.sh
@@ -46,13 +46,13 @@ fi
 
 case "$_emergency_action" in
     reboot)
-        reboot || exit 1
+        reboot -f || exit 1
         ;;
     poweroff)
-        poweroff || exit 1
+        poweroff -f || exit 1
         ;;
     halt)
-        halt || exit 1
+        halt -f || exit 1
         ;;
 esac
 

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -979,13 +979,13 @@ emergency_shell() {
 
     case "$_emergency_action" in
         reboot)
-            reboot || exit 1
+            reboot -f || exit 1
             ;;
         poweroff)
-            poweroff || exit 1
+            poweroff -f || exit 1
             ;;
         halt)
-            halt || exit 1
+            halt -f || exit 1
             ;;
     esac
 }

--- a/modules.d/99shutdown/shutdown.sh
+++ b/modules.d/99shutdown/shutdown.sh
@@ -159,17 +159,17 @@ getarg 'rd.break=shutdown' && emergency_shell --shutdown shutdown "Break before 
 
 case "$ACTION" in
     reboot | poweroff | halt)
-        $ACTION -f -n
+        $ACTION -f
         warn "$ACTION failed!"
         ;;
     kexec)
         kexec -e
         warn "$ACTION failed!"
-        reboot -f -n
+        reboot -f
         ;;
     *)
         warn "Shutdown called with argument '$ACTION'. Rebooting!"
-        reboot -f -n
+        reboot -f
         ;;
 esac
 


### PR DESCRIPTION
Use "-f" argument consistently for immediate halt, power-off, or reboot.

"-f" stands for force immediate halt, power-off, or reboot.

In shutdown module dracut uses "-n" which stands for do not sync hard disks/storage media before halt, power-off, reboot. It seems dracut should not use "-n" at shutdown.

