### PR TITLE
fix(fido2): libfido2.so depends on libz.so

### DIFF
--- a/modules.d/91fido2/module-setup.sh
+++ b/modules.d/91fido2/module-setup.sh
@@ -22,6 +22,7 @@ install() {
     _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
         {"tls/$_arch/",tls/,"$_arch/",}"libfido2.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libz.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"/cryptsetup/libcryptsetup-token-systemd-fido2.so" \
         {"tls/$_arch/",tls/,"$_arch/",}"libcbor.so.*" \


### PR DESCRIPTION
See https://github.com/Yubico/libfido2/blob/main/CMakeLists.txt#L404 and https://github.com/Yubico/libfido2/commit/bf7ea459cf5a805a36202d923c1be7c1140288bc

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2048
