### PR TITLE
fix(dracut-install): continue parsing if ldd prints "cannot execute binary file"

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -567,7 +567,7 @@ static int resolve_deps(const char *src)
 
                 /* glibc */
                 if (strstr(buf, "cannot execute binary file"))
-                        break;
+                        continue;
 
                 if (strstr(buf, "not a dynamic executable"))
                         break;


### PR DESCRIPTION
When the kernel is compiled without IA32_EMULATION and the glibc 32-bit library is installed on the system, `ldd` prints the following output:

```
> ldd /usr/lib64/libfido2.so.1.12.0
/bin/ldd: line 162: /lib/ld-linux.so.2: cannot execute binary file: Exec format error
	linux-vdso.so.1 (0x00007ffd627fa000)
	libcbor.so.0.9 => /lib64/libcbor.so.0.9 (0x00007f18d799f000)
	libcrypto.so.3 => /lib64/libcrypto.so.3 (0x00007f18d7400000)
	libudev.so.1 => /lib64/libudev.so.1 (0x00007f18d7971000)
	libhidapi-hidraw.so.0 => /lib64/libhidapi-hidraw.so.0 (0x00007f18d7968000)
	libz.so.1 => /lib64/libz.so.1 (0x00007f18d794e000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f18d7205000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f18d79f9000)
> echo $?
0
```

The `ldd` script uses the following code to resolve dependencies:

```
RTLDLIST="/lib/ld-linux.so.2 /lib64/ld-linux-x86-64.so.2 /libx32/ld-linux-x32.so.2"
...
RTLD=
ret=1
for rtld in ${RTLDLIST}; do
  if test -x $rtld; then
    verify_out=`${rtld} --verify "$file"`
    ret=$?
    case $ret in
      [02]) RTLD=${rtld}; break;;
    esac
  fi
done
```

So, if the 32-bit library fails, the 64-bit library may work, so don't stop parsing the `ldd` output unconditionally when the message "cannot execute binary file" is printed.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2190
