### PR TITLE
fix(dbus-broker): add missing sockets.target.wants/dbus.socket

### DIFF
--- a/modules.d/06dbus-broker/module-setup.sh
+++ b/modules.d/06dbus-broker/module-setup.sh
@@ -54,6 +54,8 @@ install() {
         "$systemduser"/dbus-broker.service \
         "$systemdsystemunitdir"/dbus.socket \
         "$systemduser"/dbus.socket \
+        "$systemdsystemunitdir"/sockets.target.wants/dbus.socket \
+        "$systemduser"/sockets.target.wants/dbus.socket \
         "$systemdsystemunitdir"/dbus.target.wants \
         busctl dbus-broker dbus-broker-launch
 
@@ -77,7 +79,8 @@ install() {
             "$systemdsystemconfdir"/dbus.socket \
             "$systemdsystemconfdir"/dbus.socket.d/*.conf \
             "$systemdsystemconfdir"/dbus-broker.service \
-            "$systemdsystemconfdir"/dbus-broker.service.d/*.conf
+            "$systemdsystemconfdir"/dbus-broker.service.d/*.conf \
+            "$systemdsystemconfdir"/sockets.target.wants/dbus.socket
     fi
 
     # We need to make sure that systemd-tmpfiles-setup.service->dbus.socket


### PR DESCRIPTION
If `dbus.socket` is not started automatically in the initrd, all binaries that require dbus to work fail.

E.g.:
```
sh-5.2# networkctl 
Failed to connect system bus: No such file or directory
sh-5.2# resolvectl 
sd_bus_open_system: No such file or directory
sh-5.2# systemctl status dbus.socket
○ dbus.socket - D-Bus System Message Bus Socket
     Loaded: loaded (/usr/lib/systemd/system/dbus.socket; static)
     Active: inactive (dead)
   Triggers: ● dbus-broker.service
     Listen: /run/dbus/system_bus_socket (Stream)
sh-5.2# systemctl start dbus.socket
sh-5.2# networkctl 
IDX LINK   TYPE     OPERATIONAL SETUP     
  1 lo     loopback carrier     unmanaged
  2 enp1s0 ether    routable    configured

2 links listed.
sh-5.2# resolvectl 
Global
       Protocols: +LLMNR +mDNS -DNSOverTLS DNSSEC=no/unsupported
resolv.conf mode: stub
     DNS Servers: 8.8.8.8 1.1.1.1

Link 2 (enp1s0)
Current Scopes: DNS LLMNR/IPv4 LLMNR/IPv6
     Protocols: +DefaultRoute +LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported
   DNS Servers: 192.168.122.1
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
