### PR TITLE
fix(systemd-timesyncd): typo in systemd-time-wait-sync.service local conf path

### DIFF
--- a/modules.d/01systemd-timesyncd/module-setup.sh
+++ b/modules.d/01systemd-timesyncd/module-setup.sh
@@ -60,8 +60,8 @@ install() {
             "$systemdutilconfdir/timesyncd.conf.d/*.conf" \
             "$systemdsystemconfdir"/systemd-timesyncd.service \
             "$systemdsystemconfdir/systemd-timesyncd.service.d/*.conf" \
-            "$systemdsystemunitdir"/systemd-time-wait-sync.service \
-            "$systemdsystemunitdir/systemd-time-wait-sync.service.d/*.conf" \
+            "$systemdsystemconfdir"/systemd-time-wait-sync.service \
+            "$systemdsystemconfdir/systemd-time-wait-sync.service.d/*.conf" \
             "$sysusersconfdir"/systemd-timesync.conf
     fi
 }


### PR DESCRIPTION
System service and conf already installed above:

https://github.com/dracutdevs/dracut/blob/fd9cd02cb21f25d32fec4cd9889457ea6361f45e/modules.d/01systemd-timesyncd/module-setup.sh#L44-L45

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it