### PR TITLE
fix(lsinitrd.sh): handle filenames with special characters

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -176,6 +176,8 @@ extract_files() {
     for f in "${!filenames[@]}"; do
         [[ $nofileinfo ]] || echo "initramfs:/$f"
         [[ $nofileinfo ]] || echo "========================================================================"
+        # shellcheck disable=SC2001
+        [[ $f == *"\\x"* ]] && f=$(echo "$f" | sed 's/\\x.\{2\}/????/g')
         $CAT "$image" 2> /dev/null | cpio --extract --verbose --quiet --to-stdout "$f" 2> /dev/null
         ((ret += $?))
         [[ $nofileinfo ]] || echo "========================================================================"
@@ -219,7 +221,9 @@ list_squash_content() {
 unpack_files() {
     if ((${#filenames[@]} > 0)); then
         for f in "${!filenames[@]}"; do
-            $CAT "$image" 2> /dev/null | cpio -id --quiet $verbose $f
+            # shellcheck disable=SC2001
+            [[ $f == *"\\x"* ]] && f=$(echo "$f" | sed 's/\\x.\{2\}/????/g')
+            $CAT "$image" 2> /dev/null | cpio -id --quiet $verbose "$f"
             ((ret += $?))
         done
     else


### PR DESCRIPTION
Printing and unpacking of specific files passed as arguments does not work if their filenames contain special characters with a hexadecimal character escape (`\x`), which is often the case with systemd device units.

E.g. before the patch:
```
# lsinitrd | grep timeout.conf
-rw-r--r--   1 root     root           46 Dec 14 16:14 etc/systemd/system/dev-disk-by\x2duuid-52A8\x2dA0F6.device.d/timeout.conf
# lsinitrd -f "etc/systemd/system/dev-disk-by\x2duuid-52A8\x2dA0F6.device.d/timeout.conf"
# lsinitrd --unpack /boot/initrd-$(uname -r) "etc/systemd/system/dev-disk-by\x2duuid-52A8\x2dA0F6.device.d/timeout.conf"
# cat "etc/systemd/system/dev-disk-by\x2duuid-52A8\x2dA0F6.device.d/timeout.conf"
cat: 'etc/systemd/system/dev-disk-by\x2duuid-52A8\x2dA0F6.device.d/timeout.conf': No such file or directory
# lsinitrd --unpack
# cat "etc/systemd/system/dev-disk-by\x2duuid-52A8\x2dA0F6.device.d/timeout.conf"
[Unit]
JobTimeoutSec=0
JobRunningTimeoutSec=0
```

After the patch:
```
# lsinitrd | grep "\\\\x"
drwxr-xr-x   2 root     root            0 Dec 14 16:14 etc/systemd/system/dev-disk-by\x2duuid-52A8\x2dA0F6.device.d
-rw-r--r--   1 root     root           46 Dec 14 16:14 etc/systemd/system/dev-disk-by\x2duuid-52A8\x2dA0F6.device.d/timeout.conf
lrwxrwxrwx   1 root     root           42 Dec 14 16:14 etc/systemd/system/initrd.target.wants/dev-disk-by\x2duuid-52A8\x2dA0F6.device -> ../dev-disk-by\x2duuid-52A8\x2dA0F6.device
-rw-r--r--   1 root     root           92 Dec 14 16:14 usr/lib/dracut/hooks/emergency/80-\x2fdev\x2fdisk\x2fby-uuid\x2f52A8-A0F6.sh
-rw-r--r--   1 root     root           37 Dec 14 16:14 usr/lib/dracut/hooks/initqueue/finished/devexists-\x2fdev\x2fdisk\x2fby-uuid\x2f52A8-A0F6.sh
# lsinitrd -f "etc/systemd/system/dev-disk-by\x2duuid-52A8\x2dA0F6.device.d/timeout.conf" -f "usr/lib/dracut/hooks/emergency/80-\x2fdev\x2fdisk\x2fby-uuid\x2f52A8-A0F6.sh" -f "usr/lib/dracut/hooks/initqueue/finished/devexists-\x2fdev\x2fdisk\x2fby-uuid\x2f52A8-A0F6.sh"
initramfs:/usr/lib/dracut/hooks/initqueue/finished/devexists-\x2fdev\x2fdisk\x2fby-uuid\x2f52A8-A0F6.sh
========================================================================
[ -e "/dev/disk/by-uuid/52A8-A0F6" ]
========================================================================

initramfs:/usr/lib/dracut/hooks/emergency/80-\x2fdev\x2fdisk\x2fby-uuid\x2f52A8-A0F6.sh
========================================================================
[ -e "/dev/disk/by-uuid/52A8-A0F6" ] || warn ""/dev/disk/by-uuid/52A8-A0F6" does not exist"
========================================================================

initramfs:/etc/systemd/system/dev-disk-by\x2duuid-52A8\x2dA0F6.device.d/timeout.conf
========================================================================
[Unit]
JobTimeoutSec=0
JobRunningTimeoutSec=0
========================================================================

# lsinitrd --unpack /boot/initrd-$(uname -r) "usr/lib/dracut/hooks/emergency/80-\x2fdev\x2fdisk\x2fby-uuid\x2f52A8-A0F6.sh" "usr/lib/dracut/hooks/initqueue/finished/devexists-\x2fdev\x2fdisk\x2fby-uuid\x2f52A8-A0F6.sh" "etc/systemd/system/dev-disk-by\x2duuid-52A8\x2dA0F6.device.d/timeout.conf"
# cat "etc/systemd/system/dev-disk-by\x2duuid-52A8\x2dA0F6.device.d/timeout.conf"
[Unit]
JobTimeoutSec=0
JobRunningTimeoutSec=0
# cat "usr/lib/dracut/hooks/emergency/80-\x2fdev\x2fdisk\x2fby-uuid\x2f52A8-A0F6.sh"
[ -e "/dev/disk/by-uuid/52A8-A0F6" ] || warn ""/dev/disk/by-uuid/52A8-A0F6" does not exist"
# cat "usr/lib/dracut/hooks/initqueue/finished/devexists-\x2fdev\x2fdisk\x2fby-uuid\x2f52A8-A0F6.sh"
[ -e "/dev/disk/by-uuid/52A8-A0F6" ]
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it