### PR TITLE
Guard kernel install hook

### DIFF
--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -5,6 +5,13 @@ KERNEL_VERSION="$2"
 BOOT_DIR_ABS="$3"
 KERNEL_IMAGE="$4"
 
+# Only generate a standard initrd if the installation layout asks for it.
+# In particular do not generate an initrd file if the layout is "uki", i.e. asks
+# for a unified kernel image.
+[[ "$KERNEL_INSTALL_LAYOUT" = "bls" ]] || exit 0
+# Only run dracut if asked to do so.
+[[ "$KERNEL_INSTALL_INITRD_GENERATOR" = "dracut" ]] || exit 0
+
 # If KERNEL_INSTALL_MACHINE_ID is defined but empty, BOOT_DIR_ABS is a fake directory.
 # So, let's skip to create initrd.
 if ! [[ ${KERNEL_INSTALL_MACHINE_ID-x} ]]; then

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -8,6 +8,13 @@ BOOT_DIR_ABS="${3%/*}/0-rescue"
 KERNEL_IMAGE="$4"
 
 
+# Only generate a standard initrd if the installation layout asks for it.
+# In particular do not generate an initrd file if the layout is "uki", i.e. asks
+# for a unified kernel image.
+[[ "$KERNEL_INSTALL_LAYOUT" = "bls" ]] || exit 0
+# Only run dracut if asked to do so.
+[[ "$KERNEL_INSTALL_INITRD_GENERATOR" = "dracut" ]] || exit 0
+
 dropindirs_sort()
 {
     suffix=$1; shift


### PR DESCRIPTION
## Changes

Only run our kernel-install if the initrd generator is set to dracut, and if the layout asks for a conventional bls layout.

In particular do not run this hook if the initrd generator is `mkinitcpio`, as used by Arch's standard mkinitpcio tool, and do not run this hook if the layout is set to uki, i.e. if the user asks for a unified kernel image to be generated.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
