### PR TITLE
fix(dracut-systemd): rootfs-generator issues

### DIFF
--- a/modules.d/98dracut-systemd/module-setup.sh
+++ b/modules.d/98dracut-systemd/module-setup.sh
@@ -37,6 +37,8 @@ install() {
 
     inst_script "$moddir/rootfs-generator.sh" "$systemdutildir"/system-generators/dracut-rootfs-generator
 
+    inst_hook cmdline 00 "$moddir/parse-root.sh"
+
     for i in \
         dracut-cmdline.service \
         dracut-cmdline-ask.service \

--- a/modules.d/98dracut-systemd/parse-root.sh
+++ b/modules.d/98dracut-systemd/parse-root.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+root=$(getarg root=)
+case "${root#block:}" in
+    LABEL=* | UUID=* | PARTUUID=* | PARTLABEL=*)
+        root="block:$(label_uuid_to_dev "$root")"
+        rootok=1
+        ;;
+    /dev/nfs | /dev/root) # ignore legacy
+        ;;
+    /dev/*)
+        root="block:${root}"
+        rootok=1
+        ;;
+esac
+
+if [ "$rootok" = "1" ]; then
+    root_dev="${root#block:}"
+    root_name="$(str_replace "$root_dev" '/' '\x2f')"
+    if ! [ -e "$hookdir/initqueue/finished/devexists-${root_name}.sh" ]; then
+
+        # If a LUKS device needs unlocking via systemd in the initrd, assume
+        # it's for the root device. In that case, don't block on it if it's
+        # after remote-fs-pre.target since the initqueue is ordered before it so
+        # it will never actually show up (think Tang-pinned rootfs).
+        cat > "$hookdir/initqueue/finished/devexists-${root_name}.sh" << EOF
+if ! grep -q After=remote-fs-pre.target /run/systemd/generator/systemd-cryptsetup@*.service 2>/dev/null; then
+    [ -e "$root_dev" ]
+fi
+EOF
+        {
+            printf '[ -e "%s" ] || ' "$root_dev"
+            printf 'warn "\"%s\" does not exist"\n' "$root_dev"
+        } >> "$hookdir/emergency/80-${root_name}.sh"
+    fi
+fi


### PR DESCRIPTION
- Do not hardcode the systemd generator directory.
The normal directory is the first argument passed to the systemd generator, so use it instead of hardcoding `/run/systemd/generator`.

- Check and create the generator directory outside of inner function.

- A systemd generator cannot write outside of the generator directory.
Although it was already documented in [systemd.generator(7)](https://www.freedesktop.org/software/systemd/man/systemd.generator.html#Output%20directories) that generators must not write to locations other than those passed as arguments, since https://github.com/systemd/systemd/commit/ca6ce62d systemd executes generators in a mount namespace "sandbox", so now the hooks created by the rootfs-generator are lost.
These hooks are created using the `root=` cmdline argument, so this patch moves the creation of these hooks to a cmdline hook.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2211
Fixes #2225