### PR TITLE
test: convert more tests use the test dracut modules

### DIFF
--- a/test/TEST-11-LVM/finished-false.sh
+++ b/test/TEST-11-LVM/finished-false.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exit 1

--- a/test/TEST-11-LVM/hard-off.sh
+++ b/test/TEST-11-LVM/hard-off.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-getargbool 0 rd.shell || poweroff -f
-getargbool 0 failme && poweroff -f

--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -11,7 +11,6 @@ KVERSION=${KVERSION-$(uname -r)}
 test_run() {
     dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
-    # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1
@@ -27,58 +26,25 @@ test_run() {
 }
 
 test_setup() {
-    kernel=$KVERSION
     # Create what will eventually be our root filesystem onto an overlay
-    (
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay/source
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        (
-            cd "$initdir" || exit
-            mkdir -p -- dev sys proc etc var/run tmp
-            mkdir -p root usr/bin usr/lib usr/lib64 usr/sbin
-        )
-        inst_multiple sh df free ls shutdown poweroff stty cat ps ln \
-            mount dmesg mkdir cp dd sync
-        for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
-            [ -f ${_terminfodir}/l/linux ] && break
-        done
-        inst_multiple -o ${_terminfodir}/l/linux
-
-        inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
-        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
-        inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
-
-        inst_multiple grep
-        inst_simple /etc/os-release
-        inst ./test-init.sh /sbin/init
-        find_binary plymouth > /dev/null && inst_multiple plymouth
-        cp -a /etc/ld.so.conf* "$initdir"/etc
-        mkdir -p "$initdir"/run
-        ldconfig -r "$initdir"
-    )
+    "$basedir"/dracut.sh -l --keep --tmpdir "$TESTDIR" \
+        -m "test-root" \
+        -i ./test-init.sh /sbin/init \
+        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
+        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
+        --no-hostonly --no-hostonly-cmdline --nohardlink \
+        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+    mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     # second, install the files needed to make the root filesystem
-    (
-        # shellcheck disable=SC2031
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext4 poweroff cp umount dd sync
-        inst_hook initqueue 01 ./create-root.sh
-        inst_hook initqueue/finished 01 ./finished-false.sh
-    )
-
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -m "bash lvm mdraid kernel-modules qemu" \
+        -m "test-makeroot bash lvm mdraid kernel-modules" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -I "mkfs.ext4" \
+        -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
@@ -102,18 +68,9 @@ test_setup() {
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
 
-    (
-        # shellcheck disable=SC2031
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        inst_multiple poweroff shutdown dd
-        inst_hook shutdown-emergency 000 ./hard-off.sh
-        inst_hook emergency 000 ./hard-off.sh
-    )
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \
-        -a "debug" \
+        -a "test" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1

--- a/test/TEST-12-RAID-DEG/finished-false.sh
+++ b/test/TEST-12-RAID-DEG/finished-false.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exit 1

--- a/test/TEST-12-RAID-DEG/hard-off.sh
+++ b/test/TEST-12-RAID-DEG/hard-off.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-sleep 5
-getargbool 0 rd.shell || poweroff -f
-! getargbool 0 rd.break && getargbool 0 failme && poweroff -f

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -14,7 +14,6 @@ client_run() {
     echo "CLIENT TEST START: $*"
     dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
-    # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
     # degrade the RAID
@@ -59,56 +58,24 @@ test_run() {
 
 test_setup() {
     kernel=$KVERSION
-    # Create what will eventually be our root filesystem onto an overlay
-    (
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay/source
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        (
-            cd "$initdir" || exit
-            mkdir -p -- dev sys proc etc var/run tmp
-            mkdir -p root usr/bin usr/lib usr/lib64 usr/sbin
-        )
-        inst_multiple sh df free ls shutdown poweroff stty cat ps ln \
-            mount dmesg mkdir cp dd sync
-        for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
-            [ -f ${_terminfodir}/l/linux ] && break
-        done
-        inst_multiple -o ${_terminfodir}/l/linux
-
-        inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
-        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
-        inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
-
-        inst_multiple grep
-        inst_simple /etc/os-release
-        inst ./test-init.sh /sbin/init
-        find_binary plymouth > /dev/null && inst_multiple plymouth
-        cp -a /etc/ld.so.conf* "$initdir"/etc
-        ldconfig -r "$initdir"
-    )
+    "$basedir"/dracut.sh -l --keep --tmpdir "$TESTDIR" \
+        -m "test-root" \
+        -i ./test-init.sh /sbin/init \
+        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
+        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
+        --no-hostonly --no-hostonly-cmdline --nohardlink \
+        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+    mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     # second, install the files needed to make the root filesystem
-    (
-        # shellcheck disable=SC2030
-        # shellcheck disable=SC2031
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext4 poweroff cp umount dd grep sync
-        inst_hook initqueue 01 ./create-root.sh
-        inst_hook initqueue/finished 01 ./finished-false.sh
-    )
-
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -m "bash crypt lvm mdraid kernel-modules qemu" \
+        -m "test-makeroot bash crypt lvm mdraid kernel-modules" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -I "mkfs.ext4 grep sfdisk" \
+        -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
@@ -119,7 +86,6 @@ test_setup() {
     dd if=/dev/zero of="$TESTDIR"/raid-3.img bs=1MiB count=40
     dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
-    # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1
@@ -138,26 +104,19 @@ test_setup() {
     eval "$(grep -F --binary-files=text -m 1 MD_UUID "$TESTDIR"/marker.img)"
     echo "$MD_UUID" > "$TESTDIR"/mduuid
 
-    (
-        # shellcheck disable=SC2031
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        inst_multiple poweroff shutdown dd
-        inst_hook shutdown-emergency 000 ./hard-off.sh
-        inst_hook emergency 000 ./hard-off.sh
-        inst ./cryptroot-ask.sh /sbin/cryptroot-ask
-        mkdir -p "$initdir"/etc
-        echo "ARRAY /dev/md0 level=raid5 num-devices=3 UUID=$MD_UUID" > "$initdir"/etc/mdadm.conf
-        echo "luks-$ID_FS_UUID UUID=$ID_FS_UUID /etc/key" > "$initdir"/etc/crypttab
-        echo -n test > "$initdir"/etc/key
-        chmod 0600 "$initdir"/etc/key
-    )
+    echo "ARRAY /dev/md0 level=raid5 num-devices=3 UUID=$MD_UUID" > /tmp/mdadm.conf
+    echo "luks-$ID_FS_UUID UUID=$ID_FS_UUID /etc/key" > /tmp/crypttab
+    echo -n test > /tmp/key
+    chmod 0600 /tmp/key
 
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \
-        -a "debug" \
+        -a "test" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -i "./cryptroot-ask.sh" "/sbin/cryptroot-ask" \
+        -i "/tmp/mdadm.conf" "/etc/mdadm.conf" \
+        -i "/tmp/crypttab" "/etc/crypttab" \
+        -i "/tmp/key" "/etc/key" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 }

--- a/test/TEST-13-ENC-RAID-LVM/finished-false.sh
+++ b/test/TEST-13-ENC-RAID-LVM/finished-false.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exit 1

--- a/test/TEST-13-ENC-RAID-LVM/hard-off.sh
+++ b/test/TEST-13-ENC-RAID-LVM/hard-off.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-getargbool 0 rd.shell || poweroff -f
-getargbool 0 failme && poweroff -f

--- a/test/TEST-13-ENC-RAID-LVM/test.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test.sh
@@ -17,7 +17,6 @@ test_run() {
     echo "CLIENT TEST START: $LUKSARGS"
 
     declare -a disk_args=()
-    # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1
@@ -55,68 +54,34 @@ test_run() {
 }
 
 test_setup() {
-    kernel=$KVERSION
-    # Create what will eventually be our root filesystem onto an overlay
-    (
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay/source
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        (
-            cd "$initdir" || exit
-            mkdir -p -- dev sys proc etc var/run tmp
-            mkdir -p root usr/bin usr/lib usr/lib64 usr/sbin
-        )
-        inst_multiple sh df free ls shutdown poweroff stty cat ps ln \
-            mount dmesg mkdir cp dd
-        for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
-            [ -f ${_terminfodir}/l/linux ] && break
-        done
-        inst_multiple -o ${_terminfodir}/l/linux
-
-        inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
-        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
-        inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
-
-        inst_multiple grep
-        inst_simple /etc/os-release
-        inst ./test-init.sh /sbin/init
-        find_binary plymouth > /dev/null && inst_multiple plymouth
-        cp -a /etc/ld.so.conf* "$initdir"/etc
-        ldconfig -r "$initdir"
-    )
+    "$basedir"/dracut.sh -l --keep --tmpdir "$TESTDIR" \
+        -m "test-root" \
+        -i ./test-init.sh /sbin/init \
+        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
+        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
+        --no-hostonly --no-hostonly-cmdline --nohardlink \
+        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+    mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     # second, install the files needed to make the root filesystem
-    (
-        # shellcheck disable=SC2031
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext4 poweroff cp umount grep dd sync
-        inst_hook initqueue 01 ./create-root.sh
-        inst_hook initqueue/finished 01 ./finished-false.sh
-    )
-
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -m "bash crypt lvm mdraid kernel-modules qemu" \
+        -m "test-makeroot bash crypt lvm mdraid kernel-modules" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -I "mkfs.ext4 grep" \
+        -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
 
     # Create the blank files to use as a root filesystem
-    dd if=/dev/zero of="$TESTDIR"/disk-1.img bs=1MiB count=40
-    dd if=/dev/zero of="$TESTDIR"/disk-2.img bs=1MiB count=40
-    dd if=/dev/zero of="$TESTDIR"/disk-3.img bs=1MiB count=40
+    dd if=/dev/zero of="$TESTDIR"/disk-1.img bs=2MiB count=40
+    dd if=/dev/zero of="$TESTDIR"/disk-2.img bs=2MiB count=40
+    dd if=/dev/zero of="$TESTDIR"/disk-3.img bs=2MiB count=40
     dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
-    # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1
@@ -134,29 +99,22 @@ test_setup() {
         printf ' rd.luks.uuid=luks-%s ' "$ID_FS_UUID"
     done > "$TESTDIR"/luks.txt
 
-    (
-        # shellcheck disable=SC2031
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        inst_multiple poweroff shutdown dd
-        inst_hook shutdown-emergency 000 ./hard-off.sh
-        inst_hook emergency 000 ./hard-off.sh
-        inst ./cryptroot-ask.sh /sbin/cryptroot-ask
-        mkdir -p "$initdir"/etc
-        i=1
-        for uuid in $cryptoUUIDS; do
-            eval "$uuid"
-            printf 'luks-%s /dev/disk/by-id/ata-disk_disk%s /etc/key timeout=0\n' "$ID_FS_UUID" $i
-            ((i += 1))
-        done > "$initdir"/etc/crypttab
-        echo -n test > "$initdir"/etc/key
-        chmod 0600 "$initdir"/etc/key
-    )
+    i=1
+    for uuid in $cryptoUUIDS; do
+        eval "$uuid"
+        printf 'luks-%s /dev/disk/by-id/ata-disk_disk%s /etc/key timeout=0\n' "$ID_FS_UUID" $i
+        ((i += 1))
+    done > /tmp/crypttab
+    echo -n test > /tmp/key
+    chmod 0600 /tmp/key
+
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \
-        -a "debug" \
+        -a "test" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -i "./cryptroot-ask.sh" "/sbin/cryptroot-ask" \
+        -i "/tmp/crypttab" "/etc/crypttab" \
+        -i "/tmp/key" "/etc/key" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 }

--- a/test/TEST-14-IMSM/cryptroot-ask.sh
+++ b/test/TEST-14-IMSM/cryptroot-ask.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-[ -b /dev/mapper/"$2" ] && exit 0
-printf test > /keyfile
-/sbin/cryptsetup luksOpen "$1" "$2" < /keyfile

--- a/test/TEST-14-IMSM/hard-off.sh
+++ b/test/TEST-14-IMSM/hard-off.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-getargbool 0 rd.shell || poweroff -f
-getargbool 0 failme && poweroff -f

--- a/test/TEST-15-BTRFSRAID/finished-false.sh
+++ b/test/TEST-15-BTRFSRAID/finished-false.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exit 1

--- a/test/TEST-15-BTRFSRAID/hard-off.sh
+++ b/test/TEST-15-BTRFSRAID/hard-off.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-getargbool 0 rd.shell || poweroff -f
-getargbool 0 failme && poweroff -f

--- a/test/TEST-15-BTRFSRAID/test.sh
+++ b/test/TEST-15-BTRFSRAID/test.sh
@@ -9,7 +9,6 @@ KVERSION=${KVERSION-$(uname -r)}
 test_run() {
     dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
-    # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1
@@ -30,57 +29,25 @@ test_setup() {
     rm -f -- "$DISKIMAGE"
     dd if=/dev/zero of="$DISKIMAGE" bs=1M count=1024
 
-    kernel=$KVERSION
     # Create what will eventually be our root filesystem onto an overlay
-    (
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay/source
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        (
-            cd "$initdir" || exit
-            mkdir -p -- dev sys proc etc var/run tmp
-            mkdir -p root usr/bin usr/lib usr/lib64 usr/sbin
-        )
-        inst_multiple sh df free ls shutdown poweroff stty cat ps ln \
-            mount dmesg mkdir cp sync dd
-        for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
-            [ -f ${_terminfodir}/l/linux ] && break
-        done
-        inst_multiple -o ${_terminfodir}/l/linux
-
-        inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
-        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
-        inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
-
-        inst_multiple grep
-        inst ./test-init.sh /sbin/init
-        inst_simple /etc/os-release
-        find_binary plymouth > /dev/null && inst_multiple plymouth
-        cp -a /etc/ld.so.conf* "$initdir"/etc
-        ldconfig -r "$initdir"
-    )
+    "$basedir"/dracut.sh -l --keep --tmpdir "$TESTDIR" \
+        -m "test-root" \
+        -i ./test-init.sh /sbin/init \
+        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
+        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
+        --no-hostonly --no-hostonly-cmdline --nohardlink \
+        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+    mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     # second, install the files needed to make the root filesystem
-    (
-        # shellcheck disable=SC2031
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.btrfs poweroff cp umount dd sync
-        inst_hook initqueue 01 ./create-root.sh
-        inst_hook initqueue/finished 01 ./finished-false.sh
-    )
-
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -m "bash btrfs rootfs-block kernel-modules qemu" \
+        -m "test-makeroot bash btrfs rootfs-block kernel-modules" \
         -d "piix ide-gd_mod ata_piix btrfs sd_mod" \
+        -I "mkfs.btrfs" \
+        -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
@@ -94,7 +61,6 @@ test_setup() {
     dd if=/dev/zero of="$TESTDIR"/raid-4.img bs=1MiB count=150
     dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
-    # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1
@@ -109,18 +75,9 @@ test_setup() {
 
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
 
-    (
-        # shellcheck disable=SC2031
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        inst_multiple poweroff shutdown
-        inst_hook shutdown-emergency 000 ./hard-off.sh
-        inst_hook emergency 000 ./hard-off.sh
-    )
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \
-        -a "debug" \
+        -a "test" \
         -d "piix ide-gd_mod ata_piix btrfs sd_mod" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1

--- a/test/TEST-17-LVM-THIN/finished-false.sh
+++ b/test/TEST-17-LVM-THIN/finished-false.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exit 1

--- a/test/TEST-17-LVM-THIN/hard-off.sh
+++ b/test/TEST-17-LVM-THIN/hard-off.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-getargbool 0 rd.shell || poweroff -f
-getarg failme && poweroff -f

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -10,7 +10,6 @@ KVERSION=${KVERSION-$(uname -r)}
 test_run() {
     dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
-    # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1
@@ -25,58 +24,25 @@ test_run() {
 }
 
 test_setup() {
-    kernel=$KVERSION
     # Create what will eventually be our root filesystem onto an overlay
-    (
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay/source
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        (
-            cd "$initdir" || exit
-            mkdir -p -- dev sys proc etc var/run tmp
-            mkdir -p root usr/bin usr/lib usr/lib64 usr/sbin
-        )
-        inst_multiple sh df free ls shutdown poweroff stty cat ps ln \
-            mount dmesg mkdir cp dd sync
-        for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
-            [ -f ${_terminfodir}/l/linux ] && break
-        done
-        inst_multiple -o ${_terminfodir}/l/linux
-
-        inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
-        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
-        inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
-
-        inst_multiple grep
-        inst_simple /etc/os-release
-        inst ./test-init.sh /sbin/init
-        find_binary plymouth > /dev/null && inst_multiple plymouth
-        cp -a /etc/ld.so.conf* "$initdir"/etc
-        mkdir -p "$initdir"/run
-        ldconfig -r "$initdir"
-    )
+    "$basedir"/dracut.sh -l --keep --tmpdir "$TESTDIR" \
+        -m "test-root" \
+        -i ./test-init.sh /sbin/init \
+        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
+        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
+        --no-hostonly --no-hostonly-cmdline --nohardlink \
+        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+    mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     # second, install the files needed to make the root filesystem
-    (
-        # shellcheck disable=SC2030
-        # shellcheck disable=SC2031
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext4 poweroff cp umount grep dmsetup dd sync
-        inst_hook initqueue 01 ./create-root.sh
-        inst_hook initqueue/finished 01 ./finished-false.sh
-    )
-
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -m "bash lvm mdraid kernel-modules qemu" \
+        -m "test-makeroot bash lvm mdraid kernel-modules" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -I "mkfs.ext4 grep" \
+        -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
@@ -100,18 +66,9 @@ test_setup() {
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
 
-    (
-        # shellcheck disable=SC2031
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        inst_multiple poweroff shutdown
-        inst_hook shutdown-emergency 000 ./hard-off.sh
-        inst_hook emergency 000 ./hard-off.sh
-    )
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \
-        -a "debug" -I lvs \
+        -a "test" -I lvs \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1

--- a/test/TEST-30-ISCSI/finished-false.sh
+++ b/test/TEST-30-ISCSI/finished-false.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exit 1

--- a/test/TEST-30-ISCSI/hard-off.sh
+++ b/test/TEST-30-ISCSI/hard-off.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-getargbool 0 rd.shell || poweroff -f
-getargbool 0 failme && poweroff -f

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -131,57 +131,27 @@ test_setup() {
         return 1
     fi
 
-    kernel=$KVERSION
-    # Create what will eventually be our root filesystem onto an overlay
-    rm -rf -- "$TESTDIR"/overlay
-    (
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay/source
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        (
-            cd "$initdir" || exit
-            mkdir -p -- dev sys proc etc var/run tmp
-            mkdir -p root usr/bin usr/lib usr/lib64 usr/sbin
-            mkdir -p -- var/lib/nfs/rpc_pipefs
-        )
-        inst_multiple sh shutdown poweroff stty cat ps ln ip \
-            mount dmesg mkdir cp ping grep setsid dd sync
-        for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
-            [ -f ${_terminfodir}/l/linux ] && break
-        done
-        inst_multiple -o ${_terminfodir}/l/linux
-        inst_simple /etc/os-release
+    # Create what will eventually be the client root filesystem onto an overlay
+    "$basedir"/dracut.sh -l --keep --tmpdir "$TESTDIR" \
+        -m "test-root" \
+        -i ./client-init.sh /sbin/init \
+        -I "ip ping grep setsid" \
+        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
+        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
+        --no-hostonly --no-hostonly-cmdline --nohardlink \
+        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+    mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
-        inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
-        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
-        inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
-
-        inst ./client-init.sh /sbin/init
-        cp -a /etc/ld.so.conf* "$initdir"/etc
-        ldconfig -r "$initdir"
-    )
-
-    # second, install the files needed to make the root filesystem
-    (
-        # shellcheck disable=SC2031
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext4 poweroff cp umount setsid dd sync blockdev
-        inst_hook initqueue 01 ./create-client-root.sh
-        inst_hook initqueue/finished 01 ./finished-false.sh
-    )
+    mkdir -p -- "$TESTDIR"/overlay/source/var/lib/nfs/rpc_pipefs
 
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -m "dash crypt lvm mdraid kernel-modules qemu" \
+        -m "test-makeroot dash crypt lvm mdraid kernel-modules" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -I "mkfs.ext4 setsid blockdev" \
+        -i ./create-client-root.sh /lib/dracut/hooks/initqueue/01-create-client-root.sh \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
@@ -206,79 +176,39 @@ test_setup() {
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
     rm -- "$TESTDIR"/marker.img
 
-    # shellcheck disable=SC2031
-    export kernel=$KVERSION
+    # Create what will eventually be the server root filesystem onto an overlay
     rm -rf -- "$TESTDIR"/overlay
-    (
-        mkdir -p "$TESTDIR"/overlay/source
-        # shellcheck disable=SC2031
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay/source
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        (
-            cd "$initdir" || exit
-            mkdir -p dev sys proc etc var/run tmp var/lib/dhcpd /etc/iscsi
-        )
-        inst /etc/passwd /etc/passwd
-        inst_multiple sh ls shutdown poweroff stty cat ps ln ip \
-            dmesg mkdir cp ping modprobe tcpdump setsid \
-            sleep mount chmod pidof
-        inst_multiple tgtd tgtadm
-        for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
-            [ -f ${_terminfodir}/l/linux ] && break
-        done
-        inst_multiple -o ${_terminfodir}/l/linux
-        instmods iscsi_tcp crc32c ipv6 af_packet
-        [ -f /etc/netconfig ] && inst_multiple /etc/netconfig
-        type -P dhcpd > /dev/null && inst_multiple dhcpd
-        [ -x /usr/sbin/dhcpd3 ] && inst /usr/sbin/dhcpd3 /usr/sbin/dhcpd
-        inst ./server-init.sh /sbin/init
-        inst ./hosts /etc/hosts
-        inst ./dhcpd.conf /etc/dhcpd.conf
-        inst_multiple -o {,/usr}/etc/nsswitch.conf {,/usr}/etc/rpc \
-            {,/usr}/etc/protocols {,/usr}/etc/services \
-            /etc/group /etc/os-release
+    "$basedir"/dracut.sh -l --keep --tmpdir "$TESTDIR" \
+        -m "test-root network network-legacy" \
+        -d "iscsi_tcp crc32c ipv6 af_packet" \
+        -i ./server-init.sh /sbin/init \
+        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
+        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
+        -I "ip ping tcpdump setsid pidof tgtd tgtadm /etc/passwd" \
+        --install-optional "/etc/netconfig dhcpd dhcpd3 {,/usr}/etc/nsswitch.conf {,/usr}/etc/rpc {,/usr}/etc/protocols {,/usr}/etc/services /etc/group" \
+        -i "./hosts" "/etc/hosts" \
+        -i "./dhcpd.conf" "/etc/dhcpd.conf" \
+        --no-hostonly --no-hostonly-cmdline --nohardlink \
+        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+    mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
-        _nsslibs=$(
-            cat "$dracutsysrootdir"/{,usr/}etc/nsswitch.conf 2> /dev/null \
-                | sed -e '/^#/d' -e 's/^.*://' -e 's/\[NOTFOUND=return\]//' \
-                | tr -s '[:space:]' '\n' | sort -u | tr -s '[:space:]' '|'
-        )
-        _nsslibs=${_nsslibs#|}
-        _nsslibs=${_nsslibs%|}
-
-        inst_libdir_file -n "$_nsslibs" 'libnss_*.so*'
-
-        cp -a /etc/ld.so.conf* "$initdir"/etc
-        ldconfig -r "$initdir"
-        dracut_kernel_post
-    )
+    mkdir -p "$TESTDIR"/overlay/source/var/lib/dhcpd
 
     # second, install the files needed to make the root filesystem
-    (
-        # shellcheck disable=SC2031
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext4 poweroff cp umount sync dd
-        inst_hook initqueue 01 ./create-server-root.sh
-        inst_hook initqueue/finished 01 ./finished-false.sh
-    )
-
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -m "dash rootfs-block kernel-modules qemu" \
+        -m "test-makeroot dash rootfs-block kernel-modules" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -I "mkfs.ext4" \
+        -i ./create-server-root.sh /lib/dracut/hooks/initqueue/01-create-server-root.sh \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
 
-    dd if=/dev/zero of="$TESTDIR"/server.img bs=1MiB count=60
+    dd if=/dev/zero of="$TESTDIR"/server.img bs=4MiB count=60
     dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     # shellcheck disable=SC2034
@@ -294,39 +224,21 @@ test_setup() {
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
     rm -- "$TESTDIR"/marker.img
 
-    # Make an overlay with needed tools for the test harness
-    (
-        # shellcheck disable=SC2031
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        inst_multiple poweroff shutdown
-        inst_hook shutdown-emergency 000 ./hard-off.sh
-        inst_hook emergency 000 ./hard-off.sh
-        inst_simple ./client.link /etc/systemd/network/01-client.link
-    )
     # Make client's dracut image
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth dmraid nfs" \
-        -a "debug ${USE_NETWORK}" \
+        -a "test ${USE_NETWORK}" \
+        -i "./client.link" "/etc/systemd/network/01-client.link" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 
-    (
-        # shellcheck disable=SC2031
-        export initdir="$TESTDIR"/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        rm "$initdir"/etc/systemd/network/01-client.link
-        inst_simple ./server.link /etc/systemd/network/01-server.link
-        inst_hook pre-mount 99 ./wait-if-server.sh
-        inst_multiple sysctl
-    )
     # Make server's dracut image
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -a "dash rootfs-block debug kernel-modules network network-legacy" \
+        -a "dash rootfs-block test kernel-modules network network-legacy" \
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod e1000 drbg" \
+        -i "./server.link" "/etc/systemd/network/01-server.link" \
+        -i ./wait-if-server.sh /lib/dracut/hooks/pre-mount/99-wait-if-server.sh \
+        -I "sysctl" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
 


### PR DESCRIPTION
Same as https://github.com/dracutdevs/dracut/pull/2011 but for more tests.

Follow-up to https://github.com/dracutdevs/dracut/pull/2238 .

The last [commit](https://github.com/dracutdevs/dracut/pull/2260/commits/a8238596239f2958af59f5fad9c6d3114e719d09) in the PR is the first networking test (iscsi test) converted using this infrastructure, which includes not only client but server initramfs and rootfs generation. 

After this reviewed, I plan to convert over more networking tests.

This PR is a refactor, it should not change how the tests are executed. 

This PR removes about 400 lines of code while maintaining existing functionality. 
