### PR TITLE
fix(systemd): do not include in the initrd units configured not to run there

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -106,8 +106,6 @@ install() {
         "$systemdsystemunitdir"/systemd-journald.service \
         "$systemdsystemunitdir"/systemd-vconsole-setup.service \
         "$systemdsystemunitdir"/systemd-volatile-root.service \
-        "$systemdsystemunitdir"/systemd-random-seed-load.service \
-        "$systemdsystemunitdir"/systemd-random-seed.service \
         "$systemdsystemunitdir"/systemd-sysctl.service \
         \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-modules-load.service \

--- a/modules.d/01systemd-journald/module-setup.sh
+++ b/modules.d/01systemd-journald/module-setup.sh
@@ -40,7 +40,6 @@ install() {
         "$systemdsystemunitdir"/systemd-journald-audit.socket \
         "$systemdsystemunitdir"/systemd-journald-dev-log.socket \
         "$systemdsystemunitdir"/systemd-journald-varlink@.socket \
-        "$systemdsystemunitdir"/systemd-journal-flush.service \
         "$systemdsystemunitdir"/systemd-journal-catalog-update.service \
         "$systemdsystemunitdir"/sockets.target.wants/systemd-journald-audit.socket \
         "$systemdsystemunitdir"/sockets.target.wants/systemd-journald-dev-log.socket \
@@ -63,8 +62,6 @@ install() {
             "$systemdutilconfdir/journald.conf.d/*.conf" \
             "$systemdsystemconfdir"/systemd-journald.service \
             "$systemdsystemconfdir/systemd-journald.service.d/*.conf" \
-            "$systemdsystemconfdir"/systemd-journal-flush.service \
-            "$systemdsystemconfdir/systemd-journal-flush.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-journal-catalog-update.service \
             "$systemdsystemconfdir/systemd-journal-catalog-update.service.d/*.conf" \
             "$sysusersconfdir"/systemd-journal.conf

--- a/modules.d/01systemd-pcrphase/module-setup.sh
+++ b/modules.d/01systemd-pcrphase/module-setup.sh
@@ -28,10 +28,6 @@ install() {
 
     inst_multiple -o \
         "$systemdutildir"/systemd-pcrphase \
-        "$systemdsystemunitdir"/systemd-pcrphase.service \
-        "$systemdsystemunitdir/systemd-pcrphase.service.d/*.conf" \
-        "$systemdsystemunitdir"/systemd-pcrphase-sysinit.service \
-        "$systemdsystemunitdir/systemd-pcrphase-sysinit.service/*.conf" \
         "$systemdsystemunitdir"/systemd-pcrphase-initrd.service \
         "$systemdsystemunitdir/systemd-pcrphase-initrd.service.d/*.conf" \
         "$systemdsystemunitdir"/initrd.target.wants/systemd-pcrphase-initrd.service
@@ -39,10 +35,6 @@ install() {
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
-            "$systemdsystemconfdir"/systemd-pcrphase.service \
-            "$systemdsystemconfdir/systemd-pcrphase.service.d/*.conf" \
-            "$systemdsystemconfdir"/systemd-pcrphase-sysinit.service \
-            "$systemdsystemconfdir/systemd-pcrphase-sysinit.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-pcrphase-initrd.service \
             "$systemdsystemconfdir/systemd-pcrphase-initrd.service.d/*.conf" \
             "$systemdsystemconfdir"/initrd.target.wants/systemd-pcrphase-initrd.service

--- a/modules.d/01systemd-tmpfiles/module-setup.sh
+++ b/modules.d/01systemd-tmpfiles/module-setup.sh
@@ -45,8 +45,6 @@ install() {
         "$systemdsystemunitdir/systemd-tmpfiles-setup.service.d/*.conf" \
         "$systemdsystemunitdir"/systemd-tmpfiles-setup-dev.service \
         "$systemdsystemunitdir/systemd-tmpfiles-setup-dev.service.d/*.conf" \
-        "$systemdsystemunitdir"/systemd-tmpfiles-clean.timer \
-        "$systemdsystemunitdir"/timers.target.wants/systemd-tmpfiles-clean.timer \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup-dev.service \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup.service \
         systemd-tmpfiles


### PR DESCRIPTION
Do not include in the initrd systemd units configured not to run there with `ConditionPathExists=!/etc/initrd-release`, as they just fill the log with entries like:

```
systemd[1]: <UNIT_DESCRIPTION> was skipped because of an unmet condition check (ConditionPathExists=!/etc/initrd-release).
```

References:
- https://github.com/systemd/systemd/commit/fe7f113c
- https://github.com/systemd/systemd/commit/7ef09e20

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
