### PR TITLE
Fixes for iSCSI boot & IPv6

### DIFF
--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -15,7 +15,8 @@ depends() {
 
 # called by dracut
 installkernel() {
-    return 0
+    # arping depends on af_packet
+    hostonly='' instmods af_packet
 }
 
 # called by dracut

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -727,7 +727,6 @@ wait_for_ipv6_dad() {
     while [ $cnt -lt $timeout ]; do
         [ -n "$(ip -6 addr show dev "$@")" ] \
             && [ -z "$(ip -6 addr show dev "$@" tentative)" ] \
-            && { ip -6 route list proto ra dev "$@" | grep -q ^default; } \
             && return 0
         [ -n "$(ip -6 addr show dev "$@" dadfailed)" ] \
             && return 1

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -311,7 +311,7 @@ ibft_to_cmdline() {
                 [ -e "${iface}"/hostname ] && read -r hostname < "${iface}"/hostname
                 if [ "$family" = "ipv6" ]; then
                     if [ -n "$ip" ]; then
-                        [ -n "$prefix" ] || prefix=64
+                        [ -n "$prefix" ] || prefix=128
                         ip="[${ip}]"
                         mask=$prefix
                     fi

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -312,8 +312,8 @@ ibft_to_cmdline() {
                 if [ "$family" = "ipv6" ]; then
                     if [ -n "$ip" ]; then
                         [ -n "$prefix" ] || prefix=64
-                        ip="[${ip}/${prefix}]"
-                        mask=
+                        ip="[${ip}]"
+                        mask=$prefix
                     fi
                     if [ -n "$gw" ]; then
                         gw="[${gw}]"

--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -161,7 +161,7 @@ installkernel() {
     local _funcs='iscsi_register_transport'
 
     instmods bnx2i qla4xxx cxgb3i cxgb4i be2iscsi qedi
-    hostonly="" instmods iscsi_tcp iscsi_ibft crc32c iscsi_boot_sysfs
+    hostonly="" instmods iscsi_tcp iscsi_ibft crc32c iscsi_boot_sysfs 8021q
 
     if [ "$_arch" = "s390" -o "$_arch" = "s390x" ]; then
         _s390drivers="=drivers/s390/scsi"


### PR DESCRIPTION
This pull request fixes a few issues I encountered while testing network boot with IPv6.
It prepares a final submission of #2184 (it contains the parts of #2184 which are not related to the nvmf module).

## Checklist
- [x] I have tested it locally
- [x]  I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
