### PR TITLE
feat(kernel-modules): driver support for macbook keyboards

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -55,7 +55,7 @@ installkernel() {
             "=drivers/watchdog"
 
         instmods \
-            yenta_socket \
+            yenta_socket spi_pxa2xx_platform \
             atkbd i8042 firewire-ohci pcmcia hv-vmbus \
             virtio virtio_ring virtio_pci pci_hyperv \
             "=drivers/pcmcia"


### PR DESCRIPTION
Discussed in: https://bugzilla.redhat.com/show_bug.cgi?id=2166209

## Changes

Add kernel module -driver which is needed for keybord support on macbooks.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

## Notes

I will test and report soon. This patch will also land in Fedora rawhide (for testing purposes).

Credit for patch: [Hans de Goede](mailto:hdegoede@redhat.com)