### PR TITLE
fix(rpm): add moved tests to specfile

### DIFF
--- a/pkgbuild/dracut.spec
+++ b/pkgbuild/dracut.spec
@@ -361,6 +361,9 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/modules.d/62bluetooth
 %{dracutlibdir}/modules.d/80lvmmerge
 %{dracutlibdir}/modules.d/80lvmthinpool-monitor
+%{dracutlibdir}/modules.d/80test-makeroot
+%{dracutlibdir}/modules.d/80test-root
+%{dracutlibdir}/modules.d/80test
 %{dracutlibdir}/modules.d/90btrfs
 %{dracutlibdir}/modules.d/90crypt
 %{dracutlibdir}/modules.d/90dm


### PR DESCRIPTION
Sometime around commit 79504b (test: move finished-false.sh from test case to test-makeroot module) these test modules were moved without updating the rpm spec file. This simple patch adds them to the rpm files list so the packages successfully build again.

This pull request changes...

## Changes

pkgbuild/dracut.spec

## Checklist
- [x ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

## Testing
```
mock -r opensuse-tumbleweed-x86_64  --resultdir=$PWD/results4 $PWD/dracut-059-61.git20230214.fc36.src.rpm
mock -r centos-stream+epel-9-x86_64 --resultdir=$PWD/results2 $PWD/dracut-059-61.git20230214.fc36.src.rpm
mock -r fedora-37-x86_64 --resultdir=$PWD/results2 $PWD/dracut-059-61.git20230214.fc36.src.rpm
```

Note the open SUSE mock biuld failed for unrelated reasons.

Fixes #2204
