### PR TITLE
fix(base): remove grep dependency

### DIFF
--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -1104,7 +1104,13 @@ make_trace_mem() {
 show_memstats() {
     case $1 in
         shortmem)
-            grep -e "^MemFree" -e "^Cached" -e "^Slab" /proc/meminfo
+            while read -r line || [ -n "$line" ]; do
+                str_starts "$line" "MemFree" \
+                    || str_starts "$line" "Cached" \
+                    || str_starts "$line" "Slab" \
+                    || continue
+                echo "$line"
+            done < /proc/meminfo
             ;;
         mem)
             cat /proc/meminfo


### PR DESCRIPTION
The base module requires `grep` with the `rd.memdebug=1` command line parameter. As this code is broken if `grep` is not added by other means and `grep` is only required for this, rewriting this code to avoid the dependency.

```
# cat /proc/cmdline 
BOOT_IMAGE=/boot/vmlinuz-5.19.2-1-default root=UUID=7fc47d56-42d7-4f0e-9e31-58ea3e4d8158 splash=silent mitigations=auto quiet security=apparmor rd.memdebug=1
# journalctl -b | grep -B1 -w grep
Nov 30 12:02:16 localhost dracut-pre-udev[297]: [debug_mem] hook pre-udev
Nov 30 12:02:16 localhost dracut-pre-udev[299]: /lib/dracut-lib.sh: line 1132: grep: command not found
--
Nov 30 12:02:16 localhost dracut-initqueue[340]: [debug_mem] hook initqueue
Nov 30 12:02:16 localhost dracut-initqueue[345]: /lib/dracut-lib.sh: line 1132: grep: command not found
--
Nov 30 12:02:17 localhost dracut-pre-mount[435]: [debug_mem] hook pre-mount
Nov 30 12:02:17 localhost dracut-pre-mount[437]: /lib/dracut-lib.sh: line 1132: grep: command not found
--
Nov 30 12:02:17 localhost dracut-pre-pivot[497]: [debug_mem] hook pre-pivot
Nov 30 12:02:17 localhost dracut-pre-pivot[499]: /lib/dracut-lib.sh: line 1132: grep: command not found
# grep -n -w grep /usr/lib/dracut/modules.d/99base/dracut-lib.sh
1132:            grep -e "^MemFree" -e "^Cached" -e "^Slab" /proc/meminfo
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
