### PR TITLE
ci: run all local tests on systemd enabled containers

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,7 +46,10 @@ jobs:
         strategy:
             matrix:
                 container: [
+                        "arch:latest",
+                        "debian:latest",
                         "fedora:latest",
+                        "opensuse:latest",
                 ]
                 test: [
                         "01",

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,35 +8,6 @@ env:
     DEBUGFAIL: "${{ secrets.ACTIONS_STEP_DEBUG && 'rd.debug' }}"
 
 jobs:
-    basic:
-        runs-on: ubuntu-latest
-        timeout-minutes: 30
-        concurrency:
-            group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
-            cancel-in-progress: true
-        strategy:
-            matrix:
-                container: [
-                        "arch:latest",
-                        "debian:latest",
-                        "fedora:latest",
-                        "opensuse:latest",
-                ]
-                test: [
-                        "04",
-                ]
-            fail-fast: false
-        container:
-            image: ghcr.io/dracutdevs/${{ matrix.container }}
-            options: "--privileged -v /dev:/dev"
-        steps:
-            -   name: "Checkout Repository"
-                uses: actions/checkout@v3
-                with:
-                    fetch-depth: 0
-
-            -   name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-                run: ./tools/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
     test:
         runs-on: ubuntu-latest
         timeout-minutes: 30
@@ -55,6 +26,7 @@ jobs:
                         "01",
                         "02",
                         "03",
+                        "04",
                         "10",
                         "11",
                         "12",

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,7 @@ env:
 jobs:
     basic:
         runs-on: ubuntu-latest
-        timeout-minutes: 45
+        timeout-minutes: 30
         concurrency:
             group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
             cancel-in-progress: true
@@ -39,7 +39,7 @@ jobs:
                 run: ./tools/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
     test:
         runs-on: ubuntu-latest
-        timeout-minutes: 45
+        timeout-minutes: 30
         concurrency:
             group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
             cancel-in-progress: true


### PR DESCRIPTION
This PR runs the local tests not only on fedora but on all 4 systemd enabled containers.

This PR increases the number of test runs from 32 to 71 (more than double).This sounds quite scary but tests do run in parallel, so it does not actually increases the time to finish running all the tests.

If this for some reason becomes a problem, we can always ration and discuss what is important to run and what gives the project most test coverage, but perhaps as a start we can try with the full "local" matrix.

All tests are passing except test 17 on debian. Test 17 on debian is fixed by https://github.com/dracutdevs/dracut/pull/2028 .