### PR TITLE
fix(udev-rules): remove old edd_id extra rules

### DIFF
--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -38,7 +38,6 @@ install() {
         60-cdrom_id.rules \
         60-pcmcia.rules \
         60-persistent-storage.rules \
-        61-persistent-storage-edd.rules \
         64-btrfs.rules \
         70-uaccess.rules \
         71-seat.rules \
@@ -76,7 +75,6 @@ install() {
         "${udevdir}"/ata_id \
         "${udevdir}"/cdrom_id \
         "${udevdir}"/create_floppy_devices \
-        "${udevdir}"/edd_id \
         "${udevdir}"/firmware.sh \
         "${udevdir}"/firmware \
         "${udevdir}"/firmware.agent \


### PR DESCRIPTION
The `61-persistent-storage-edd.rules` rule has been removed upstream in [2012](https://github.com/systemd/systemd/commit/4774868ccabd76c3d208343026f1c6e57094642b)

Fixes https://github.com/dracutdevs/dracut/issues/2009 (partially)
