### PR TITLE
fix: shellcheck 0.8.0

### DIFF
--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -143,7 +143,7 @@ do_fips() {
             BOOT_IMAGE="$(echo "${BOOT_IMAGE}" | sed 's/^(.*)//')"
 
             BOOT_IMAGE_NAME="${BOOT_IMAGE##*/}"
-            BOOT_IMAGE_PATH="${BOOT_IMAGE%${BOOT_IMAGE_NAME}}"
+            BOOT_IMAGE_PATH="${BOOT_IMAGE%"${BOOT_IMAGE_NAME}"}"
 
             if [ -z "$BOOT_IMAGE_NAME" ]; then
                 BOOT_IMAGE_NAME="vmlinuz-${KERNEL}"

--- a/modules.d/35network-legacy/parse-ip-opts.sh
+++ b/modules.d/35network-legacy/parse-ip-opts.sh
@@ -12,6 +12,9 @@
 # routing,dns,dhcp-options,etc.
 #
 
+# we really need to use `expr substr` with dash
+# shellcheck disable=SC2003 disable=SC2308
+
 command -v getarg > /dev/null || . /lib/dracut-lib.sh
 
 if [ -n "$netroot" ] && [ -z "$(getarg ip=)" ] && [ -z "$(getarg BOOTIF=)" ]; then

--- a/modules.d/90mdraid/parse-md.sh
+++ b/modules.d/90mdraid/parse-md.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # we really need to use `expr substr` with dash
-# shellcheck disable=SC2003
+# shellcheck disable=SC2003 disable=SC2308
 
 MD_UUID=$(getargs rd.md.uuid -d rd_MD_UUID=)
 # normalize the uuid

--- a/modules.d/95nfs/nfs-lib.sh
+++ b/modules.d/95nfs/nfs-lib.sh
@@ -36,7 +36,7 @@ nfsroot_to_var() {
     # strip nfs[4]:
     local arg="$*:"
     nfs="${arg%%:*}"
-    arg="${arg##$nfs:}"
+    arg="${arg##"$nfs":}"
 
     # check if we have a server
     if strstr "$arg" ':/'; then
@@ -47,7 +47,7 @@ nfsroot_to_var() {
     path="${arg%%:*}"
 
     # rest are options
-    options="${arg##$path}"
+    options="${arg##"$path"}"
     # strip leading ":"
     options="${options##:}"
     # strip  ":"


### PR DESCRIPTION
Add missing fixes to pass shellcheck 0.8.0.

```
# make syncheck 
find . -name '*.sh' -print0 | xargs -0 shellcheck
# echo $?
0
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
