### PR TITLE
fix(fs-lib): fix e2fsck call

### DIFF
--- a/modules.d/99fs-lib/fs-lib.sh
+++ b/modules.d/99fs-lib/fs-lib.sh
@@ -107,7 +107,8 @@ fsck_drv_com() {
 
     info "issuing $_drv $_fop $_dev"
     # we enforce non-interactive run, so $() is fine
-    _out=$($_drv "$_fop" "$_dev")
+    # shellcheck disable=SC2086
+    _out=$($_drv $_fop "$_dev")
     _ret=$?
     fsck_tail
 


### PR DESCRIPTION
Fix regression introduced by https://github.com/dracutdevs/dracut/pull/1254 in v54.

Fixes #2261
