### PR TITLE
fix(network-manager): add "After" dependency on dbus.service

### DIFF
--- a/modules.d/35network-manager/nm-initrd.service
+++ b/modules.d/35network-manager/nm-initrd.service
@@ -3,6 +3,7 @@ DefaultDependencies=no
 Wants=systemd-udev-trigger.service
 After=systemd-udev-trigger.service
 After=dracut-cmdline.service
+After=dbus.service
 Wants=network.target
 Before=network.target
 ConditionPathExists=/run/NetworkManager/initrd/neednet


### PR DESCRIPTION
## Changes

During shutdown, there is no ordering dependency between the nm-initrd service and the D-Bus daemon, and so the latter can be stopped before. This causes issues to NetworkManager, especially when team interfaces are present because NM will see teamd dropping from the bus and will try to reactivate the connection.

Add a `After` dependency to make sure the D-Bus daemon is stopped after NM on shutdown.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant

