### PR TITLE
ci: run the networking tests with the network meta module

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -87,7 +87,7 @@ jobs:
                         "fedora:latest",
                 ]
                 network: [
-                        "network-manager",
+                        "network",
                         "network-legacy",
                         #"systemd-networkd",
                         #"network-wicked",


### PR DESCRIPTION
Instead of using network-manager dracut module, use the network dracut module, which defaults to network-manager anyways on the Fedora CI container.

This ensures that network module also gets tested without adding a lot of extra additional tests.

Not quite sure yet where this leads us in the future, but I think the most important module for networking to test is the network meta module, and it is wrong if we do not test that.

