### PR TITLE
ci: add ovmf to test containers for UEFI testing

### DIFF
--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -46,6 +46,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && DEBIAN_FRONTEND=nonintera
     nfs-kernel-server \
     ntfs-3g \
     open-iscsi \
+    ovmf \
     parted \
     pigz \
     pkg-config \


### PR DESCRIPTION
This is in preparation to have a test case for the "--uefi" dracut argument.

CI requires to land the container changes first.