### PR TITLE
ci: remove native dracut installation from the test containers

### DIFF
--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -51,7 +51,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     shfmt \
     parted \
     ntfsprogs \
-    && dnf -y update && dnf clean all
+    && dnf -y remove dracut && dnf -y update && dnf clean all
 
 # Set default command
 CMD ["/usr/bin/bash"]

--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -14,7 +14,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     sudo kernel dhcp-client qemu-kvm /usr/bin/qemu-system-$(uname -m) e2fsprogs \
     tcpdump iproute iputils kbd NetworkManager btrfsprogs tgt dbus-broker \
     iscsiuio open-iscsi which ShellCheck procps pigz parted squashfs ntfsprogs \
-    && dnf -y update && dnf clean all
+    && dnf -y remove dracut && dnf -y update && dnf clean all
 
 RUN shfmt_version=3.2.4; wget "https://github.com/mvdan/sh/releases/download/v${shfmt_version}/shfmt_v${shfmt_version}_linux_amd64" -O /usr/local/bin/shfmt \
     && chmod +x /usr/local/bin/shfmt


### PR DESCRIPTION
The installed packaged dracut version from distributions can interfere with testing latest dracut from source, which is the primary goal of these containers.

I was not able to uninstall the full dracut package in the openSUSE container, as sadly would also uninstall the mdadm package. Fedora does not have this dependency.