### PR TITLE
ci: install procps-ng into Fedora container

### DIFF
--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -51,7 +51,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     shfmt \
     parted \
     ntfsprogs \
-    && dnf -y remove dracut && dnf -y update && dnf clean all
+    && dnf -y remove dracut && dnf -y update && dnf -y install --setopt=install_weak_deps=False procps-ng && dnf clean all
 
 # Set default command
 CMD ["/usr/bin/bash"]


### PR DESCRIPTION
Fixes regression caused by https://github.com/dracutdevs/dracut/commit/bf545567aba244b13eac08491b1fdc3e1bc42aa9 . Regression is only for Fedora container and only for networking tests. 