### PR TITLE
fix(dmsquash-live): allow other fstypes

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+type det_fs > /dev/null 2>&1 || . /lib/fs-lib.sh
 
 command -v unpack_archive > /dev/null || . /lib/img-lib.sh
 
@@ -61,7 +62,7 @@ get_check_dev() {
 # Find the right device to run check on
 check_dev=$(get_check_dev "$livedev")
 # CD/DVD media check
-[ -b "$check_dev" ] && fs=$(blkid -s TYPE -o value "$check_dev")
+[ -b "$check_dev" ] && fs=$(det_fs "$check_dev")
 if [ "$fs" = "iso9660" -o "$fs" = "udf" ]; then
     check="yes"
 fi
@@ -110,7 +111,7 @@ if [ -f "$livedev" ]; then
     esac
     [ -e /sys/fs/"$fstype" ] || modprobe "$fstype"
 else
-    livedev_fstype=$(blkid -o value -s TYPE "$livedev")
+    livedev_fstype=$(det_fs "$livedev")
     if [ "$livedev_fstype" = "squashfs" ]; then
         # no mount needed - we've already got the LiveOS image in $livedev
         SQUASHED=$livedev

--- a/test/TEST-16-DMSQUASH/create-root.sh
+++ b/test/TEST-16-DMSQUASH/create-root.sh
@@ -26,6 +26,16 @@ mkdir -p /root/run /root/testdir
 cp -a -t /root /source/*
 echo "Creating squashfs"
 mksquashfs /source /root/testdir/rootfs.img -quiet
+
+# Copy rootfs.img to the NTFS drive if exists
+if [ -e "/dev/disk/by-id/ata-disk_root_ntfs" ]; then
+    mkfs.ntfs -F -L dracut_ntfs /dev/disk/by-id/ata-disk_root_ntfs
+    mkdir -p /root_ntfs
+    mount -t ntfs3 /dev/disk/by-id/ata-disk_root_ntfs /root_ntfs
+    mkdir -p /root_ntfs/run /root_ntfs/testdir
+    cp /root/testdir/rootfs.img /root_ntfs/testdir/rootfs.img
+fi
+
 umount /root
 echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 poweroff -f

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -15,6 +15,11 @@ test_run() {
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root
 
+    # NTFS drive
+    if modprobe --dry-run ntfs3 &> /dev/null && command -v mkfs.ntfs &> /dev/null; then
+        qemu_add_drive_args disk_index disk_args "$TESTDIR"/root_ntfs.img root_ntfs
+    fi
+
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -boot order=d \
@@ -40,6 +45,18 @@ test_run() {
         -initrd "$TESTDIR"/initramfs.testing
 
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success -- "$TESTDIR"/marker.img || return 1
+
+    # Run the NTFS test only if mkfs.ntfs is available
+    if modprobe --dry-run ntfs3 &> /dev/null && command -v mkfs.ntfs &> /dev/null; then
+        dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
+        "$testdir"/run-qemu \
+            "${disk_args[@]}" \
+            -boot order=d \
+            -append "rd.live.image rd.live.overlay.overlayfs=1 rd.live.dir=testdir root=LABEL=dracut_ntfs console=ttyS0,115200n81 quiet selinux=0 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 $DEBUGFAIL" \
+            -initrd "$TESTDIR"/initramfs.testing
+
+        grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success -- "$TESTDIR"/marker.img || return 1
+    fi
 
     dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     rootPartitions=$(sfdisk -d "$TESTDIR"/root.img | grep -c 'root\.img[0-9]')
@@ -81,8 +98,8 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         --modules "test-makeroot rootfs-block qemu" \
-        --drivers "ext4 sd_mod" \
-        --install "sfdisk mkfs.ext4 mksquashfs" \
+        --drivers "ext4 ntfs3 sd_mod" \
+        --install "sfdisk mkfs.ext4 mkfs.ntfs mksquashfs" \
         --include ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --no-hostonly --no-hostonly-cmdline --no-early-microcode --nofscks --nomdadmconf --nohardlink --nostrip \
         --force "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
@@ -96,6 +113,12 @@ test_setup() {
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root
 
+    # NTFS drive
+    if modprobe --dry-run ntfs3 &> /dev/null && command -v mkfs.ntfs &> /dev/null; then
+        dd if=/dev/zero of="$TESTDIR"/root_ntfs.img bs=1MiB count=160
+        qemu_add_drive_args disk_index disk_args "$TESTDIR"/root_ntfs.img root_ntfs
+    fi
+
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -107,11 +130,17 @@ test_setup() {
         return 1
     fi
 
+    # mount NTFS with ntfs3 driver inside the generated initramfs
+    cat > /tmp/ntfs3.rules << 'EOF'
+SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="ntfs", ENV{ID_FS_TYPE}="ntfs3"
+EOF
+
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         --modules "test dash dmsquash-live qemu" \
         --omit "rngd" \
-        --drivers "ext4 sd_mod" \
+        --drivers "ext4 ntfs3 sd_mod" \
         --install "mkfs.ext4" \
+        --include /tmp/ntfs3.rules /lib/udev/rules.d/ntfs3.rules \
         --no-hostonly --no-hostonly-cmdline \
         --force "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -18,15 +18,21 @@ test_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -boot order=d \
-        -append "rd.live.overlay.overlayfs=1 root=LABEL=dracut console=ttyS0,115200n81 quiet selinux=0 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 $DEBUGFAIL" \
+        -append "rd.live.overlay.overlayfs=1 root=live:/dev/disk/by-label/dracut console=ttyS0,115200n81 quiet selinux=0 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing
 
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success -- "$TESTDIR"/marker.img || return 1
+
+    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -boot order=d \
         -append "rd.live.image rd.live.overlay.overlayfs=1 root=LABEL=dracut console=ttyS0,115200n81 quiet selinux=0 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing
 
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success -- "$TESTDIR"/marker.img || return 1
+
+    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -boot order=d \
@@ -35,6 +41,7 @@ test_run() {
 
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success -- "$TESTDIR"/marker.img || return 1
 
+    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     rootPartitions=$(sfdisk -d "$TESTDIR"/root.img | grep -c 'root\.img[0-9]')
     [ "$rootPartitions" -eq 1 ] || return 1
 


### PR DESCRIPTION
This PR provides a test case that currently fails. It than fixes the dmsquash-live module which than make the test case to pass.

The test is booting from an ntfs partition. The fix is to mount "other fstypes" as "auto" if dracut does not recognize the fstype. This than enables booting from ntfs with the ntfs3 driver without assuming that ntfs3 driver is preferred or specifically adding any kind of ntfs3 support code into dracut.

The test case introduced fails without additional fixes in the dmsquash-live module.
Link to the log of the failed run https://github.com/dracutdevs/dracut/actions/runs/3717705436/jobs/6305328592

> 2022-12-17T01:09:26.6103722Z [   18.783055] dracut: FATAL: Failed to mount block device of live image: Missing NTFS support
> 2022-12-17T01:09:26.6112994Z [   18.784772] dracut: Refusing to continue

This error message is coming from: https://github.com/dracutdevs/dracut/blob/master/modules.d/90dmsquash-live/dmsquash-live-root.sh#L136

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [X] I am providing new code and test(s) for it