### PR TITLE
fix(plymouth): remove /etc/system-release dependency

### DIFF
--- a/modules.d/50plymouth/plymouth-populate-initrd.sh
+++ b/modules.d/50plymouth/plymouth-populate-initrd.sh
@@ -3,8 +3,7 @@
 PLYMOUTH_LOGO_FILE="/usr/share/pixmaps/system-logo-white.png"
 PLYMOUTH_THEME=$(plymouth-set-default-theme)
 
-inst_multiple plymouthd plymouth \
-    /etc/system-release
+inst_multiple plymouthd plymouth
 
 test -e "${PLYMOUTH_LOGO_FILE}" && inst_simple "${PLYMOUTH_LOGO_FILE}"
 


### PR DESCRIPTION
/etc/*release files should not be managed in the plymouth module and more importantly dracut assumes /etc/os-release not /etc/system-release

CC @zboszor 

/etc/system-release got introduced in 2009 (in case this helps with the reviews) - https://github.com/dracutdevs/dracut/commit/0f46778162a373afa903f57c7518489dbafb87a7#diff-a8af7c75c2fa972878d519a2ba0e62870206416f73f627ae8414c5d8fb07501bR62