### PR TITLE
test: only load i6300esb for watchdog driver to improve reliability 

### DIFF
--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -15,7 +15,7 @@ test_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -device i6300esb -watchdog-action poweroff \
-        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot \"root=LABEL=  rdinit=/bin/sh\" rw systemd.log_level=debug systemd.log_target=console rd.retry=3 rd.debug console=ttyS0,115200n81 rd.shell=0 $DEBUGFAIL" \
+        -append "rd.driver.pre=i6300esb panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot \"root=LABEL=  rdinit=/bin/sh\" rw systemd.log_level=debug systemd.log_target=console rd.retry=3 rd.debug console=ttyS0,115200n81 rd.shell=0 $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     test_marker_check || return 1
@@ -61,7 +61,7 @@ test_setup() {
     # make sure --omit-drivers does not filter out drivers using regexp to test for an earlier regression (assuming there is no one letter linux kernel module needed to run the test)
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -a "test watchdog" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod i6300esb ib700wdt" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod i6300esb" \
         --omit-drivers 'a b c d e f g h i j k l m n o p q r s t u v w x y z' \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1

--- a/test/TEST-03-USR-MOUNT/test.sh
+++ b/test/TEST-03-USR-MOUNT/test.sh
@@ -23,7 +23,7 @@ client_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -device i6300esb -watchdog-action poweroff \
-        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=LABEL=dracut $client_opts loglevel=7 rd.retry=3 rd.info console=ttyS0,115200n81 selinux=0 rd.debug rd.shell=0 $DEBUGFAIL" \
+        -append "rd.driver.pre=i6300esb panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=LABEL=dracut $client_opts loglevel=7 rd.retry=3 rd.info console=ttyS0,115200n81 selinux=0 rd.debug rd.shell=0 $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     if ! test_marker_check; then
@@ -86,7 +86,7 @@ test_setup() {
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -a "test watchdog" \
         -o "network kernel-network-modules" \
-        -d "piix ide-gd_mod ata_piix btrfs sd_mod i6300esb ib700wdt" \
+        -d "piix ide-gd_mod ata_piix btrfs sd_mod i6300esb" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -27,7 +27,7 @@ client_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "systemd.unit=testsuite.target systemd.mask=systemd-firstboot panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=LABEL=dracut $client_opts rd.retry=3 console=ttyS0,115200n81 selinux=0 $DEBUGOUT rd.shell=0 $DEBUGFAIL" \
+        -append "rd.driver.pre=i6300esb systemd.unit=testsuite.target systemd.mask=systemd-firstboot panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=LABEL=dracut $client_opts rd.retry=3 console=ttyS0,115200n81 selinux=0 $DEBUGOUT rd.shell=0 $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     if ! test_marker_check; then
@@ -152,7 +152,7 @@ EOF
         -a "test systemd i18n qemu" \
         ${EXTRA_MACHINE:+-I "$EXTRA_MACHINE"} \
         -o "network plymouth lvm mdraid resume crypt caps dm terminfo usrmount kernel-network-modules rngd" \
-        -d "piix ide-gd_mod ata_piix btrfs sd_mod i6300esb ib700wdt" \
+        -d "piix ide-gd_mod ata_piix btrfs sd_mod i6300esb" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -22,7 +22,7 @@ run_server() {
         -net nic,macaddr=52:54:01:12:34:56,model=e1000 \
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
         -device i6300esb -watchdog-action poweroff \
-        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=LABEL=dracut rootfstype=ext4 rw console=ttyS0,115200n81 selinux=0" \
+        -append "rd.driver.pre=i6300esb panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=LABEL=dracut rootfstype=ext4 rw console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.server \
         -pidfile "$TESTDIR"/server.pid -daemonize || return 1
 
@@ -355,7 +355,7 @@ test_setup() {
     # Make server's dracut image
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -m "bash rootfs-block debug kernel-modules watchdog qemu network network-legacy" \
-        -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod nfsv2 nfsv3 nfsv4 nfs_acl nfs_layout_nfsv41_files nfsd e1000 i6300esb ib700wdt" \
+        -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod nfsv2 nfsv3 nfsv4 nfs_acl nfs_layout_nfsv41_files nfsd e1000 i6300esb" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
 

--- a/test/TEST-60-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-60-BONDBRIDGEVLAN/test.sh
@@ -89,6 +89,7 @@ client_test() {
         -hda "$TESTDIR"/client.img \
         -device i6300esb -watchdog-action poweroff \
         -append "
+        rd.driver.pre=i6300esb
         panic=1 oops=panic softlockup_panic=1
         ifname=net1:52:54:00:12:34:01
         ifname=net2:52:54:00:12:34:02
@@ -384,7 +385,7 @@ test_setup() {
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         --no-early-microcode \
         -m "rootfs-block debug kernel-modules watchdog qemu network network-legacy" \
-        -d "ipvlan macvlan af_packet piix ide-gd_mod ata_piix ext4 sd_mod nfsv2 nfsv3 nfsv4 nfs_acl nfs_layout_nfsv41_files nfsd virtio-net i6300esb ib700wdt" \
+        -d "ipvlan macvlan af_packet piix ide-gd_mod ata_piix ext4 sd_mod nfsv2 nfsv3 nfsv4 nfs_acl nfs_layout_nfsv41_files nfsd virtio-net i6300esb" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
 }


### PR DESCRIPTION
The recommended watchdog device is i6300esb, see https://libvirt.org/formatdomain.html#watchdog-devices.

Preload the i6300esb driver.

Do not load ib700wdt, to avoid the two watchdog drivers to interfere. 

No regression in tests (and presumably tests would run more reliable). 

Without this PR, log of test runs are full of the following messages

> [   10.754346] ib700wdt: WDT device closed unexpectedly.  WDT will not stop!

Fixes #2212

CC @bengal