### PR TITLE
fix(dmsquash-live): live:/dev/*

### DIFF
--- a/modules.d/90dmsquash-live/parse-dmsquash-live.sh
+++ b/modules.d/90dmsquash-live/parse-dmsquash-live.sh
@@ -34,6 +34,7 @@ case "$liveroot" in
         rootok=1
         ;;
     live:/dev/*)
+        root="live:${root#live:}"
         rootok=1
         ;;
     live:/*.[Ii][Mm][Gg] | /*.[Ii][Mm][Gg])


### PR DESCRIPTION
fix a bug introduced in 71cfa2e22

make sure root is set correctly for both of the following cases
 - "root=live:/dev/*"
 - "rd.live.image root=/dev/*"