### PR TITLE
ci: improve manual Github Action

### DIFF
--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -11,6 +11,7 @@ on:
                 description: 'distro'
                 default: 'fedora'
                 options:
+                    - "all"
                     - "fedora"
                     - "arch"
                     - "debian"
@@ -19,6 +20,9 @@ on:
             env:
                 description: 'Environment (optional)'
                 default: '{"DEBUGFAIL": "rd.debug"}'
+            registry:
+                description: 'Registry for container'
+                default: 'ghcr.io/dracutdevs'
 
 env:
     ${{ fromJSON(inputs.env) }}
@@ -28,6 +32,7 @@ jobs:
         runs-on: ubuntu-latest
         outputs:
             tests: ${{ steps.set-matrix.outputs.tests }}
+            container: ${{ steps.set-matrix.outputs.container }}
         steps:
             -   name: "Checkout Repository"
                 uses: actions/checkout@v1
@@ -36,22 +41,29 @@ jobs:
             -   id: set-matrix
                 name: "Set Matrix"
                 run: |
+                     [[ "${{ inputs.container }}" != 'all' ]] && echo "container=[\"${{ inputs.container }}\"]" >> $GITHUB_OUTPUT \
+                     || ( containers=$(find test/container -name "Dockerfile-*" | cut -d\- -f2 | tr '[:upper:]' '[:lower:]' | sed -z 's/\n/","/g'); echo "container=[\"${containers%??}]" >> $GITHUB_OUTPUT )
                      [[ "${{ toJson(fromJson(inputs.test)) }}" != '[]' ]] && echo "tests=${{ inputs.test }}" >> $GITHUB_OUTPUT \
                      || ( tests=$(find test -type d -a -name "TEST-*" | cut -d\- -f2 | sed -z 's/\n/","/g' ); echo "tests=[\"${tests%??}]" >> $GITHUB_OUTPUT )
     test:
         needs: matrix
         runs-on: ubuntu-latest
         timeout-minutes: 45
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+            cancel-in-progress: true
         strategy:
             matrix:
+                container: ${{ fromJSON(needs.matrix.outputs.container) }}
                 test: ${{ fromJSON(needs.matrix.outputs.tests) }}
+            fail-fast: false
         container:
-            image: ghcr.io/dracutdevs/${{ inputs.container }}
+            image: ${{ inputs.registry }}/${{ matrix.container }}
             options: "--privileged -v /dev:/dev"
         steps:
             -   name: "Checkout Repository"
                 uses: actions/checkout@v1
                 with:
                     fetch-depth: 0
-            -   name: "${{ inputs.container }} ${{ matrix.test }}"
+            -   name: "${{ matrix.container }} ${{ matrix.test }}"
                 run: ./tools/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}


### PR DESCRIPTION
**The main motivation is to help facilitate development of dracut using GitHub infra.** 

As the number of tests and number of containers grow, we could consider running less tests automatically on each PR and only run them on demand with the manual Github Action.

Running manual tests has the benefit of having the log available for everyone to see after the run, and saves the time of manually creating distro environments and uploading test logs. 

**1./ This commit enables setting environment variables before running the test.** More specifically it sets rd.debug for manual builds by default, which can be turned off by simply clearing the "Enviroment" input (see screenshot below).

This change would allow to debug issues like https://github.com/dracutdevs/dracut/issues/2225 on GitHub.

It also allows setting networking to e.g. systemd-networked  ( `{"USE_NETWORK": "systemd-networkd"}` )  without changing a single line of code for e.g. https://github.com/dracutdevs/dracut/issues/2141

**2./ This commit allows to run all the test parallel.** It uses "[find](https://github.com/dracutdevs/dracut/pull/2227/files#diff-bfc808a21f4571bc9a2270255dd381c6e136d5f07453bbcba1937d85a299879eR44)" to compute the list of tests, so if we add new tests we do not need to update this list.

**3./ This commit allows to run all test(s) in all containers in parallel using the new "all" entry.** It uses "[find](https://github.com/dracutdevs/dracut/pull/2227/files#diff-bfc808a21f4571bc9a2270255dd381c6e136d5f07453bbcba1937d85a299879eR42)" to compute the list of containers, so if we add new containers we do not need to update this list.

After the PR, this is how you can run all tests on all containers in debug mode with "one click". Here is [an example run](https://github.com/LaszloGombos/dracut/actions/runs/4276459540)

<img width="319" alt="Screen Shot 2023-02-26 at 1 39 18 PM" src="https://user-images.githubusercontent.com/1522773/221429993-214e3c42-2392-4154-877b-2e174df37aa2.png">

