### PR TITLE
fix(dracut.sh): abort on `instmods -c ...` failure

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1954,11 +1954,17 @@ if [[ $no_kernel != yes ]]; then
 
     if [[ -n ${add_drivers// /} ]]; then
         # shellcheck disable=SC2086
-        hostonly='' instmods -c $add_drivers
+        if ! hostonly='' instmods -c $add_drivers; then
+            dfatal "instmods failed for add_drivers: $add_drivers"
+            exit 1
+        fi
     fi
     if [[ $force_drivers ]]; then
         # shellcheck disable=SC2086
-        hostonly='' instmods -c $force_drivers
+        if hostonly='' instmods -c $force_drivers; then
+            dfatal "instmods failed for force_drivers: $force_drivers"
+            exit 1
+        fi
         rm -f "$initdir"/etc/cmdline.d/20-force_driver.conf
         for mod in $force_drivers; do
             echo "rd.driver.pre=$mod" >> "$initdir"/etc/cmdline.d/20-force_drivers.conf
@@ -1966,7 +1972,10 @@ if [[ $no_kernel != yes ]]; then
     fi
     if [[ $filesystems ]]; then
         # shellcheck disable=SC2086
-        hostonly='' instmods -c $filesystems
+        if ! hostonly='' instmods -c $filesystems; then
+            dfatal "instmods failed for filesystems: $filesystems"
+            exit 1
+        fi
     fi
 
     dinfo "*** Installing kernel module dependencies ***"


### PR DESCRIPTION
Currently, instmods exit status is not validated and as a result initrd generation continues even when dracut-install fails.

For instance when add-drivers is called with a non existent driver:
```
...
dracut: Executing: /usr/bin/dracut -H -f --add-drivers "xen-blkfront xen-acpi-processor xen-evtchn xen-gntalloc xen-gntdev xen-privcmd xen-pciback xenfs hv_utils hv_vmbus hv_storvsc hv_netvsc hv_sock hv_balloon cn dm-mod" /boot/initramfs-6.1.10-1.ph5-secure.img 6.1.10-1.ph5-secure
...
dracut-install: Failed to find module 'xen_blkfront'
dracut: FAILED:  /usr/lib/dracut/dracut-install -o -D /var/tmp/dracut.r2Cc7L/initramfs --kerneldir /lib/modules/6.1.10-1.ph5-secure/ -m xen_blkfront xen-acpi-processor xen-evtchn xen-gntalloc xen-gntdev xen-privcmd xen-pciback xenfs hv_utils hv_vmbus hv_storvsc hv_netvsc hv_sock hv_balloon cn dm-mod
dracut: *** Installing kernel module dependencies ***
dracut: *** Installing kernel module dependencies done ***
dracut: *** Resolving executable dependencies ***
dracut: *** Resolving executable dependencies done ***
dracut: *** Hardlinking files ***
...
```

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
