### PR TITLE
fix(zipl): do not use deprecated `blkid -o udev`

### DIFF
--- a/modules.d/91zipl/module-setup.sh
+++ b/modules.d/91zipl/module-setup.sh
@@ -29,7 +29,7 @@ installkernel() {
 
     _boot_zipl=$(get_boot_zipl_dev)
     if [ -n "$_boot_zipl" ]; then
-        eval "$(blkid -s TYPE -o udev "${_boot_zipl}")"
+        eval "$(udevadm info --query=property --name="${_boot_zipl}" 2> /dev/null | grep ID_FS_TYPE)"
         if [ -n "$ID_FS_TYPE" ]; then
             case "$ID_FS_TYPE" in
                 ext?)


### PR DESCRIPTION
`blkid -o udev` is deprecated since https://github.com/util-linux/util-linux/commit/24d741d8, replace it with `udevadm info`.

Issue spotted in #2222

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
