### PR TITLE
test: disable debug logs by default

### DIFF
--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -8,8 +8,6 @@ TEST_DESCRIPTION="root filesystem on NFS with $USE_NETWORK"
 KVERSION=${KVERSION-$(uname -r)}
 
 # Uncomment this to debug failures
-DEBUGFAIL="rd.debug loglevel=7"
-#DEBUGFAIL="rd.shell rd.break rd.debug loglevel=7 "
 #DEBUGFAIL="rd.debug loglevel=7 rd.break=initqueue rd.shell"
 SERVER_DEBUG="rd.debug loglevel=7"
 #SERIAL="unix:/tmp/server.sock"

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -7,9 +7,7 @@ TEST_DESCRIPTION="root filesystem over iSCSI with $USE_NETWORK"
 
 KVERSION=${KVERSION-$(uname -r)}
 
-DEBUGFAIL="loglevel=1"
 #DEBUGFAIL="rd.shell rd.break rd.debug loglevel=7 "
-DEBUGFAIL="rd.debug loglevel=7 "
 #SERVER_DEBUG="rd.debug loglevel=7"
 #SERIAL="tcp:127.0.0.1:9999"
 

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -7,9 +7,7 @@ TEST_DESCRIPTION="root filesystem over multiple iSCSI with $USE_NETWORK"
 
 KVERSION=${KVERSION-$(uname -r)}
 
-#DEBUGFAIL="loglevel=1"
 #DEBUGFAIL="rd.shell rd.break rd.debug loglevel=7 "
-DEBUGFAIL="rd.debug loglevel=7 "
 #SERVER_DEBUG="rd.debug loglevel=7"
 #SERIAL="tcp:127.0.0.1:9999"
 


### PR DESCRIPTION
This makes the the tests more consistent, run faster by default and less likely to timeout on the CI.

This is a follow-up to https://github.com/dracutdevs/dracut/commit/d0a5b039dd02400d4203717c4cfa45dcd369845c. Without these changes enabling debugging on Github does not really taken into effect as the test case itself overwrites the DEBUGFAIL variable.