### PR TITLE
feat(lvm): install lvm commands symlinks

### DIFF
--- a/modules.d/90lvm/module-setup.sh
+++ b/modules.d/90lvm/module-setup.sh
@@ -50,6 +50,12 @@ installkernel() {
 install() {
     inst_multiple lvm grep
 
+    # install lvm commands symlinks useful for emergency shell
+    _lvm_bin=$(find_binary lvm)
+    while read -r -d '' file; do
+        inst "${file}"
+    done < <(find -L /sbin -maxdepth 1 -samefile "$_lvm_bin" -print0)
+
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _lvmconf
         _lvmconf=$(cmdline)


### PR DESCRIPTION
May I suggest, with this patch, to add lvm core functionality to the initrd tree.

It will install for convenience, lvm's core commands tools. **lvm** package installs all of them as symlink to the binary, and they are universally used without `lvm` command.
It would be helpful for admin to recreate a familiar environment during the emergency shell. If someone is reaching for these tools in the initrd it's probably because something is wrong, and so the admin may be stressed or flustered and may not connect that "lvm" as a command does everything they need. So recreating a familiar environment will really help them.

Nevertheless, I agree to keep the minimal stuff as possible to the initrd, but as it is "only" symlink, it doesn't increase a lot the size, see below, we just add 1K Bytes:

```bash
localhost:~ # ls -lh --block-size=K /boot/test
-rw------- 1 root root 29963K Dec 19 14:04 initrd-5.19.8-1-default-after
-rw------- 1 root root 29962K Dec 19 14:03 initrd-5.19.8-1-default-before
```

So, What do you think about this changes for helping with the user experience ?

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

