### PR TITLE
fix(network-manager): on machines with systemd, start the online hook…

### DIFF
--- a/modules.d/35network-manager/NetworkManager-dispatcher.service
+++ b/modules.d/35network-manager/NetworkManager-dispatcher.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Network Manager Script Dispatcher Service
+DefaultDependencies=no
+After=dbus.socket
+
+[Service]
+Type=dbus
+BusName=org.freedesktop.nm_dispatcher
+ExecStart=/usr/libexec/nm-dispatcher
+NotifyAccess=main
+
+# Enable debug logging in dispatcher service. Note that dispatcher
+# also honors debug logging requests from NetworkManager, so you
+# can also control logging requests with
+# `nmcli general logging domain DISPATCHER level TRACE`.
+#Environment=NM_DISPATCHER_DEBUG_LOG=1
+
+# We want to allow scripts to spawn long-running daemons, so tell
+# systemd to not clean up when nm-dispatcher exits
+KillMode=process
+
+[Install]
+Alias=dbus-org.freedesktop.nm-dispatcher.service
+

--- a/modules.d/35network-manager/nm-lib.sh
+++ b/modules.d/35network-manager/nm-lib.sh
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
 type getcmdline > /dev/null 2>&1 || . /lib/dracut-lib.sh
+type source_hook > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 nm_generate_connections() {
     rm -f /run/NetworkManager/system-connections/*
@@ -20,8 +21,13 @@ nm_generate_connections() {
             /etc/NetworkManager/system-connections/* \
             /etc/sysconfig/network-scripts/ifcfg-*; do
             [ -f "$i" ] || continue
-            mkdir -p "$hookdir"/initqueue/finished
-            echo '[ -f /tmp/nm.done ]' > "$hookdir"/initqueue/finished/nm.sh
+            #on machines with systemd, nm-wait-online is ordered before the initqueue,
+            #so there is no need to do the nm.done check. Even if something fails,
+            #there is nothing in initqueue to wait for.
+            if [ -z "$DRACUT_SYSTEMD" ]; then
+                mkdir -p "$hookdir"/initqueue/finished
+                echo '[ -f /tmp/nm.done ]' > "$hookdir"/initqueue/finished/nm.sh
+            fi
             mkdir -p /run/NetworkManager/initrd
             : > /run/NetworkManager/initrd/neednet # activate NM services
             break
@@ -31,4 +37,48 @@ nm_generate_connections() {
 
 nm_reload_connections() {
     [ -n "$DRACUT_SYSTEMD" ] && systemctl is-active nm-initrd.service && nmcli connection reload
+}
+
+kf_get_string() {
+    # NetworkManager writes keyfiles (glib's GKeyFile API). Have a naive
+    # parser for it.
+    #
+    # But GKeyFile will backslash escape certain keys (\s, \t, \n) but also
+    # escape backslash. As an approximation, interpret the string with printf's
+    # '%b'.
+    #
+    # This is supposed to mimic g_key_file_get_string() (poorly).
+
+    v1="$(sed -n "s/^$1=/=/p" | sed '1!d')"
+    test "$v1" = "${v1#=}" && return 1
+    printf "%b" "${v1#=}"
+}
+
+kf_unescape() {
+    # Another layer of unescaping. While values in GKeyFile format
+    # are backslash escaped, the original strings (which are in no
+    # defined encoding) are backslash escaped too to be valid UTF-8.
+    # This will undo the second layer of escaping to give binary "strings".
+    printf "%b" "$1"
+}
+
+kf_parse() {
+    v3="$(kf_get_string "$1")" || return 1
+    v3="$(kf_unescape "$v3")"
+    printf '%s=%s\n' "$2" "$(printf '%q' "$v3")"
+}
+
+dhcpopts_create() {
+    kf_parse root-path new_root_path < "$1"
+    kf_parse next-server new_next_server < "$1"
+    kf_parse dhcp-bootfile filename < "$1"
+}
+
+nm_call_hooks() {
+    ifname="$1"
+    [ -n "$ifname" ] || return 1
+    state="/run/NetworkManager/devices/"$(cat /sys/class/net/"${ifname}"/ifindex)
+    dhcpopts_create "$state" > /tmp/dhclient."$ifname".dhcpopts
+    source_hook initqueue/online "$ifname"
+    /sbin/netroot "$ifname"
 }

--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -1,68 +1,34 @@
 #!/bin/bash
 
 type source_hook > /dev/null 2>&1 || . /lib/dracut-lib.sh
+type nm_call_hooks > /dev/null 2>&1 || . /lib/nm-lib.sh
 
-if [ -z "$DRACUT_SYSTEMD" ]; then
-    # Only start NM if networking is needed
-    if [ -e /run/NetworkManager/initrd/neednet ]; then
-        for i in /usr/lib/NetworkManager/system-connections/* \
-            /run/NetworkManager/system-connections/* \
-            /etc/NetworkManager/system-connections/* \
-            /etc/sysconfig/network-scripts/ifcfg-*; do
-            [ -f "$i" ] || continue
-            /usr/sbin/NetworkManager --configure-and-quit=initrd --no-daemon
-            break
-        done
-    fi
+if [ -e /tmp/nm.done ]; then
+    return
+fi
+
+# Only start NM if networking is needed
+if [ -e /run/NetworkManager/initrd/neednet ]; then
+    for i in /usr/lib/NetworkManager/system-connections/* \
+        /run/NetworkManager/system-connections/* \
+        /etc/NetworkManager/system-connections/* \
+        /etc/sysconfig/network-scripts/ifcfg-*; do
+        [ -f "$i" ] || continue
+        /usr/sbin/NetworkManager --configure-and-quit=initrd --no-daemon
+        break
+    done
 fi
 
 if [ -s /run/NetworkManager/initrd/hostname ]; then
     cat /run/NetworkManager/initrd/hostname > /proc/sys/kernel/hostname
 fi
 
-kf_get_string() {
-    # NetworkManager writes keyfiles (glib's GKeyFile API). Have a naive
-    # parser for it.
-    #
-    # But GKeyFile will backslash escape certain keys (\s, \t, \n) but also
-    # escape backslash. As an approximation, interpret the string with printf's
-    # '%b'.
-    #
-    # This is supposed to mimic g_key_file_get_string() (poorly).
-
-    v1="$(sed -n "s/^$1=/=/p" | sed '1!d')"
-    test "$v1" = "${v1#=}" && return 1
-    printf "%b" "${v1#=}"
-}
-
-kf_unescape() {
-    # Another layer of unescaping. While values in GKeyFile format
-    # are backslash escaped, the original strings (which are in no
-    # defined encoding) are backslash escaped too to be valid UTF-8.
-    # This will undo the second layer of escaping to give binary "strings".
-    printf "%b" "$1"
-}
-
-kf_parse() {
-    v3="$(kf_get_string "$1")" || return 1
-    v3="$(kf_unescape "$v3")"
-    printf '%s=%s\n' "$2" "$(printf '%q' "$v3")"
-}
-
-dhcpopts_create() {
-    kf_parse root-path new_root_path < "$1"
-    kf_parse next-server new_next_server < "$1"
-    kf_parse dhcp-bootfile filename < "$1"
-}
-
 for _i in /sys/class/net/*; do
     [ -d "$_i" ] || continue
     state="/run/NetworkManager/devices/$(cat "$_i"/ifindex)"
     grep -q '^connection-uuid=' "$state" 2> /dev/null || continue
     ifname="${_i##*/}"
