### PR TITLE
WIP: feat(crypt): remove crypt keyfile before entering emergency shell

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -259,6 +259,8 @@ Creates initial ramdisk images for preloading modules
   --printsize           Print out the module install size.
   --sshkey [SSHKEY]     Add SSH key to initramfs (use with ssh-client module).
   --logfile [FILE]      Logfile to use (overrides configuration setting).
+  --keep-cryptkeyfiles  Don't remove keyfiles for decryption when entering the
+                        emergency shell (use with crypt module)
   --reproducible        Create reproducible images.
   --no-reproducible     Do not create reproducible images.
   --loginstall [DIR]    Log all files installed from the host to [DIR].
@@ -450,6 +452,7 @@ rearrange_params() {
             --long show-modules \
             --long keep \
             --long printsize \
+            --long keep-cryptkeyfiles \
             --long regenerate-all \
             --long parallel \
             --long noimageifnotneeded \
@@ -818,6 +821,7 @@ while :; do
             ;;
         --keep) keep="yes" ;;
         --printsize) printsize="yes" ;;
+        --keep-cryptkeyfiles) keep_cryptkeyfiles="yes" ;;
         --regenerate-all) regenerate_all_l="yes" ;;
         -p | --parallel) parallel_l="yes" ;;
         --noimageifnotneeded) noimageifnotneeded="yes" ;;
@@ -1791,7 +1795,7 @@ export initdir dracutbasedir \
     host_fs_types host_devs swap_devs sshkey add_fstab \
     DRACUT_VERSION \
     prefix filesystems drivers \
-    hostonly_cmdline loginstall
+    hostonly_cmdline loginstall keep_cryptkeyfiles
 
 mods_to_load=""
 # check all our modules to see if they should be sourced.

--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -536,6 +536,10 @@ will not be able to boot. Equivalent to "--compress=zstd -15 -q -T0".
 **--printsize**::
     Print out the module install size.
 
+**--keep-cryptkeyfiles**::
+    Don't remove keyfiles for decryption when entering the
+    emergency shell (use with crypt module).
+
 **--profile**::
     Output profile information of the build process.
 


### PR DESCRIPTION
## Changes

There is work in progress for grub to write keyfiles for decrypting an encrypted root file systems into the initrd.
This is done in order to avoid having to type the decryption password twice, one time for grub and another time in the initrd.
Also user provided keyfiles in the initrd provide an attack vector, because it is easy to arrive at the emergency shell and the system root password could be guessed.
Therefore, dracut should per default remove all crypt keyfiles from the initrd before entering the emergency shell while leaving the option to keep them if desired.

The patch for grub is not yet upstream, and I'm open for a discussion whether removing user provided keyfiles is really desireable.
Therefore I provide this pr as WIP.

## Checklist
- [X ] I have tested it locally
- [X ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #

security concerns