### PR TITLE
test: check if systemctl is available for network-manager tests

### DIFF
--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -20,6 +20,11 @@ DEBUGFAIL="rd.debug loglevel=7"
 SERVER_DEBUG="rd.debug loglevel=7"
 #SERIAL="unix:/tmp/server.sock"
 
+test_check() {
+    # network-manager module has a dependency on systemd
+    ! [[ $NM ]] || command -v systemctl &> /dev/null
+}
+
 run_server() {
     # Start server first
     echo "NFS TEST SETUP: Starting DHCP/NFS server"

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -19,6 +19,11 @@ DEBUGFAIL="rd.debug loglevel=7 "
 #SERVER_DEBUG="rd.debug loglevel=7"
 #SERIAL="tcp:127.0.0.1:9999"
 
+test_check() {
+    # network-manager module has a dependency on systemd
+    ! [[ $NM ]] || command -v systemctl &> /dev/null
+}
+
 run_server() {
     # Start server first
     echo "iSCSI TEST SETUP: Starting DHCP/iSCSI server"

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -19,6 +19,11 @@ DEBUGFAIL="rd.debug loglevel=7 "
 #SERVER_DEBUG="rd.debug loglevel=7"
 #SERIAL="tcp:127.0.0.1:9999"
 
+test_check() {
+    # network-manager module has a dependency on systemd
+    ! [[ $NM ]] || command -v systemctl &> /dev/null
+}
+
 run_server() {
     # Start server first
     echo "iSCSI TEST SETUP: Starting DHCP/iSCSI server"

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -19,6 +19,11 @@ KVERSION=${KVERSION-$(uname -r)}
 #SERIAL="tcp:127.0.0.1:9999"
 
 test_check() {
+    # network-manager module has a dependency on systemd
+    ! [[ $NM ]] || command -v systemctl &> /dev/null
+}
+
+test_check() {
     if ! type -p nbd-server &> /dev/null; then
         echo "Test needs nbd-server... Skipping"
         return 1

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -17,6 +17,11 @@ KVERSION=${KVERSION-$(uname -r)}
 #DEBUGFAIL="loglevel=7 rd.shell rd.break"
 #SERIAL="tcp:127.0.0.1:9999"
 
+test_check() {
+    # network-manager module has a dependency on systemd
+    ! [[ $NM ]] || command -v systemctl &> /dev/null
+}
+
 run_server() {
     # Start server first
     echo "MULTINIC TEST SETUP: Starting DHCP/NFS server"

--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
+++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
@@ -20,6 +20,11 @@ KVERSION=${KVERSION-$(uname -r)}
 #DEBUGFAIL="rd.shell rd.break rd.debug"
 #SERIAL="tcp:127.0.0.1:9999"
 
+test_check() {
+    # network-manager module has a dependency on systemd
+    ! [[ $NM ]] || command -v systemctl &> /dev/null
+}
+
 run_server() {
     # Start server first
     echo "MULTINIC TEST SETUP: Starting DHCP/NFS server"


### PR DESCRIPTION
This is useful when the full testsuite is run and systemd is not available.

This will also help test cases self documenting supported configurations.