### PR TITLE
fix(systemd-hostnamed): add missing dbus-org.freedesktop.hostname1.service

### DIFF
--- a/modules.d/01systemd-hostnamed/module-setup.sh
+++ b/modules.d/01systemd-hostnamed/module-setup.sh
@@ -39,6 +39,7 @@ install() {
         "$systemdutildir"/systemd-hostnamed \
         "$systemdsystemunitdir"/systemd-hostnamed.service \
         "$systemdsystemunitdir/systemd-hostnamed.service.d/*.conf" \
+        "$systemdsystemunitdir"/dbus-org.freedesktop.hostname1.service \
         hostnamectl
 
     # Install the hosts local user configurations if enabled.


### PR DESCRIPTION
Without this service, `hostnamectl` fails to run in the initrd.

```
sh-5.2# hostnamectl
Failed to query system properties: Could not activate remote peer: activation request failed: unknown unit.
sh-5.2# systemctl status dbus | grep hostname
Dec 22 11:07:56 sd-net-test dbus-broker-launch[216]: Activation request for 'org.freedesktop.hostname1' failed: The systemd unit 'dbus-org.freedesktop.hostname1.service' could not be found.
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
