### PR TITLE
fix(network,dbus): improve dependency checking

### DIFF
--- a/modules.d/09dbus/module-setup.sh
+++ b/modules.d/09dbus/module-setup.sh
@@ -19,7 +19,7 @@ depends() {
         fi
     done
 
-    if find_binary dbus-broker &> /dev/null; then
+    if check_module "dbus-broker"; then
         echo "dbus-broker"
         return 0
     else

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -2,7 +2,7 @@
 
 # called by dracut
 check() {
-    require_binaries sed grep || return 1
+    require_binaries sed grep NetworkManager || return 1
 
     # do not add this module by default
     return 255

--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -17,11 +17,11 @@ depends() {
     done
 
     if [ -z "$network_handler" ]; then
-        if [[ -e $dracutsysrootdir$systemdsystemunitdir/connman.service ]]; then
+        if check_module "connman"; then
             network_handler="connman"
-        elif [[ -x $dracutsysrootdir/usr/libexec/nm-initrd-generator ]] || [[ -x $dracutsysrootdir/usr/lib/nm-initrd-generator ]]; then
+        elif check_module "network-manager"; then
             network_handler="network-manager"
-        elif [[ -x $dracutsysrootdir$systemdutildir/systemd-networkd ]]; then
+        elif check_module "systemd-networkd"; then
             network_handler="systemd-networkd"
         else
             network_handler="network-legacy"


### PR DESCRIPTION
This PR removes distribution dependent logic from the code.

Decouple implementation details of the backend dependencies from the meta module.

Call [check_module](https://github.com/dracutdevs/dracut/blob/master/dracut-init.sh#L985) for each submodule instead of reimplementing sub-package dependency checking inside the meta module itself.

[check_module](https://github.com/dracutdevs/dracut/blob/master/dracut-init.sh#L985) calls the module's [check()](https://github.com/dracutdevs/dracut/blob/master/dracut-init.sh#L784) function from [module-setup.sh](https://github.com/dracutdevs/dracut/blob/master/dracut-init.sh#L779) to check if it can be installed or not.

Add missing NetworkManager binary to the network-manager dracut module check. 

Fixes: #1756