### PR TITLE
fix(network-manager): support nm-initrd-generator under NetworkManager

### DIFF
--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -30,8 +30,8 @@ install() {
     inst_multiple ip sed grep
 
     inst NetworkManager
-    inst_multiple -o /usr/{lib,libexec}/nm-initrd-generator
-    inst_multiple -o /usr/{lib,libexec}/nm-daemon-helper
+    inst_multiple -o /usr/{lib,libexec}{,/NetworkManager}/nm-initrd-generator
+    inst_multiple -o /usr/{lib,libexec}{,/NetworkManager}/nm-daemon-helper
     inst_multiple -o teamd dhclient
     inst_hook cmdline 99 "$moddir/nm-config.sh"
     if dracut_module_included "systemd"; then


### PR DESCRIPTION
Upstream NetworkManager explicitly [supports Debian](https://github.com/NetworkManager/NetworkManager/blob/main/.gitlab-ci/debian-install.sh). This PR proposes the same for the network-manager dracut module.

Upstream NetworkManager explicitly supports prefix for libexecdir [here](https://github.com/NetworkManager/NetworkManager/blob/main/meson.build#L41) .

In [network-manager/module-setup.sh nm-initrd-generator](https://github.com/dracutdevs/dracut/blob/master/modules.d/35network-manager/module-setup.sh#L33) is already marked optional to accomodate different locations for nm-initrd-generator in different setups as the path is not stable between Linux installations and versions.

The file in [Debian 12](https://packages.debian.org/bookworm/amd64/network-manager/filelist) is located in `/usr/lib/NetworkManager/nm-initrd-generator` .

The file location has been in stable Debian **for about 4 years now** ([since Debian 10](https://packages.debian.org/buster/amd64/network-manager/filelist)). 

This issue impacts over 50 Linux distributions and blocks testing NetwrokManager for Debian on the upstream CI.

From [FHS 3.0](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s07.html)

> Some previous versions of this document did not support /usr/libexec, despite it being standard practice in a number of environments. To accomodate this restriction, it became common practice to use /usr/lib instead. **Either practice is now acceptable**, but each application must choose one way or the other to organize itself.

CC @Mrfai  @bdrung