### PR TITLE
ci: add more packages to Fedora to allow testing more dracut containers

### DIFF
--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -11,15 +11,23 @@ RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)'
 RUN dnf -y install --setopt=install_weak_deps=False \
     asciidoc \
     bash-completion \
+    biosdevname \
+    bluez \
     btrfs-progs \
+    busybox \
     bzip2 \
+    cifs-utils \
     cryptsetup \
     dash \
     dbus-daemon \
+    device-mapper-multipath \
     dhcp-client \
     dhcp-server \
     dmraid \
     e2fsprogs \
+    f2fs-tools \
+    fcoe-utils \
+    fuse3 \
     gcc \
     git \
     iproute \
@@ -28,17 +36,28 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     kbd \
     kernel \
     kmod-devel \
+    libkcapi-hmaccalc \
+    libselinux-utils \
     lvm2 \
+    lzop \
     make \
     mdadm \
+    memstrack \
+    mksh \
     nbd \
+    ndctl \
     NetworkManager \
     nfs-utils \
+    ntfs-3g \
     ntfsprogs \
+    nvme-cli \
     parted \
+    pcsc-lite \
     pigz \
     qemu-system-x86-core \
+    rng-tools \
     rpm-build \
+    sbsigntools \
     scsi-target-utils \
     ShellCheck \
     shfmt \
@@ -46,8 +65,10 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     strace \
     sudo \
     systemd-networkd \
+    systemd-resolved \
     tar \
     tcpdump \
+    tpm2-tools \
     wget \
     which \
     xz \

--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -9,50 +9,49 @@ RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)'
 
 # Install needed packages for the dracut CI container
 RUN dnf -y install --setopt=install_weak_deps=False \
-    dash \
-    pigz \
     asciidoc \
-    mdadm \
-    lvm2 \
-    dmraid \
-    cryptsetup \
-    nfs-utils \
-    nbd \
-    dhcp-server \
-    scsi-target-utils \
-    iscsi-initiator-utils \
-    strace \
-    btrfs-progs \
-    kmod-devel \
-    gcc \
-    bzip2 \
-    xz \
-    tar \
-    wget \
-    rpm-build \
-    make \
-    git \
     bash-completion \
-    sudo \
-    kernel \
+    btrfs-progs \
+    bzip2 \
+    cryptsetup \
+    dash \
+    dbus-daemon \
     dhcp-client \
-    /usr/bin/qemu-kvm \
-    /usr/bin/qemu-system-$(uname -i) \
+    dhcp-server \
+    dmraid \
     e2fsprogs \
-    tcpdump \
+    gcc \
+    git \
     iproute \
     iputils \
-    dbus-daemon \
+    iscsi-initiator-utils \
     kbd \
+    kernel \
+    kmod-devel \
+    lvm2 \
+    make \
+    mdadm \
+    nbd \
     NetworkManager \
-    systemd-networkd \
-    squashfs-tools \
-    which \
+    nfs-utils \
+    ntfsprogs \
+    parted \
+    pigz \
+    qemu-system-x86-core \
+    rpm-build \
+    scsi-target-utils \
     ShellCheck \
     shfmt \
-    parted \
-    ntfsprogs \
-    && dnf -y remove dracut && dnf -y update && dnf -y install --setopt=install_weak_deps=False procps-ng && dnf clean all
+    squashfs-tools \
+    strace \
+    sudo \
+    systemd-networkd \
+    tar \
+    tcpdump \
+    wget \
+    which \
+    xz \
+    && dnf -y remove dracut --noautoremove && dnf -y update && dnf clean all
 
 # Set default command
 CMD ["/usr/bin/bash"]


### PR DESCRIPTION
PR allows to reproduce more issues with more dracut modules.

This does not mean or imply that we should do the same for the other test container.

I think each test container should serve a slightly different purpose, and it make sense to make Fedora the most complete test container in terms of binaries installed. 
