### PR TITLE
test: do not omit dracut modules for initramfs.testing

### DIFF
--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -69,7 +69,6 @@ test_setup() {
     # make the man command succeed always
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -a "test systemd" \
-        -o "network kernel-network-modules" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         -i ./systemd-analyze.sh /lib/dracut/hooks/pre-pivot/00-systemd-analyze.sh \
         -i "/bin/true" "/usr/bin/man" \

--- a/test/TEST-03-USR-MOUNT/test.sh
+++ b/test/TEST-03-USR-MOUNT/test.sh
@@ -91,7 +91,6 @@ test_setup() {
 
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -a "test watchdog" \
-        -o "network kernel-network-modules" \
         -d "piix ide-gd_mod ata_piix btrfs sd_mod i6300esb ib700wdt" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -29,7 +29,7 @@ client_run() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "systemd.unit=testsuite.target systemd.mask=systemd-firstboot panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=LABEL=dracut $client_opts rd.retry=3 console=ttyS0,115200n81 selinux=0 $DEBUGOUT rd.shell=0 $DEBUGFAIL" \
+        -append "systemd.unit=testsuite.target systemd.mask=systemd-firstboot rd.multipath=0 panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=LABEL=dracut $client_opts rd.retry=3 console=ttyS0,115200n81 selinux=0 $DEBUGOUT rd.shell=0 $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     if ! grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success "$TESTDIR"/marker.img; then
@@ -157,7 +157,6 @@ EOF
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -a "test systemd i18n qemu" \
         ${EXTRA_MACHINE:+-I "$EXTRA_MACHINE"} \
-        -o "network plymouth lvm mdraid resume crypt caps dm terminfo usrmount kernel-network-modules rngd" \
         -d "piix ide-gd_mod ata_piix btrfs sd_mod i6300esb ib700wdt" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1

--- a/test/TEST-10-RAID/test.sh
+++ b/test/TEST-10-RAID/test.sh
@@ -119,7 +119,6 @@ test_setup() {
     )
 
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -o "plymouth network kernel-network-modules" \
         -a "debug" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \

--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -112,7 +112,6 @@ test_setup() {
         inst_hook emergency 000 ./hard-off.sh
     )
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -o "plymouth network kernel-network-modules" \
         -a "debug" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -155,7 +155,6 @@ test_setup() {
     )
 
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -o "plymouth network kernel-network-modules" \
         -a "debug" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \

--- a/test/TEST-13-ENC-RAID-LVM/test.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test.sh
@@ -154,7 +154,6 @@ test_setup() {
         chmod 0600 "$initdir"/etc/key
     )
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -o "plymouth network kernel-network-modules" \
         -a "debug" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \

--- a/test/TEST-14-IMSM/test.sh
+++ b/test/TEST-14-IMSM/test.sh
@@ -142,7 +142,6 @@ test_setup() {
         inst_hook emergency 000 ./hard-off.sh
     )
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -o "plymouth network kernel-network-modules" \
         -a "debug" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \

--- a/test/TEST-15-BTRFSRAID/test.sh
+++ b/test/TEST-15-BTRFSRAID/test.sh
@@ -119,7 +119,6 @@ test_setup() {
         inst_hook emergency 000 ./hard-off.sh
     )
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -o "plymouth network kernel-network-modules" \
         -a "debug" \
         -d "piix ide-gd_mod ata_piix btrfs sd_mod" \
         --no-hostonly-cmdline -N \

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -102,7 +102,6 @@ test_setup() {
 
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         --modules "test dash dmsquash-live qemu" \
-        --omit "rngd" \
         --drivers "ext4 sd_mod" \
         --install "mkfs.ext4" \
         --no-hostonly --no-hostonly-cmdline \
@@ -110,7 +109,6 @@ test_setup() {
 
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         --modules "test dmsquash-live-autooverlay qemu" \
-        --omit "rngd" \
         --drivers "ext4 sd_mod" \
         --install "mkfs.ext4" \
         --no-hostonly --no-hostonly-cmdline \

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -110,7 +110,6 @@ test_setup() {
         inst_hook emergency 000 ./hard-off.sh
     )
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -o "plymouth network kernel-network-modules" \
         -a "debug" -I lvs \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -408,7 +408,6 @@ test_setup() {
 
     # Make client's dracut image
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -o "plymouth" \
         -a "dmsquash-live debug watchdog ${USE_NETWORK}" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -308,7 +308,6 @@ test_setup() {
     )
     # Make client's dracut image
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -o "plymouth dmraid nfs" \
         -a "debug ${USE_NETWORK}" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -320,7 +320,6 @@ test_setup() {
     )
     # Make client's dracut image
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -o "plymouth dmraid nfs" \
         -a "debug ${USE_NETWORK}" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -480,7 +480,6 @@ test_setup() {
     )
 
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -o "plymouth iscsi nfs" \
         -a "debug watchdog ${USE_NETWORK}" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -345,7 +345,6 @@ test_setup() {
     )
     # Make client's dracut image
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -o "ifcfg plymouth" \
         -a "debug watchdog ${USE_NETWORK}" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1

--- a/test/TEST-60-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-60-BONDBRIDGEVLAN/test.sh
@@ -368,7 +368,6 @@ test_setup() {
     # Make client's dracut image
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         --no-early-microcode \
-        -o "plymouth" \
         -a "debug ${USE_NETWORK}" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1


### PR DESCRIPTION
We want to know if including dracut modules makes the test fail instead of masking issues by omitting dracut modules.

This PR increase test coverage and makes the tests simpler to maintain.

This PR exposed an issue with multipath dracut module for full systemd test (test 04). For now limit this PR just for changing tests, so disable multipath from kernel command line to keep the test passing.

The exposed new issue confirms the reasoning behind why this PR increases test coverage.
