### PR TITLE
feat(network,dbus): meta module should check if module exists

### DIFF
--- a/modules.d/09dbus/module-setup.sh
+++ b/modules.d/09dbus/module-setup.sh
@@ -19,10 +19,10 @@ depends() {
         fi
     done
 
-    if find_binary dbus-broker &> /dev/null; then
+    if [[ -d "$dracutbasedir"/modules.d/06dbus-broker ]] && find_binary dbus-broker &> /dev/null; then
         echo "dbus-broker"
         return 0
-    else
+    elif [[ -d "$dracutbasedir"/modules.d/06dbus-daemon ]]; then
         echo "dbus-daemon"
         return 0
     fi

--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -17,15 +17,15 @@ depends() {
     done
 
     if [ -z "$network_handler" ]; then
-        if [[ -e $dracutsysrootdir$systemdsystemunitdir/wicked.service ]]; then
+        if [[ -d "$dracutbasedir"/modules.d/35network-wicked ]] && [[ -e $dracutsysrootdir$systemdsystemunitdir/wicked.service ]]; then
             network_handler="network-wicked"
-        elif [[ -e $dracutsysrootdir$systemdsystemunitdir/connman.service ]]; then
+        elif [[ -d "$dracutbasedir"/modules.d/35connman ]] && [[ -e $dracutsysrootdir$systemdsystemunitdir/connman.service ]]; then
             network_handler="connman"
-        elif [[ -x $dracutsysrootdir/usr/libexec/nm-initrd-generator ]] || [[ -x $dracutsysrootdir/usr/lib/nm-initrd-generator ]]; then
+        elif [[ -d "$dracutbasedir"/modules.d/35network-manager ]] && [[ -x $dracutsysrootdir/usr/libexec/nm-initrd-generator ]] || [[ -x $dracutsysrootdir/usr/lib/nm-initrd-generator ]]; then
             network_handler="network-manager"
-        elif [[ -x $dracutsysrootdir$systemdutildir/systemd-networkd ]]; then
+        elif [[ -d "$dracutbasedir"/modules.d/01systemd-networkd ]] && [[ -x $dracutsysrootdir$systemdutildir/systemd-networkd ]]; then
             network_handler="systemd-networkd"
-        else
+        elif [[ -d "$dracutbasedir"/modules.d/35network-legacy ]]; then
             network_handler="network-legacy"
         fi
     fi


### PR DESCRIPTION
dracut modules are design to be optional, so meta module should not just assume that all modules are available.

It has been a recommended practice by dracut to drop unsupported dracut modules for a given vendor/distro/architecture that are not supported  - see https://github.com/dracutdevs/dracut/blob/master/pkgbuild/dracut.spec for examples

meta packages should support this practice.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: #1756