### PR TITLE
fix(dracut.sh): kmoddir does not handle trailing /

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1033,7 +1033,7 @@ stdloglvl=$((stdloglvl + verbosity_mod_l))
 ((stdloglvl < 0)) && stdloglvl=0
 
 [[ $drivers_dir_l ]] && drivers_dir=$drivers_dir_l
-drivers_dir="${drivers_dir%%+(/)}"
+drivers_dir="${drivers_dir%"${drivers_dir##*[!/]}"}"
 [[ $do_strip_l ]] && do_strip=$do_strip_l
 [[ $do_strip ]] || do_strip=yes
 [[ $aggressive_strip_l ]] && aggressive_strip=$aggressive_strip_l


### PR DESCRIPTION
Fixes https://github.com/dracutdevs/dracut/issues/2236

+(/) only works in bash interactive mode. Using any non-interactive bash run simply doesn't remove anything.

The solution is copied from dracut-lib.sh, trim().

## Changes

Trailing / for kmoddir variable are now handled properly.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2236 
