### PR TITLE
feat(network): include 98-default-mac-none.link if it exists

### DIFF
--- a/modules.d/01systemd-networkd/module-setup.sh
+++ b/modules.d/01systemd-networkd/module-setup.sh
@@ -44,6 +44,7 @@ install() {
         "$systemdnetwork"/80-container-vz.network \
         "$systemdnetwork"/80-vm-vt.network \
         "$systemdnetwork"/80-wifi-adhoc.network \
+        "$systemdnetwork"/98-default-mac-none.link \
         "$systemdnetwork"/99-default.link \
         "$systemdsystemunitdir"/systemd-networkd.service \
         "$systemdsystemunitdir"/systemd-networkd.socket \

--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -23,9 +23,11 @@ installkernel() {
 install() {
     local _arch
 
-    #Adding default link
+    # Adding default link and (if exists) 98-default-mac-none.link
     if dracut_module_included "systemd"; then
-        inst_multiple -o "${systemdnetwork}/99-default.link"
+        inst_multiple -o \
+            "${systemdnetwork}/99-default.link" \
+            "${systemdnetwork}/98-default-mac-none.link"
         [[ $hostonly ]] && inst_multiple -H -o "${systemdnetworkconfdir}/*.link"
     fi
 

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -51,8 +51,10 @@ install() {
         inst_simple "$moddir"/nm-initrd.service "$systemdsystemunitdir"/nm-initrd.service
         inst_simple "$moddir"/nm-wait-online-initrd.service "$systemdsystemunitdir"/nm-wait-online-initrd.service
 
-        # Adding default link
-        inst_multiple -o "${systemdnetwork}/99-default.link"
+        # Adding default link and (if exists) 98-default-mac-none.link
+        inst_multiple -o \
+            "${systemdnetwork}/99-default.link" \
+            "${systemdnetwork}/98-default-mac-none.link"
         [[ $hostonly ]] && inst_multiple -H -o "${systemdnetworkconfdir}/*.link"
 
         $SYSTEMCTL -q --root "$initdir" enable nm-initrd.service


### PR DESCRIPTION
In Fedora Linux there was a new 98-default-mac-none.link file added to set the MACAddressPolicy=none for bond/bridge/team devices. We'd like for this policy to apply in the initramfs as well. See

- https://fedoraproject.org/wiki/Changes/MAC_Address_Policy_none
- https://src.fedoraproject.org/rpms/systemd/pull-request/100#

## Checklist
> - [ ] I have tested it locally

I have ✔️ - at least for the `35network-manager` module.

> - [ ] I have reviewed and updated any documentation if relevant

Not sure if any docs exist for this.

> - [ ] I am providing new code and test(s) for it

Not sure if this is a large enough change for a new test, but let me know and I'll be glad to take a look.