-    dhcpopts_create "$state" > /tmp/dhclient."$ifname".dhcpopts
-    source_hook initqueue/online "$ifname"
-    /sbin/netroot "$ifname"
+    nm_call_hooks "$ifname"
 done
 
 : > /tmp/nm.done

--- a/modules.d/35network-manager/online-initqueue.sh
+++ b/modules.d/35network-manager/online-initqueue.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+type nm_call_hooks > /dev/null 2>&1 || . /lib/nm-lib.sh
+
+ifname="$1"
+action="$2"
+
+[ "${action}" = "up" ] || exit 0
+
+. /dracut-state.sh
+
+nm_call_hooks "$ifname"


### PR DESCRIPTION
…s from nm-dispatcher

So there are three steps we need to do when a NIC appears: 1) We want udev to do its stuff
2) We want NetworkManager to setup the interface
3) We want to run the online hooks

On machines without systemd this works just fine. nm-run is called after udev settles and it starts NM in the oneshoot mode and call the hooks. Everything is done nicely synchronously.

On machines with systemd, NM is started as a daemon earlier and listens to udev events. When it gets the event that device appeared it starts the configuration.

But we only run the hooks once after NM told us that it finished the setting up everything. But if an additional device appears later, we will not start the related hooks again.

So let's use NM's dispatcher to start the hooks.

This pull request changes...

## Changes

## Checklist
- [X ] I have tested it locally
- [N/A ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

