### PR TITLE
fix(dracut.sh): handle /etc/machine-id empty or uninitialized

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -19,8 +19,9 @@ SKIP="$dracutbasedir/skipcpio"
 
 if [[ -d /efi/Default ]] || [[ -d /boot/Default ]] || [[ -d /boot/efi/Default ]]; then
     MACHINE_ID="Default"
-elif [[ -f /etc/machine-id ]]; then
+elif [[ -s /etc/machine-id ]]; then
     read -r MACHINE_ID < /etc/machine-id
+    [[ $MACHINE_ID == "uninitialized" ]] && MACHINE_ID="Default"
 else
     MACHINE_ID="Default"
 fi

--- a/dracut.sh
+++ b/dracut.sh
@@ -1087,8 +1087,9 @@ if ! [[ $outfile ]]; then
             || [[ -d "$dracutsysrootdir"/boot/Default ]] \
             || [[ -d "$dracutsysrootdir"/boot/efi/Default ]]; then
             MACHINE_ID="Default"
-        elif [[ -f "$dracutsysrootdir"/etc/machine-id ]]; then
+        elif [[ -s "$dracutsysrootdir"/etc/machine-id ]]; then
             read -r MACHINE_ID < "$dracutsysrootdir"/etc/machine-id
+            [[ $MACHINE_ID == "uninitialized" ]] && MACHINE_ID="Default"
         else
             MACHINE_ID="Default"
         fi

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -111,8 +111,9 @@ if [[ $1 ]]; then
 else
     if [[ -d /efi/Default ]] || [[ -d /boot/Default ]] || [[ -d /boot/efi/Default ]]; then
         MACHINE_ID="Default"
-    elif [[ -f /etc/machine-id ]]; then
+    elif [[ -s /etc/machine-id ]]; then
         read -r MACHINE_ID < /etc/machine-id
+        [[ $MACHINE_ID == "uninitialized" ]] && MACHINE_ID="Default"
     else
         MACHINE_ID="Default"
     fi


### PR DESCRIPTION
Handle the case where the user tries to generate the initrd after explicitly resetting the `/etc/machine-id` file.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2267
