### PR TITLE
chore(base): remove support for <udev-176.

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -560,6 +560,8 @@ build_ld_cache() {
 }
 
 prepare_udev_rules() {
+    dwarn "prepare_udev_rules: deprecated and will be removed"
+
     if [ -z "$UDEVVERSION" ]; then
         UDEVVERSION=$(udevadm --version)
         export UDEVVERSION

--- a/modules.d/90dm/59-persistent-storage-dm.rules
+++ b/modules.d/90dm/59-persistent-storage-dm.rules
@@ -10,6 +10,6 @@ ENV{DM_NAME}!="?*", GOTO="dm_end"
 ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="1", GOTO="dm_end"
 ENV{DM_UUID}=="CRYPT-TEMP-?*", GOTO="dm_end"
 ENV{DM_UUID}!="?*", ENV{DM_NAME}=="temporary-cryptsetup-?*", GOTO="dm_end"
-IMPORT BLKID
+IMPORT{builtin}="blkid"
 
 LABEL="dm_end"

--- a/modules.d/90dm/module-setup.sh
+++ b/modules.d/90dm/module-setup.sh
@@ -36,7 +36,6 @@ install() {
     inst_rules "$moddir/11-dm.rules"
 
     inst_rules "$moddir/59-persistent-storage-dm.rules"
-    prepare_udev_rules 59-persistent-storage-dm.rules
 
     inst_hook shutdown 25 "$moddir/dm-shutdown.sh"
 }

--- a/modules.d/90mdraid/59-persistent-storage-md.rules
+++ b/modules.d/90mdraid/59-persistent-storage-md.rules
@@ -17,7 +17,7 @@ ATTR{md/array_state}=="|clear|inactive", GOTO="md_end"
 LABEL="md_ignore_state"
 
 IMPORT{program}="/sbin/mdadm --detail --export $tempnode"
-IMPORT BLKID
+IMPORT{builtin}="blkid"
 OPTIONS+="link_priority=100"
 OPTIONS+="watch"
 OPTIONS+="db_persist"

--- a/modules.d/90mdraid/module-setup.sh
+++ b/modules.d/90mdraid/module-setup.sh
@@ -96,7 +96,6 @@ install() {
     inst_rules "$moddir/65-md-incremental-imsm.rules"
 
     inst_rules "$moddir/59-persistent-storage-md.rules"
-    prepare_udev_rules 59-persistent-storage-md.rules
 
     if [[ $hostonly ]] || [[ $mdadmconf == "yes" ]]; then
         if [[ -f $dracutsysrootdir/etc/mdadm.conf ]]; then

--- a/modules.d/95udev-rules/59-persistent-storage.rules
+++ b/modules.d/95udev-rules/59-persistent-storage.rules
@@ -3,7 +3,7 @@ ACTION!="add|change", GOTO="ps_end"
 # Also don't process disks that are slated to be a multipath device
 ENV{DM_MULTIPATH_DEVICE_PATH}=="1", GOTO="ps_end"
 
-KERNEL=="cciss[0-9]*", IMPORT BLKID
-KERNEL=="nbd[0-9]*", IMPORT BLKID
+KERNEL=="cciss[0-9]*", IMPORT{builtin}="blkid"
+KERNEL=="nbd[0-9]*", IMPORT{builtin}="blkid"
 
 LABEL="ps_end"

--- a/modules.d/95udev-rules/61-persistent-storage.rules
+++ b/modules.d/95udev-rules/61-persistent-storage.rules
@@ -12,7 +12,7 @@ GOTO="pss_end"
 
 LABEL="do_pss"
 # by-path (parent device path)
-ENV{DEVTYPE}=="disk", ENV{ID_PATH}=="", DEVPATH!="*/virtual/*", IMPORT PATH_ID
+ENV{DEVTYPE}=="disk", ENV{ID_PATH}=="", DEVPATH!="*/virtual/*", IMPORT{builtin}="path_id"
 ENV{DEVTYPE}=="disk", ENV{ID_PATH}=="?*", SYMLINK+="disk/by-path/$env{ID_PATH}"
 ENV{DEVTYPE}=="partition", ENV{ID_PATH}=="?*", SYMLINK+="disk/by-path/$env{ID_PATH}-part%n"
 

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -50,7 +50,6 @@ install() {
         "$moddir/59-persistent-storage.rules" \
         "$moddir/61-persistent-storage.rules"
 
-    prepare_udev_rules 59-persistent-storage.rules 61-persistent-storage.rules
     # debian udev rules
     inst_rules 91-permissions.rules
     # eudev rules


### PR DESCRIPTION
This PR reverts 579238a3acd0317d7124a76dc489f19d9471fb63.

Udev 176 was released in 2012. I think it is safe to assume that dracut only supports going back 11 years and not more.
