### PR TITLE
fix(udev-rules): remove old rules

### DIFF
--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -27,7 +27,6 @@ install() {
     fi
 
     inst_rules \
-        40-redhat.rules \
         50-firmware.rules \
         50-udev-default.rules \
         55-scsi-sg3_id.rules \

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -37,7 +37,6 @@ install() {
         60-cdrom_id.rules \
         60-pcmcia.rules \
         60-persistent-storage.rules \
-        61-persistent-storage-edd.rules \
         64-btrfs.rules \
         70-uaccess.rules \
         71-seat.rules \
@@ -72,7 +71,6 @@ install() {
         "${udevdir}"/ata_id \
         "${udevdir}"/cdrom_id \
         "${udevdir}"/create_floppy_devices \
-        "${udevdir}"/edd_id \
         "${udevdir}"/firmware.sh \
         "${udevdir}"/firmware \
         "${udevdir}"/firmware.agent \

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -46,8 +46,6 @@ install() {
         "$moddir/59-persistent-storage.rules" \
         "$moddir/61-persistent-storage.rules"
 
-    # eudev rules
-    inst_rules 80-drivers-modprobe.rules
     # legacy persistent network device name rules
     [[ $hostonly ]] && inst_rules 70-persistent-net.rules
 

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -29,7 +29,6 @@ install() {
     inst_rules \
         40-redhat.rules \
         50-firmware.rules \
-        50-udev.rules \
         50-udev-default.rules \
         55-scsi-sg3_id.rules \
         58-scsi-sg3_symlink.rules \
@@ -46,12 +45,9 @@ install() {
         75-net-description.rules \
         80-drivers.rules 95-udev-late.rules \
         80-net-name-slot.rules 80-net-setup-link.rules \
-        95-late.rules \
         "$moddir/59-persistent-storage.rules" \
         "$moddir/61-persistent-storage.rules"
 
-    # debian udev rules
-    inst_rules 91-permissions.rules
     # eudev rules
     inst_rules 80-drivers-modprobe.rules
     # legacy persistent network device name rules


### PR DESCRIPTION
**1./ Debian rules**
`50-udev.rules` `95-late.rules` added in [2009](https://github.com/dracutdevs/dracut/commit/f2b44e351bb181e3b2b689cdf42dd6314c11454f) .

`91-permissions.rules` added in [2013](https://github.com/dracutdevs/dracut/commit/5decf6d81362ee1903da1400744061b999263df9)

The last [Debian release](https://www.debian.org/releases/) that carried `91-permissions.rules` is [wheezy](https://www.apt-browse.org/browse/debian/wheezy/main/amd64/udev/175-7.2/file/lib/udev/rules.d/91-permissions.rules) it is it is no longer used by [jessie](https://www.apt-browse.org/browse/debian/jessie/main/amd64/udev/) .

These files are no longer used by [Debian stretch](https://packages.debian.org/stretch/amd64/udev/filelist), which already ended [LTS](https://wiki.debian.org/LTS) support on June 30, 2022.

**2./ edd rules**
The `61-persistent-storage-edd.rules` rule has been removed upstream in [2012](https://github.com/systemd/systemd/commit/4774868ccabd76c3d208343026f1c6e57094642b)

**3./ RedHat rules**
The `40-redhat.rules` rule has been removed upstream in [2010](https://github.com/systemd/systemd/commit/abbc1c17a0cd0c6f5d00f9d2cd3bf19901ccb6f8)

**4./ eudev rules**
remove old eudev specific `80-drivers-modprobe.rules` rule . This reverts [add eudev rules](https://github.com/dracutdevs/dracut/commit/64fb0900cbc47804b4225287e4622063169db360)

Fixes #2009 (partially)

CC @Mrfai @nabijaczleweli @bluca @mbiebl