### PR TITLE
ci: limit when code scanning runs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.language }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['cpp', 'python']
+        language: ['cpp']
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,9 +8,13 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'src/**'
   pull_request:
     branches:
       - master
+    paths:
+      - 'src/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
1./ Do not scan python code

The one python tool the dracut project has is a non-production developer tool, that does not change frequently.
The last time this tool changed was in [2012](https://github.com/dracutdevs/dracut/commit/28a6eef3b)

2./ Only run scanner if src/ directory changed

3./ Upgrade to ubuntu-latest to minimize maintenance 
