### PR TITLE
fix(systemd-coredump): correct systemd-coredump binary path

### DIFF
--- a/modules.d/01systemd-coredump/module-setup.sh
+++ b/modules.d/01systemd-coredump/module-setup.sh
@@ -33,7 +33,7 @@ install() {
     inst_multiple -o \
         "$sysctld"/50-coredump.conf \
         "$systemdutildir"/coredump.conf \
-        "$systemdsystemunitdir"/systemd-coredump \
+        "$systemdutildir"/systemd-coredump \
         "$systemdsystemunitdir"/systemd-coredump.socket \
         "$systemdsystemunitdir"/systemd-coredump@.service \
         "$systemdsystemunitdir"/sockets.target.wants/systemd-coredump.socket \


### PR DESCRIPTION
This issue went unnoticed because the systemd module always installs the systemd-coredump binary using the right path.

https://github.com/dracutdevs/dracut/blob/fd9cd02cb21f25d32fec4cd9889457ea6361f45e/modules.d/00systemd/module-setup.sh#L35

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
