### PR TITLE
fix(base): log the full udev database in rdsosreport

### DIFF
--- a/modules.d/99base/rdsosreport.sh
+++ b/modules.d/99base/rdsosreport.sh
@@ -28,7 +28,7 @@ cat /proc/self/mountinfo
 cat /proc/mounts
 
 blkid
-blkid -o udev
+command -v udevadm > /dev/null 2> /dev/null && udevadm info --export-db
 
 ls -l /dev/disk/by*
 


### PR DESCRIPTION
`blkid -o udev` is deprecated since [2012](https://github.com/util-linux/util-linux/commit/24d741d88a31863e82feb3f3a4516d7df006378b)

`udevadm info --export-db` logs the full content of the udev database.