### PR TITLE
Save the configuration of an image in the image.

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -338,6 +338,14 @@ case $bin in
         ;;
 esac
 
+type "${CAT%% *}" > /dev/null 2>&1 || {
+    echo "
+    Compressor package '${CAT%% *}' is not available.
+        Try 'sudo dnf install ${CAT%% *}'.
+        "
+    exit 1
+}
+
 skipcpio() {
     $SKIP "$@" | $ORIG_CAT
 }

--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -62,10 +62,13 @@ OPTIONS
 **-f, --force**::
     Overwrite existing initramfs file.
 
-_<output file>_ **--rebuild**::
-    Append the current arguments to those with which the input initramfs image
-    was built. This option helps in incrementally building the initramfs for
-    testing. If optional _<output file>_ is not provided, the input initramfs
+**--rebuild** [_<output file>_]::
+    Append any current arguments to those saved in an input initramfs image.
+    Ignore the configuration directory files, --confdir _<directory>_ (default
+    /etc/dracut.conf.d/) and source those saved in the input initramfs image at
+    */lib/dracut/conffiles/* as well as any newly provided in -c, --conf
+    _<file>_.  This option aids in incrementally building the initramfs for
+    testing.  If optional _<output file>_ is not provided, the input initramfs
     provided to rebuild will be used as output file.
 
 **-a, --add** _<list of dracut modules>_::


### PR DESCRIPTION
Save the configuration files used to build an image in
the initrd image and incorporate them in --rebuild mode.
This facilitates image rebuilding and supplements the
build-parameter.txt record of the dracut command line
arguments.

Allow the --rebuild [output file] to be optional, as
documented. Update and fix the documentation of --rebuild,
which is hidden on some online versions of the manual page.

Also, drop a redundant existence check for config files
in the configuration directory.

### Checklist
- [✔] I have tested it locally.
- [✔] I have reviewed and updated the documentation.


Also, check for missing compressor software packages
and provide improved feedback to the user.  Avoid the
confusion experienced in #2034.
