### PR TITLE
ci: set DEBUGFAIL to rd.debug when debug logging is enabled

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,9 @@ on:
     pull_request:
         branches: [ master ]
 
+env:
+    DEBUGFAIL: "${{ secrets.ACTIONS_STEP_DEBUG && 'rd.debug' }}"
+
 jobs:
     basic:
         runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub Actions allow to opt-in to more debug logging both on web UI and on the command line.

When GitHub Action debug logging is enabled also enable additional dracut test debugging by setting DEBUGFAIL to rd.debug.

This is particularly useful when re-run failed jobs with debug logging enabled.

GiHub documentation for this: https://github.blog/changelog/2022-05-24-github-actions-re-run-jobs-with-debug-logging/

This is how the WebUI looks like for enabling debug logging for dracut:
![image](https://user-images.githubusercontent.com/1522773/205109553-c3565e1e-8a20-4db9-9dfd-a2be8e17a39b.png)
