### PR TITLE
feat(dracut.sh): allow to pass all UEFI options as dracut arguments

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -271,6 +271,14 @@ Creates initial ramdisk images for preloading modules
   --uefi-splash-image [FILE]
                         Use [FILE] as a splash image when creating an UEFI
                          executable. Requires bitmap (.bmp) image format.
+  --uefi-secureboot-cert [FILE], --uefi-secureboot-key [FILE]
+                        Specifies a certificate and corresponding key, which are
+                         used to sign the created UEFI executable.
+                         Requires both certificate and key need to be specified
+                         and sbsign to be installed.
+  --uefi-secureboot-engine [ENGINE]
+                        Specifies an OpenSSL engine to use when signing the
+                         created UEFI executable. E.g. "pkcs11".
   --kernel-image [FILE] Location of the kernel image.
   --sbat [PARAMETERS]   The SBAT parameters to be added to .sbat.
                          The string "sbat,1,SBAT Version,sbat,1,
@@ -466,6 +474,9 @@ rearrange_params() {
             --long no-uefi \
             --long uefi-stub: \
             --long uefi-splash-image: \
+            --long uefi-secureboot-cert: \
+            --long uefi-secureboot-key: \
+            --long uefi-secureboot-engine: \
             --long kernel-image: \
             --long sbat: \
             --long no-hostonly-i18n \
@@ -840,6 +851,21 @@ while :; do
             PARMS_TO_STORE+=" '$2'"
             shift
             ;;
+        --uefi-secureboot-cert)
+            uefi_secureboot_cert_l="$2"
+            PARMS_TO_STORE+=" '$2'"
+            shift
+            ;;
+        --uefi-secureboot-key)
+            uefi_secureboot_key_l="$2"
+            PARMS_TO_STORE+=" '$2'"
+            shift
+            ;;
+        --uefi-secureboot-engine)
+            uefi_secureboot_engine_l="$2"
+            PARMS_TO_STORE+=" '$2'"
+            shift
+            ;;
         --kernel-image)
             kernel_image_l="$2"
             PARMS_TO_STORE+=" '$2'"
@@ -1088,6 +1114,9 @@ drivers_dir="${drivers_dir%"${drivers_dir##*[!/]}"}"
 [[ $uefi_l ]] && uefi=$uefi_l
 [[ $uefi_stub_l ]] && uefi_stub="$uefi_stub_l"
 [[ $uefi_splash_image_l ]] && uefi_splash_image="$uefi_splash_image_l"
+[[ $uefi_secureboot_cert_l ]] && uefi_secureboot_cert="$uefi_secureboot_cert_l"
+[[ $uefi_secureboot_key_l ]] && uefi_secureboot_key="$uefi_secureboot_key_l"
+[[ $uefi_secureboot_engine_l ]] && uefi_secureboot_engine="$uefi_secureboot_engine_l"
 [[ $kernel_image_l ]] && kernel_image="$kernel_image_l"
 [[ $sbat_l ]] && sbat="$sbat_l"
 [[ $machine_id_l ]] && machine_id="$machine_id_l"

--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -595,6 +595,16 @@ and no /etc/cmdline/*.conf will be generated into the initramfs.
     Specifies the UEFI stub loader's splash image. Requires bitmap (**.bmp**)
     image format.
 
+**--uefi-secureboot-cert _<file>_, --uefi-secureboot-key _<file>_**::
+    Specifies a certificate and corresponding key, which are used to sign the
+    created UEFI executable.
+    Requires both certificate and key need to be specified and _sbsign_ to be
+    installed.
+
+**--uefi-secureboot-engine _engine_**::
+    Specifies an OpenSSL engine to use when signing the created UEFI executable.
+    E.g. "pkcs11".
+
 **--kernel-image _<file>_**::
     Specifies the kernel image, which to include in the UEFI executable. The
     default is _/lib/modules/<KERNEL-VERSION>/vmlinuz_ or

--- a/man/dracut.conf.5.asc
+++ b/man/dracut.conf.5.asc
@@ -294,8 +294,9 @@ Logging levels:
     Requires both certificate and key need to be specified and _sbsign_ to be
     installed.
 
-*uefi_secureboot_engine=*"_parameter_"::
-    Specifies an engine to use when signing the created UEFI executable. E.g. "pkcs11"
+*uefi_secureboot_engine=*"_engine_"::
+    Specifies an OpenSSL engine to use when signing the created UEFI executable.
+    E.g. "pkcs11".
 
 *kernel_image=*"_<file>_"::
     Specifies the kernel image, which to include in the UEFI executable. The

--- a/shell-completion/bash/dracut
+++ b/shell-completion/bash/dracut
@@ -22,6 +22,11 @@ __contains_word() {
     return 1
 }
 
+__get_openssl_engines() {
+    # sbsign uses installed OpenSSL engines
+    openssl engine 2> /dev/null | awk -F[\(\)] '{print $2}'
+}
+
 _dracut() {
     local cur=${COMP_WORDS[COMP_CWORD]} prev=${COMP_WORDS[COMP_CWORD - 1]}
     local -A OPTS=(
@@ -46,7 +51,8 @@ _dracut() {
             --kernel-cmdline --sshkey --persistent-policy --install-optional
             --loginstall --uefi-stub --kernel-image --squash-compressor
             --sysroot --hostonly-mode --hostonly-nics --include --logfile
-            --uefi-splash-image --sbat
+            --uefi-splash-image --sbat --uefi-secureboot-cert
+            --uefi-secureboot-key --uefi-secureboot-engine
             '
     )
 
@@ -58,7 +64,8 @@ _dracut() {
                 compopt -o filenames
                 ;;
             -c | --conf | --sshkey | --add-fstab | --add-device | -I | \
-                --install | --install-optional | --uefi-splash-image)
+                --install | --install-optional | --uefi-splash-image | \
+                --uefi-secureboot-cert | --uefi-secureboot-key)
                 comps=$(compgen -f -- "$cur")
                 compopt -o filenames
                 ;;
@@ -85,6 +92,9 @@ _dracut() {
                     cd /sys/class/net/ || return 0
                     printf -- "%s " *
                 )
+                ;;
+            --uefi-secureboot-engine)
+                comps="$(__get_openssl_engines)"
                 ;;
             *)
                 return 0


### PR DESCRIPTION
This patch adds three dracut arguments that can currently only be set via configuration files: `--uefi-secureboot-cert`, `--uefi-secureboot-key` and `--uefi-secureboot-engine`.

This is useful in build environments (e.g. OBS) to avoid creating a temporary configuration file only to set these options.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it