### PR TITLE
fix(systemd-timedated): add missing dbus-org.freedesktop.timedate1.service

### DIFF
--- a/modules.d/01systemd-timedated/module-setup.sh
+++ b/modules.d/01systemd-timedated/module-setup.sh
@@ -34,6 +34,7 @@ install() {
         "$dbussystemservices"/org.freedesktop.timedate1.service \
         "$systemdutildir"/systemd-timedated \
         "$systemdsystemunitdir"/systemd-timedated.service \
+        "$systemdsystemunitdir"/dbus-org.freedesktop.timedate1.service \
         timedatectl
 
     # Install the hosts local user configurations if enabled.


### PR DESCRIPTION
Without this service, `timedatectl` fails to run in the initrd.

```
sh-5.2# timedatectl
Failed to query server: Could not activate remote peer: activation request failed: unknown unit.
sh-5.2# systemctl status dbus | grep timedate
Dec 22 13:57:03 sd-net-test dbus-broker-launch[219]: Activation request for 'org.freedesktop.timedate1' failed: The systemd unit 'dbus-org.freedesktop.timedate1.service' could not be found.
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

