### PR TITLE
refactor: use read -r instead of cat

### DIFF
--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -82,7 +82,7 @@ fips_load_crypto() {
     local _module
     local _found
 
-    FIPSMODULES=$(cat /etc/fipsmodules)
+    read -d '' -r FIPSMODULES < /etc/fipsmodules
 
     fips_info "Loading and integrity checking all crypto modules"
     mv /etc/modprobe.d/fips.conf /etc/modprobe.d/fips.conf.bak

--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -14,7 +14,7 @@ depends() {
 installkernel() {
     local _fipsmodules _mod _bootfstype
     if [[ -f "${srcmods}/modules.fips" ]]; then
-        _fipsmodules="$(cat "${srcmods}/modules.fips")"
+        read -d '' -r _fipsmodules < "${srcmods}/modules.fips"
     else
         _fipsmodules=""
 

--- a/modules.d/35connman/netroot.sh
+++ b/modules.d/35connman/netroot.sh
@@ -26,7 +26,7 @@ netif=$1
 case "$netif" in
     ??:??:??:??:??:??) # MAC address
         for i in /sys/class/net/*/address; do
-            mac=$(cat "$i")
+            read -r mac < "$i"
             if [ "$mac" = "$netif" ]; then
                 i=${i%/address}
                 netif=${i##*/}

--- a/modules.d/35network-legacy/dhcp-multi.sh
+++ b/modules.d/35network-legacy/dhcp-multi.sh
@@ -58,7 +58,7 @@ do_dhclient() {
         # or it finished execution but failed dhcp on that interface.
 
         if [ $retv -eq 127 ]; then
-            pid=$(cat /tmp/dhclient."$netif".pid)
+            read -r pid < /tmp/dhclient."$netif".pid
             info "PID $pid was not found by wait for $netif"
             if [ -e /tmp/dhclient."$netif".lease ]; then
                 info "PID $pid not found but DHCP successful on $netif"
@@ -116,7 +116,7 @@ if [ $ret -eq 0 ]; then
             # Kill all existing dhclient calls for other interfaces, since we
             # already got one successful interface
 
-            npid=$(cat /tmp/dhclient."$netif".pid)
+            read -r npid < /tmp/dhclient."$netif".pid
             pidlist=$(pgrep dhclient)
             for pid in $pidlist; do
                 [ "$pid" -eq "$npid" ] && continue

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -384,7 +384,7 @@ if [ -z "$NO_TEAM_MASTER" ]; then
                     ip link set dev "$slave" down
                     (
                         unset TEAM_PORT_CONFIG
-                        _hwaddr=$(cat "/sys/class/net/$slave/address")
+                        read -r _hwaddr < "/sys/class/net/$slave/address"
                         _subchannels=$(iface_get_subchannels "$slave")
                         if [ -n "$_hwaddr" ] && [ -e "/etc/sysconfig/network-scripts/mac-${_hwaddr}.conf" ]; then
                             # shellcheck disable=SC1090
@@ -531,7 +531,7 @@ done
 if [ -z "$NO_AUTO_DHCP" ] && [ ! -e "/tmp/net.${netif}.up" ]; then
     ret=1
     if [ -e /tmp/net.bootdev ]; then
-        BOOTDEV=$(cat /tmp/net.bootdev)
+        read -r BOOTDEV < /tmp/net.bootdev
         if [ "$netif" = "$BOOTDEV" ] || [ "$BOOTDEV" = "$(cat "/sys/class/net/${netif}/address")" ]; then
             do_dhcp
             ret=$?

--- a/modules.d/35network-legacy/net-genrules.sh
+++ b/modules.d/35network-legacy/net-genrules.sh
@@ -67,7 +67,7 @@ command -v fix_bootif > /dev/null || . /lib/net-lib.sh
     fi
 
     if [ -e /tmp/net.bootdev ]; then
-        bootdev=$(cat /tmp/net.bootdev)
+        read -r bootdev < /tmp/net.bootdev
     fi
 
     # shellcheck disable=SC2016

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -822,7 +822,7 @@ is_persistent_ethernet_name() {
     local _name_assign_type="0"
 
     [ -f "/sys/class/net/$_netif/name_assign_type" ] \
-        && _name_assign_type=$(cat "/sys/class/net/$_netif/name_assign_type" 2> /dev/null)
+        && read -r _name_assign_type < "/sys/class/net/$_netif/name_assign_type" 2> /dev/null
 
     # NET_NAME_ENUM 1
     [ "$_name_assign_type" = "1" ] && return 1
@@ -857,7 +857,7 @@ is_kernel_ethernet_name() {
     local _name_assign_type="1"
 
     if [ -e "/sys/class/net/$_netif/name_assign_type" ]; then
-        _name_assign_type=$(cat "/sys/class/net/$_netif/name_assign_type")
+        read -r _name_assign_type < "/sys/class/net/$_netif/name_assign_type"
 
         case "$_name_assign_type" in
             2 | 3 | 4)

--- a/modules.d/40network/netroot.sh
+++ b/modules.d/40network/netroot.sh
@@ -26,7 +26,7 @@ netif=$1
 case "$netif" in
     ??:??:??:??:??:??) # MAC address
         for i in /sys/class/net/*/address; do
-            mac=$(cat "$i")
+            read -r mac < "$i"
             if [ "$mac" = "$netif" ]; then
                 i=${i%/address}
                 netif=${i##*/}

--- a/modules.d/45ifcfg/write-ifcfg.sh
+++ b/modules.d/45ifcfg/write-ifcfg.sh
@@ -151,7 +151,7 @@ for netup in /tmp/net.*.did-setup; do
     # shellcheck disable=SC1090
     [ -e /tmp/team."${netif}".info ] && . /tmp/team."${netif}".info
 
-    uuid=$(cat /proc/sys/kernel/random/uuid)
+    read -r uuid < /proc/sys/kernel/random/uuid
     if [ "$netif" = "$bridgename" ]; then
         bridge=yes
     elif [ "$netif" = "$teammaster" ]; then

--- a/modules.d/80cms/cms-write-ifcfg.sh
+++ b/modules.d/80cms/cms-write-ifcfg.sh
@@ -23,7 +23,7 @@ function cms_write_config() {
 
     DEVICE=$(cd "/sys/devices/${driver}/$devbusid/net/" && set -- * && [ "$1" != "*" ] && echo "$1")
 
-    uuid=$(cat /proc/sys/kernel/random/uuid)
+    read -r uuid < /proc/sys/kernel/random/uuid
 
     IFCFGFILE=/run/initramfs/state/etc/sysconfig/network-scripts/ifcfg-$DEVICE
 

--- a/modules.d/90dm/dm-shutdown.sh
+++ b/modules.d/90dm/dm-shutdown.sh
@@ -17,7 +17,7 @@ _remove_dm() {
             return 0
             ;;
         *)
-            devname=$(cat /sys/block/"${dev}"/dm/name)
+            read -r devname < /sys/block/"${dev}"/dm/name
             dmsetup -v --noudevsync remove "$devname" || return $?
             ;;
     esac

--- a/modules.d/90dmsquash-live-autooverlay/create-overlay.sh
+++ b/modules.d/90dmsquash-live-autooverlay/create-overlay.sh
@@ -47,12 +47,12 @@ gatherData() {
     rootDeviceSysfsPath=/sys/class/block/${rootDeviceAbsolutePath##*/}
     if [ -f "${rootDeviceSysfsPath}/partition" ]; then
         # shellcheck disable=SC2086
-        partition=$(cat ${rootDeviceSysfsPath}/partition)
+        read -r partition < ${rootDeviceSysfsPath}/partition
     else
         partition=0
     fi
     # shellcheck disable=SC2086
-    readonly=$(cat ${rootDeviceSysfsPath}/ro)
+    read -r readonly < ${rootDeviceSysfsPath}/ro
     # shellcheck disable=SC2086
     if [ "$partition" != "1" ] || [ "$readonly" != "0" ]; then
         info "Skipping overlay creation: unpartitioned or read-only media detected"

--- a/modules.d/95fcoe/fcoe-up.sh
+++ b/modules.d/95fcoe/fcoe-up.sh
@@ -18,8 +18,8 @@ dcb=$2
 mode=$3
 vlan="yes"
 
-iflink=$(cat /sys/class/net/"$netif"/iflink)
-ifindex=$(cat /sys/class/net/"$netif"/ifindex)
+read -r iflink < /sys/class/net/"$netif"/iflink
+read -r ifindex < /sys/class/net/"$netif"/ifindex
 if [ "$iflink" != "$ifindex" ]; then
     # Skip VLAN devices
     exit 0

--- a/modules.d/95iscsi/iscsiroot.sh
+++ b/modules.d/95iscsi/iscsiroot.sh
@@ -59,7 +59,7 @@ handle_firmware() {
             set -- /sys/firmware/ibft/ethernet*
             echo $#
         )
-        retry=$(cat /tmp/session-retry)
+        read -r retry < /tmp/session-retry
 
         if [ "$retry" -lt "$ifaces" ]; then
             retry=$((retry + 1))

--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -78,10 +78,10 @@ install_iscsiroot() {
     for flash in "${host}"/flashnode_sess-*; do
         [ -f "$flash" ] || continue
         [ ! -e "$flash/is_boot_target" ] && continue
-        is_boot=$(cat "$flash"/is_boot_target)
+        read -r is_boot < "$flash"/is_boot_target
         if [ "$is_boot" -eq 1 ]; then
             # qla4xxx flashnode session; skip iBFT discovery
-            iscsi_initiator=$(cat /sys/class/iscsi_host/"${iscsi_host}"/initiatorname)
+            read -r iscsi_initiator < /sys/class/iscsi_host/"${iscsi_host}"/initiatorname
             echo "rd.iscsi.initiator=${iscsi_initiator}"
             return
         fi
@@ -93,14 +93,14 @@ install_iscsiroot() {
                 c=${d##*/}
                 conn=${d}/iscsi_connection/${c}
                 if [ -d "${conn}" ]; then
-                    iscsi_address=$(cat "${conn}"/persistent_address)
-                    iscsi_port=$(cat "${conn}"/persistent_port)
+                    read -r iscsi_address < "${conn}"/persistent_address
+                    read -r iscsi_port < "${conn}"/persistent_port
                 fi
                 ;;
             *session)
                 if [ -d "${d}"/"${iscsi_session}" ]; then
-                    iscsi_initiator=$(cat "${d}"/"${iscsi_session}"/initiatorname)
-                    iscsi_targetname=$(cat "${d}"/"${iscsi_session}"/targetname)
+                    read -r iscsi_initiator < "${d}"/"${iscsi_session}"/initiatorname
+                    read -r iscsi_targetname < "${d}"/"${iscsi_session}"/targetname
                 fi
                 ;;
         esac

--- a/modules.d/95lunmask/fc_transport_scan_lun.sh
+++ b/modules.d/95lunmask/fc_transport_scan_lun.sh
@@ -20,7 +20,7 @@ HOST=${ID%%:*}
 CHANNEL=${ID%%-*}
 CHANNEL=${CHANNEL#*:}
 if [ -f /sys"$DEVPATH"/scsi_target_id ]; then
-    TARGET=$(cat /sys"$DEVPATH"/scsi_target_id)
+    read -r TARGET < /sys"$DEVPATH"/scsi_target_id
 fi
 [ -z "$TARGET" ] && exit 1
 echo "$CHANNEL" "$TARGET" $LUN > /sys/class/scsi_host/host"$HOST"/scan

--- a/modules.d/95lunmask/module-setup.sh
+++ b/modules.d/95lunmask/module-setup.sh
@@ -21,7 +21,7 @@ cmdline() {
             _rport="${_rport%%/*}"
             _classdev="/sys/class/fc_remote_ports/rport-${_rport}"
             [ -d "$_classdev" ] || return 1
-            _wwpn=$(cat "${_classdev}"/port_name)
+            read -r _wwpn < "${_classdev}"/port_name
             echo "rd.lunmask=fc,${_wwpn},${_lun}"
             return 0
         fi
@@ -31,7 +31,7 @@ cmdline() {
             _end_device="${_end_device%%/*}"
             _classdev="/sys/class/sas_device/end_device-${_end_device}"
             [ -e "$_classdev" ] || return 1
-            _sas_address=$(cat "${_classdev}"/sas_address)
+            read -r _sas_address < "${_classdev}"/sas_address
             echo "rd.lunmask=sas,${_sas_address},${_lun}"
             return 0
         fi
@@ -46,7 +46,7 @@ cmdline() {
 check() {
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         [ -w /sys/module/scsi_mod/parameters/scan ] || return 255
-        scan_type=$(cat /sys/module/scsi_mod/parameters/scan)
+        read -r scan_type < /sys/module/scsi_mod/parameters/scan
         [ "$scan_type" = "manual" ] && return 0
         return 255
     }

--- a/modules.d/95lunmask/sas_transport_scan_lun.sh
+++ b/modules.d/95lunmask/sas_transport_scan_lun.sh
@@ -20,7 +20,7 @@ HOST=${ID%%:*}
 CHANNEL=${ID%%-*}
 CHANNEL=${CHANNEL#*:}
 if [ -f /sys"$DEVPATH"/scsi_target_id ]; then
-    TARGET=$(cat /sys"$DEVPATH"/scsi_target_id)
+    read -r TARGET < /sys"$DEVPATH"/scsi_target_id
 fi
 [ -z "$TARGET" ] && exit 1
 echo 0 "$TARGET" $LUN > /sys/class/scsi_host/host"$HOST"/scan

--- a/modules.d/95nfs/nfsroot-cleanup.sh
+++ b/modules.d/95nfs/nfsroot-cleanup.sh
@@ -2,7 +2,7 @@
 
 type incol2 > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
-[ -f /tmp/nfs.rpc_pipefs_path ] && rpcpipefspath=$(cat /tmp/nfs.rpc_pipefs_path)
+[ -f /tmp/nfs.rpc_pipefs_path ] && read -r rpcpipefspath < /tmp/nfs.rpc_pipefs_path
 [ -z "$rpcpipefspath" ] && rpcpipefspath=var/lib/nfs/rpc_pipefs
 
 pid=$(pidof rpc.statd)

--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -18,7 +18,7 @@ check() {
         for d in device/nvme*; do
             [ -L "$d" ] || continue
             if readlink "$d" | grep -q nvme-fabrics; then
-                trtype=$(cat "$d"/transport)
+                read -r trtype < "$d"/transport
                 break
             fi
         done
@@ -75,7 +75,7 @@ cmdline() {
         for d in device/nvme*; do
             [ -L "$d" ] || continue
             if readlink "$d" | grep -q nvme-fabrics; then
-                trtype=$(cat "$d"/transport)
+                read -r trtype < "$d"/transport
                 break
             fi
         done
@@ -98,11 +98,11 @@ cmdline() {
     }
 
     if [ -f /etc/nvme/hostnqn ]; then
-        _hostnqn=$(cat /etc/nvme/hostnqn)
+        read -r _hostnqn < /etc/nvme/hostnqn
         echo -n " rd.nvmf.hostnqn=${_hostnqn}"
     fi
     if [ -f /etc/nvme/hostid ]; then
-        _hostid=$(cat /etc/nvme/hostid)
+        read -r _hostid < /etc/nvme/hostid
         echo -n " rd.nvmf.hostid=${_hostid}"
     fi
 

--- a/modules.d/95rootfs-block/mount-root.sh
+++ b/modules.d/95rootfs-block/mount-root.sh
@@ -51,7 +51,7 @@ mount_root() {
 
     if ! getargbool 0 rd.skipfsck; then
         if [ -f "$NEWROOT"/fsckoptions ]; then
-            fsckoptions=$(cat "$NEWROOT"/fsckoptions)
+            read -r fsckoptions < "$NEWROOT"/fsckoptions
         fi
 
         if [ -f "$NEWROOT"/forcefsck ] || getargbool 0 forcefsck; then

--- a/modules.d/97masterkey/masterkey.sh
+++ b/modules.d/97masterkey/masterkey.sh
@@ -50,7 +50,7 @@ load_masterkey() {
     fi
 
     # read the kernel master key blob
-    KEYBLOB=$(cat "${MASTERKEYPATH}")
+    read -r KEYBLOB < "${MASTERKEYPATH}"
 
     # add the 'load' prefix if the key type is 'trusted'
     [ "${MASTERKEYTYPE}" = "trusted" ] \

--- a/modules.d/98ecryptfs/ecryptfs-mount.sh
+++ b/modules.d/98ecryptfs/ecryptfs-mount.sh
@@ -36,7 +36,7 @@ load_ecryptfs_key() {
     fi
 
     # read the eCryptfs encrypted key blob
-    KEYBLOB=$(cat "${ECRYPTFSKEYPATH}")
+    read -r KEYBLOB < "${ECRYPTFSKEYPATH}"
 
     # load the eCryptfs encrypted key blob
     if ! ECRYPTFSKEYID=$(keyctl add ${ECRYPTFSKEYTYPE} ${ECRYPTFSKEYDESC} "load ${KEYBLOB}" @u); then

--- a/modules.d/98integrity/evm-enable.sh
+++ b/modules.d/98integrity/evm-enable.sh
@@ -50,7 +50,7 @@ load_evm_key() {
     fi
 
     # read the EVM encrypted key blob
-    KEYBLOB=$(cat "${EVMKEYPATH}")
+    read -r KEYBLOB < "${EVMKEYPATH}"
 
     # load the EVM encrypted key
     if ! EVMKEYID=$(keyctl add ${EVMKEYTYPE} ${EVMKEYDESC} "load ${KEYBLOB}" @u); then

--- a/modules.d/98usrmount/mount-usr.sh
+++ b/modules.d/98usrmount/mount-usr.sh
@@ -26,7 +26,7 @@ fsck_usr() {
     local _fsckoptions
 
     if [ -f "$NEWROOT"/fsckoptions ]; then
-        _fsckoptions=$(cat "$NEWROOT"/fsckoptions)
+        read -r _fsckoptions < "$NEWROOT"/fsckoptions
     fi
 
     if [ -f "$NEWROOT"/forcefsck ] || getargbool 0 forcefsck; then

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -932,7 +932,7 @@ _emergency_shell() {
         if [ -z "$_ctty" ]; then
             _ctty=console
             while [ -f /sys/class/tty/$_ctty/active ]; do
-                _ctty=$(cat /sys/class/tty/$_ctty/active)
+                read -r _ctty < /sys/class/tty/$_ctty/active
                 _ctty=${_ctty##* } # last one in the list
             done
             _ctty=/dev/$_ctty


### PR DESCRIPTION
This pull request changes bad style `var=$(cat <file>)`. Replace by `read -r var < file`

## Checklist
- [x] I have tested it locally

Fixes #2093 