### PR TITLE
fix(overlayfs): allow hostonly and nfs support

### DIFF
--- a/modules.d/90overlayfs/module-setup.sh
+++ b/modules.d/90overlayfs/module-setup.sh
@@ -14,6 +14,7 @@ installkernel() {
 }
 
 install() {
-    inst_hook mount 01 "$moddir/mount-overlayfs.sh"
     inst_hook pre-mount 01 "$moddir/prepare-overlayfs.sh"
+    inst_hook mount 01 "$moddir/mount-overlayfs.sh"     # overlay on top of block device
+    inst_hook pre-pivot 10 "$moddir/mount-overlayfs.sh" # overlay on top of network device (e.g. nfs)
 }

--- a/modules.d/90overlayfs/module-setup.sh
+++ b/modules.d/90overlayfs/module-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 check() {
-    [[ $hostonly ]] && return 1
+    require_kernel_modules overlay || return 1
     return 255
 }
 
@@ -10,7 +10,7 @@ depends() {
 }
 
 installkernel() {
-    instmods overlay
+    hostonly="" instmods overlay
 }
 
 install() {

--- a/test/TEST-20-NFS/client-init.sh
+++ b/test/TEST-20-NFS/client-init.sh
@@ -24,6 +24,13 @@ while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
     break
 done < /proc/mounts
 
+# fail the test of rd.live.overlay did not worked as expected
+if grep -qF 'rd.live.overlay' /proc/cmdline; then
+    if ! strstr "$(cat /proc/mounts)" LiveOS_rootfs; then
+        echo "nfs-FAIL" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+    fi
+fi
+
 if [ "$fstype" = "nfs" -o "$fstype" = "nfs4" ]; then
 
     serverip=${dev%:*}


### PR DESCRIPTION
Check for overlay kernel module support.

Execute mount-overlayfs later in the boot process. Without this change `dracut  -a "overlayfs nfs"` does not work as expected.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [X] I am providing new code and test(s) for it

Fixes #
