### PR TITLE
cryptsetup,crypttab - Optional performance enhacement for fast ssds

### DIFF
--- a/modules.d/90crypt/cryptroot-ask.sh
+++ b/modules.d/90crypt/cryptroot-ask.sh
@@ -109,12 +109,26 @@ while [ $# -gt 0 ]; do
         allow-discards)
             allowdiscards="--allow-discards"
             ;;
+        no-read-workqueue)
+            no_read_workqueue="--perf-no_read_workqueue"
+            ;;
+        no-write-workqueue)
+            no_write_workqueue="--perf-no_write_workqueue"
+            ;;
         header=*)
             cryptsetupopts="${cryptsetupopts} --${1}"
             ;;
     esac
     shift
 done
+
+if strstr "$(cryptsetup --help)" "perf-no_read_workqueue"; then
+    cryptsetupopts="$cryptsetupopts $no_read_workqueue"
+fi
+
+if strstr "$(cryptsetup --help)" "perf-no_write_workqueue"; then
+    cryptsetupopts="$cryptsetupopts $no_write_workqueue"
+fi
 
 # parse for allow-discards
 if strstr "$(cryptsetup --help)" "allow-discards"; then

--- a/modules.d/90crypt/cryptroot-ask.sh
+++ b/modules.d/90crypt/cryptroot-ask.sh
@@ -125,10 +125,12 @@ done
 if strstr "$(cryptsetup --help)" "perf-no_read_workqueue"; then
     cryptsetupopts="$cryptsetupopts $no_read_workqueue"
 fi
+unset no_read_workqueue
 
 if strstr "$(cryptsetup --help)" "perf-no_write_workqueue"; then
     cryptsetupopts="$cryptsetupopts $no_write_workqueue"
 fi
+unset no_write_workqueue
 
 # parse for allow-discards
 if strstr "$(cryptsetup --help)" "allow-discards"; then


### PR DESCRIPTION
Reference: https://wiki.archlinux.org/title/Dm-crypt/Specialties#Disable_workqueue_for_increased_solid_state_drive_(SSD)_performance


adds no-read-workqueue,no-write-workqueue  options.