### PR TITLE
fix(dracut.sh): handle out of space error for UEFI builds

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2496,9 +2496,11 @@ if [[ $uefi == yes ]]; then
                 ${uefi_secureboot_engine:+--engine "$uefi_secureboot_engine"} \
                 --key "${uefi_secureboot_key}" \
                 --cert "${uefi_secureboot_cert}" \
-                --output "$outfile" "${uefi_outdir}/linux.efi"; then
+                --output "$outfile" "${uefi_outdir}/linux.efi" \
+                && sbverify --cert "${uefi_secureboot_cert}" "$outfile" > /dev/null 2>&1; then
                 dinfo "*** Creating signed UEFI image file '$outfile' done ***"
             else
+                rm -f -- "$outfile"
                 dfatal "*** Creating signed UEFI image file '$outfile' failed ***"
                 exit 1
             fi

--- a/dracut.sh
+++ b/dracut.sh
@@ -2505,6 +2505,10 @@ if [[ $uefi == yes ]]; then
         else
             if cp --reflink=auto "${uefi_outdir}/linux.efi" "$outfile"; then
                 dinfo "*** Creating UEFI image file '$outfile' done ***"
+            else
+                rm -f -- "$outfile"
+                dfatal "Creation of $outfile failed"
+                exit 1
             fi
         fi
     else


### PR DESCRIPTION
- `sbsign` does not issue any error if there is not enough disk space to create
the signed file using its `--output` option. So, verify the signed image after
its creation using `sbverify`.

```
dracut: *** Creating image file '/tmp/tmp.YC4iYlF8UF/test.img' ***
dracut: Using UEFI kernel cmdline:
dracut: rd.driver.pre=btrfs  resume=UUID=3c21ec01-f8e7-4b9e-a7e7-26c050fee9ec  root=UUID=bc1664be-7f7e-48d1-8e99-25d9a98c8e3c rootfstype=btrfs rootflags=rw,relatime,discard=async,space_cache=v2,subvolid=266,subvol=/@/.snapshots/1/snapshot,subvol=@/.snapshots/1/snapshot 
warning: data remaining[88700416 vs 88712928]: gaps between PE/COFF sections?
Signing Unsigned original image
/bin/dracut: line 2676: 30903 Segmentation fault      (core dumped) sbverify --cert "${uefi_secureboot_cert}" "$outfile" > /dev/null 2>&1
dracut: *** Creating signed UEFI image file '/tmp/tmp.YC4iYlF8UF/test.img' failed ***
# echo $?
1
```

Fixes issue #2197

- Also, if `cp` fails, do not continue, print an error and exit, like it's already
being done for non-UEFI builds.

```
# dracut -f --stdlog 3 --uefi /tmp/tmp.YC4iYlF8UF/test.img
cp: error writing '/tmp/tmp.YC4iYlF8UF/test.img': No space left on device
# echo $?
0
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
