### PR TITLE
Revert "fix(35network-manager): avoid restarting NetworkManager"

### DIFF
--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -2,10 +2,6 @@
 
 type source_hook > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
-if [ -e /tmp/nm.done ]; then
-    return
-fi
-
 if [ -z "$DRACUT_SYSTEMD" ]; then
     # Only start NM if networking is needed
     if [ -e /run/NetworkManager/initrd/neednet ]; then


### PR DESCRIPTION
This reverts commit 77630365aed201a729c73a9ffda0733a75f3fee4.

Its commit message states:

```
  On EL8.3 the NetworkManager keep restarting even if it exits successfully
  while waiting for Clevis to unlock. This patch ensures NetworkManager runs
  only once in initrd.
```

Yes; NetworkManager is run multiple times, so that it's able to configure interfaces that haven't been seen previously (because bus was slow to scan or device took time to initialize).

It's not clear what problem was the original commit trying to fix. I suspect there was no problem, just a misunderstanding.