### PR TITLE
fix(dracut-systemd): remove unused argument

### DIFF
--- a/modules.d/98dracut-systemd/rootfs-generator.sh
+++ b/modules.d/98dracut-systemd/rootfs-generator.sh
@@ -104,7 +104,7 @@ esac
 GENERATOR_DIR="$1"
 
 if [ "$rootok" = "1" ]; then
-    generator_wait_for_dev "${root#block:}" "$RDRETRY"
+    generator_wait_for_dev "${root#block:}"
     generator_fsck_after_pre_mount "${root#block:}"
     strstr "$(cat /proc/cmdline)" 'root=' || generator_mount_rootfs "${root#block:}" "$(getarg rootfstype=)" "$(getarg rootflags=)"
 fi


### PR DESCRIPTION
The `generator_wait_for_dev` function of the dracut rootfs systemd generator only uses the first argument. Moreover, `RDRETRY` is unset at this point.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
