### PR TITLE
fix(dracut.sh): correct --help and --version exit codes

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -801,7 +801,7 @@ while :; do
         --fstab) use_fstab_l="yes" ;;
         -h | --help)
             long_usage
-            exit 1
+            exit 0
             ;;
         --bzip2) compress_l="bzip2" ;;
         --lzma) compress_l="lzma" ;;
@@ -845,7 +845,7 @@ while :; do
             ;;
         --version)
             long_version
-            exit 1
+            exit 0
             ;;
         --)
             shift


### PR DESCRIPTION
Both are valid options that cause regular program termination without errors, so dracut should return 0.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
