### PR TITLE
ci: introduce more networking options into test containers

### DIFF
--- a/test/container/Dockerfile-Arch
+++ b/test/container/Dockerfile-Arch
@@ -11,7 +11,7 @@ RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)'
 RUN pacman --noconfirm -Syu \
     linux dash strace dhclient asciidoc cpio pigz squashfs-tools \
     qemu btrfs-progs mdadm dmraid nfs-utils nfsidmap lvm2 nbd \
-    dhcp networkmanager multipath-tools vi tcpdump open-iscsi \
+    dhcp networkmanager multipath-tools vi tcpdump open-iscsi connman \
     git shfmt shellcheck astyle which base-devel glibc parted ntfs-3g && yes | pacman -Scc
 
 RUN useradd -m build

--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -45,6 +45,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     dbus-daemon \
     kbd \
     NetworkManager \
+    systemd-networkd \
     squashfs-tools \
     which \
     ShellCheck \


### PR DESCRIPTION
Add systemd-networked to Fedora container.
Add connman to Arch container.

This change enables manual testing of various network configurations and also allows the ci to ensure that having additional networking packages installed does not break the network meta module.

