### PR TITLE
ci: make NFS and NBD tests pass in Gentoo test containers

### DIFF
--- a/test/TEST-20-NFS/server-init.sh
+++ b/test/TEST-20-NFS/server-init.sh
@@ -88,7 +88,7 @@ rpc.nfsd
 : > /dev/watchdog
 rpc.mountd
 : > /dev/watchdog
-rpc.idmapd
+command -v rpc.idmapd > /dev/null && [ -z "$(pidof rpc.idmapd)" ] && rpc.idmapd
 : > /dev/watchdog
 exportfs -r
 : > /dev/watchdog

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -279,7 +279,7 @@ test_setup() {
         inst ./dhcpd.conf /etc/dhcpd.conf
         inst_multiple -o {,/usr}/etc/nsswitch.conf {,/usr}/etc/rpc \
             {,/usr}/etc/protocols {,/usr}/etc/services
-        inst_multiple rpc.idmapd /etc/idmapd.conf
+        inst_multiple -o rpc.idmapd /etc/idmapd.conf
 
         inst_libdir_file 'libnfsidmap_nsswitch.so*'
         inst_libdir_file 'libnfsidmap/*.so*'

--- a/test/TEST-50-MULTINIC/server-init.sh
+++ b/test/TEST-50-MULTINIC/server-init.sh
@@ -77,7 +77,7 @@ rpc.nfsd
 : > /dev/watchdog
 rpc.mountd
 : > /dev/watchdog
-rpc.idmapd
+command -v rpc.idmapd > /dev/null && [ -z "$(pidof rpc.idmapd)" ] && rpc.idmapd
 : > /dev/watchdog
 exportfs -r
 : > /dev/watchdog

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -224,7 +224,7 @@ test_setup() {
         inst ./dhcpd.conf /etc/dhcpd.conf
         inst_multiple -o {,/usr}/etc/nsswitch.conf {,/usr}/etc/rpc \
             {,/usr}/etc/protocols {,/usr}/etc/services
-        inst_multiple rpc.idmapd /etc/idmapd.conf
+        inst_multiple -o rpc.idmapd /etc/idmapd.conf
 
         inst_libdir_file 'libnfsidmap_nsswitch.so*'
         inst_libdir_file 'libnfsidmap/*.so*'

--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/server-init.sh
+++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/server-init.sh
@@ -109,7 +109,7 @@ rpc.nfsd
 : > /dev/watchdog
 rpc.mountd
 : > /dev/watchdog
-rpc.idmapd -S
+command -v rpc.idmapd > /dev/null && [ -z "$(pidof rpc.idmapd)" ] && rpc.idmapd -S
 : > /dev/watchdog
 exportfs -r
 : > /dev/watchdog

--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
+++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
@@ -258,7 +258,7 @@ test_setup() {
         inst ./dhcpd.conf /etc/dhcpd.conf
         inst_multiple -o {,/usr}/etc/nsswitch.conf {,/usr}/etc/rpc {,/usr}/etc/protocols
 
-        inst_multiple rpc.idmapd /etc/idmapd.conf
+        inst_multiple -o rpc.idmapd /etc/idmapd.conf
 
         inst_libdir_file 'libnfsidmap_nsswitch.so*'
         inst_libdir_file 'libnfsidmap/*.so*'
@@ -306,7 +306,7 @@ test_setup() {
         inst /etc/passwd /etc/passwd
         inst /etc/group /etc/group
 
-        inst_multiple rpc.idmapd /etc/idmapd.conf
+        inst_multiple -o rpc.idmapd /etc/idmapd.conf
         inst_libdir_file 'libnfsidmap_nsswitch.so*'
         inst_libdir_file 'libnfsidmap/*.so*'
         inst_libdir_file 'libnfsidmap*.so*'

--- a/test/container/Dockerfile-Gentoo
+++ b/test/container/Dockerfile-Gentoo
@@ -20,12 +20,17 @@ RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)'
 # Only install `dmsetup`: attempting to install all of lvm2 fails due to missing kernel headers.
 RUN echo 'sys-fs/lvm2 device-mapper-only -thin' > /etc/portage/package.use/lvm2
 
+RUN echo 'net-fs/nfs-utils -nfsv4' > /etc/portage/package.use/nfs-utils
+
 # Install needed packages for the dracut CI container
 RUN emerge -qv \
     app-arch/cpio \
     app-emulation/qemu \
     app-shells/dash \
+    net-fs/nfs-utils \
+    net-misc/dhcp \
     sys-apps/busybox \
+    sys-block/nbd \
     sys-block/parted \
     sys-fs/btrfs-progs \
     sys-fs/lvm2 \


### PR DESCRIPTION
This PR should enable the following tests to pass in Gentoo:
 - 20 (NFS)
 - 40 (NBD)
 - 50 (MULTINIC)