### PR TITLE
docs: document the new release process

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -40,31 +40,7 @@ This documents contains the necessary steps to conduct a successful release.
 
    Add the section from `NEWS.md` to the git tag message.
 
-6. Push git to kernel.org
-
-   With:
-   ```console
-   $ git remote add kernelorg ssh://gitolite@ra.kernel.org/pub/scm/boot/dracut/dracut.git
-   ```
-
-   Push to kernel.org git:
-   ```console
-   $ git push --atomic kernelorg master "$VERSION"
-   ```
-
-
-7. Sign and upload tarballs to kernel.org
-
-   ```console
-   $ make upload
-   ```
-
-   This requires `kup` and a kernel.org account.
-   Wait until the tarballs are synced to http://www.kernel.org/pub/linux/utils/boot/dracut/ .
-
-8. Create a new release on github (https://github.com/dracutdevs/dracut/releases/new)
+6. Create a new release on github (https://github.com/dracutdevs/dracut/releases/new)
    - Add the section from `NEWS.md` to the release.
-   - Attach the tarballs and signature file from http://www.kernel.org/pub/linux/utils/boot/dracut/ to the github release.
 
-9. Close the github milestone and open a new one (https://github.com/dracutdevs/dracut/milestones)
-10. Ensure that announcement was sent and reached the linux-initramfs mailinglist (https://www.spinics.net/lists/linux-initramfs/)
+7. Close the github milestone and open a new one (https://github.com/dracutdevs/dracut/milestones)


### PR DESCRIPTION
Release tarballs are only available on github from now on.

Fixes #1837

Somewhat related: https://github.com/dracutdevs/dracut/issues/1850

