### PR TITLE
feat(dmsquash-live-autooverlay): Add an explicit disabler argument

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1175,6 +1175,11 @@ rd.live.overlay=UUID=99440c1f-8daa-41bf-b965-b7240a8996f4
 Specifies the filesystem to use when formatting the overlay partition.
 The default is ext4.
 
+**rd.live.overlay.nocreate=**1::
+Specifies that a persistent overlay should not be automatically created.
+This option is used to allow automatic persistent overlay detection to be specified,
+while gracefully falling back to temporary overlays if nothing is found.
+
 **rd.live.overlay.size=**__<size_MiB>__::
 Specifies a non-persistent Device-mapper overlay size in MiB.  The default is
 _32768_.

--- a/modules.d/90dmsquash-live-autooverlay/create-overlay.sh
+++ b/modules.d/90dmsquash-live-autooverlay/create-overlay.sh
@@ -14,6 +14,12 @@ gatherData() {
         info "Skipping overlay creation: kernel command line parameter 'rd.live.overlay' is not set"
         exit 0
     fi
+    overlaynocreate=$(getarg rd.live.overlay.nocreate)
+    if [ -n "$overlaynocreate" ]; then
+        info "Skipping overlay creation: automatic overlay creation disabled"
+        exit 0
+    fi
+
     # shellcheck disable=SC2086
     if ! str_starts ${overlay} LABEL=; then
         die "Overlay creation failed: the partition must be set by LABEL in the 'rd.live.overlay' kernel parameter"


### PR DESCRIPTION
This pull request changes...

## Changes
This enables users to set up live media such that if persistence can be used if it has been set up, but it will gracefully fall back to using in-RAM overlays if no persistence volume exists.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it
