### PR TITLE
RFC: feat(lvm): always include all drivers that LVM can use

### DIFF
--- a/modules.d/90lvm/module-setup.sh
+++ b/modules.d/90lvm/module-setup.sh
@@ -43,7 +43,7 @@ cmdline() {
 }
 
 installkernel() {
-    hostonly='' instmods dm-snapshot
+    hostonly='' dracut_instmods -o -P ".*/(bcache/|md-cluster).*" "=drivers/md"
 }
 
 # called by dracut


### PR DESCRIPTION
This patch adds all the kernel modules that might be needed by LVM, to avoid having to rebuild the initrd in hostonly mode after a dynamic change that requires new drivers to boot.

For example, LVM allows to dynamically convert a linear logical volume to a RAID-1 type (`lvconvert --type raid1 vg/lv`), which, in hostonly mode, will require the user to manually rebuild the initrd again to include the new RAID drivers in use, otherwise the system will fail to boot.

Identified kernel modules used by LVM (CC: @zhaohem @teigland): all in `drivers/md/*`, excluding `bcache` directory and `md-cluster.ko`.

The size increase is approx. +1MB (using zstd compression):

```
localhost:~ # ls -l initrd-6.0.7-1-default-*
-rw------- 1 root root 22675622 Dec 13 14:43 initrd-6.0.7-1-default-before
-rw------- 1 root root 23758084 Dec 14 09:38 initrd-6.0.7-1-default-after
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
