### PR TITLE
fix: make iso-scan trigger udev events

### DIFF
--- a/modules.d/90dmsquash-live/iso-scan.sh
+++ b/modules.d/90dmsquash-live/iso-scan.sh
@@ -22,6 +22,7 @@ do_iso_scan() {
         mount -t auto -o ro "$dev" "/run/initramfs/isoscan" || continue
         if [ -f "/run/initramfs/isoscan/$isofile" ]; then
             losetup -f "/run/initramfs/isoscan/$isofile"
+            udevadm trigger --action=add > /dev/null 2>&1
             ln -s "$dev" /run/initramfs/isoscandev
             rm -f -- "$job"
             exit 0


### PR DESCRIPTION
## Changes

Added a call to `udevadm trigger` needed on linux 5.19+ due to a change in how udev events are triggered when loop devices are added.

The exact line is taken from the [fips module](https://github.com/dracutdevs/dracut/blob/master/modules.d/01fips/fips.sh#L32) as suggested in #2183 

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
    (I don't think documentation updates apply here)
- [ ] I am providing new code and test(s) for it
    Is this something that needs tests? Not sure how to go about creating tests

Fixes #2183
