### PR TITLE
fix(systemd-hostnamed): correct sysusers configuration

### DIFF
--- a/modules.d/01systemd-hostnamed/systemd-hostname-dracut.conf
+++ b/modules.d/01systemd-hostnamed/systemd-hostname-dracut.conf
@@ -1,2 +1,2 @@
 # This file is part of dracut systemd-hostnamed module.
-g systemd-hostname - "systemd hostname"
+g systemd-hostname -


### PR DESCRIPTION
Lines of type 'g' don't take a GECOS field.

```
Dec 22 10:27:28 sd-net-test systemd-sysusers[198]: /usr/lib/sysusers.d/systemd-hostname-dracut.conf:2: Lines of type 'g' don't take a GECOS field.
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it