### PR TITLE
fix(dm): add rootfs-block as a dependency to dm module

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -19,7 +19,7 @@ check() {
 # called by dracut
 depends() {
     local deps
-    deps="dm rootfs-block"
+    deps="dm"
     if [[ $hostonly && -f "$dracutsysrootdir"/etc/crypttab ]]; then
         if grep -q -e "fido2-device=" -e "fido2-cid=" "$dracutsysrootdir"/etc/crypttab; then
             deps+=" fido2"

--- a/modules.d/90dm/module-setup.sh
+++ b/modules.d/90dm/module-setup.sh
@@ -8,6 +8,7 @@ check() {
 
 # called by dracut
 depends() {
+    echo rootfs-block
     return 0
 }
 

--- a/modules.d/90dmraid/module-setup.sh
+++ b/modules.d/90dmraid/module-setup.sh
@@ -31,7 +31,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo dm rootfs-block
+    echo dm
     return 0
 }
 

--- a/modules.d/90dmsquash-live/module-setup.sh
+++ b/modules.d/90dmsquash-live/module-setup.sh
@@ -11,7 +11,7 @@ check() {
 depends() {
     # if dmsetup is not installed, then we cannot support fedora/red hat
     # style live images
-    echo dm rootfs-block img-lib overlayfs
+    echo dm img-lib overlayfs
     return 0
 }
 

--- a/modules.d/90lvm/module-setup.sh
+++ b/modules.d/90lvm/module-setup.sh
@@ -18,7 +18,7 @@ check() {
 # called by dracut
 depends() {
     # We depend on dm_mod being loaded
-    echo rootfs-block dm
+    echo dm
     return 0
 }
 

--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -34,7 +34,6 @@ check() {
 
 # called by dracut
 depends() {
-    echo rootfs-block
     echo dm
     return 0
 }


### PR DESCRIPTION
Supporting dm without rootfs-block not tested configuration. I do not see use case to support dm module without rootfs-block.

The main intent of this PR is to simplify code for maintenance and improve dependency management.  

After this PR `dracut -m dm` will actually produce a bootable initramfs with rootfs-block included.