### PR TITLE
fix(systemd-timesynced, systemd-resolved): install system user and group

### DIFF
--- a/modules.d/01systemd-resolved/module-setup.sh
+++ b/modules.d/01systemd-resolved/module-setup.sh
@@ -46,6 +46,14 @@ install() {
     # Enable systemd type unit(s)
     $SYSTEMCTL -q --root "$initdir" enable systemd-resolved.service
 
+    {
+        grep '^systemd-resolve:' "$dracutsysrootdir"/etc/passwd 2> /dev/null
+    } >> "$initdir/etc/passwd"
+
+    {
+        grep '^systemd-resolve:' "$dracutsysrootdir"/etc/group 2> /dev/null
+    } >> "$initdir/etc/group"
+
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \

--- a/modules.d/01systemd-timesyncd/module-setup.sh
+++ b/modules.d/01systemd-timesyncd/module-setup.sh
@@ -52,6 +52,14 @@ install() {
         $SYSTEMCTL -q --root "$initdir" enable "$i"
     done
 
+    {
+        grep '^systemd-timesync:' "$dracutsysrootdir"/etc/passwd 2> /dev/null
+    } >> "$initdir/etc/passwd"
+
+    {
+        grep '^systemd-timesync:' "$dracutsysrootdir"/etc/group 2> /dev/null
+    } >> "$initdir/etc/group"
+
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \


### PR DESCRIPTION
To make use of these daemons a new system user and group needs to be created on installation.
