### PR TITLE
refactor(virtiofs): remove exit after die

### DIFF
--- a/modules.d/95virtiofs/mount-virtiofs.sh
+++ b/modules.d/95virtiofs/mount-virtiofs.sh
@@ -10,7 +10,6 @@ if [ "${fstype}" = "virtiofs" -o "${root%%:*}" = "virtiofs" ]; then
     mount -t virtiofs -o "$rflags" "${root#virtiofs:}" "$NEWROOT" 2>&1 | vinfo
     if ! ismounted "$NEWROOT"; then
         die "virtiofs: failed to mount root fs"
-        exit 1
     fi
 
     info "virtiofs: root fs mounted (options: '${rflags}')"


### PR DESCRIPTION
The `die` function already ends with `exit 1`.

Spotted and missing in #2124

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
