### PR TITLE
fix(fips): do not blindly remove /boot

### DIFF
--- a/modules.d/01fips/fips-boot.sh
+++ b/modules.d/01fips/fips-boot.sh
@@ -8,7 +8,9 @@ elif [ -z "$fipsmode" ]; then
     die "FIPS mode have to be enabled by 'fips=1' not just 'fips'"
 elif getarg boot= > /dev/null; then
     . /sbin/fips.sh
+    fips_info "fips-boot: start"
     if mount_boot; then
         do_fips || die "FIPS integrity test failed"
     fi
+    fips_info "fips-boot: done!"
 fi

--- a/modules.d/01fips/fips-load-crypto.sh
+++ b/modules.d/01fips/fips-load-crypto.sh
@@ -8,5 +8,7 @@ elif [ -z "$fipsmode" ]; then
     die "FIPS mode have to be enabled by 'fips=1' not just 'fips'"
 else
     . /sbin/fips.sh
+    fips_info "fips-load-crypto: start"
     fips_load_crypto || die "FIPS integrity test failed"
+    fips_info "fips-load-crypto: done!"
 fi

--- a/modules.d/01fips/fips-noboot.sh
+++ b/modules.d/01fips/fips-noboot.sh
@@ -8,6 +8,8 @@ elif [ -z "$fipsmode" ]; then
     die "FIPS mode have to be enabled by 'fips=1' not just 'fips'"
 elif ! [ -f /tmp/fipsdone ]; then
     . /sbin/fips.sh
+    fips_info "fips-noboot: start"
     mount_boot
     do_fips || die "FIPS integrity test failed"
+    fips_info "fips-noboot: done!"
 fi

--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -47,7 +47,7 @@ mount_boot() {
         mkdir -p /boot
         fips_info "Mounting $boot as /boot"
         mount -oro "$boot" /boot || return 1
-    elif [ -d "$NEWROOT/boot" ]; then
+    elif ! ismounted /boot && [ -d "$NEWROOT/boot" ]; then
         # shellcheck disable=SC2114
         rm -fr -- /boot
         ln -sf "$NEWROOT/boot" /boot

--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -62,7 +62,7 @@ installkernel() {
 
 # called by dracut
 install() {
-    inst_hook pre-mount 01 "$moddir/fips-boot.sh"
+    inst_hook pre-pivot 00 "$moddir/fips-boot.sh"
     inst_hook pre-pivot 01 "$moddir/fips-noboot.sh"
     inst_hook pre-udev 01 "$moddir/fips-load-crypto.sh"
     inst_script "$moddir/fips.sh" /sbin/fips.sh


### PR DESCRIPTION
The `mount_boot` method called from fips-noboot.sh in the pre-pivot hook blindly
executes `rm -rf /boot` if there is no `boot=` command line parameter, without
first checking that /boot is not already mounted by other means.

We hit this issue in certain specific circumstances (s390x arch, separate /boot
partition, initrd built with `--mount` to mount /boot and incorrect user
configuration without the `boot=` command line parameter), but this part of the
code must be protected anyway.

```
[   29.932607] dracut-pre-pivot[922]: rm: cannot remove '/boot/boot.readme': Read-only file system
[   29.932814] dracut-pre-pivot[922]: rm: cannot remove '/boot/System.map-5.14.21-150500.34-default': Read-only file system
[   29.932909] dracut-pre-pivot[922]: rm: cannot remove '/boot/initrd-5.14.21-150500.34-default': Read-only file system
[   29.933015] dracut-pre-pivot[922]: rm: cannot remove '/boot/image-5.14.21-150500.34-default': Read-only file system
...
[   29.960631] dracut-pre-pivot[922]: rm: cannot remove '/boot/grub2/grub.cfg': Read-only file system
[   29.961253] dracut-pre-pivot[922]: rm: cannot remove '/boot/grub2/fonts/unicode.pf2': Read-only file system
[   29.980315] dracut-pre-pivot[922]: rm: cannot remove '/boot/zipl': Read-only file system
[   29.982016] dracut-pre-pivot[923]: ln: failed to create symbolic link '/boot/boot': Read-only file system
[   29.987197] dracut-pre-pivot[912]: Checking integrity of kernel
[   30.356025] dracut-pre-pivot[912]: All initrd crypto checks done
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
