### PR TITLE
skip generating the initrd when installing an unified kernel image

### DIFF
--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -11,6 +11,11 @@ if ! [[ ${KERNEL_INSTALL_MACHINE_ID-x} ]]; then
     exit 0
 fi
 
+# unified kernel images already have an initrd included
+if [[ "$KERNEL_INSTALL_IMAGE_TYPE" == "uki" ]]; then
+    exit 0
+fi
+
 if [[ -d "$BOOT_DIR_ABS" ]]; then
     INITRD="initrd"
 else


### PR DESCRIPTION
## Changes

The KERNEL_INSTALL_IMAGE_TYPE variable is set by newer kernel-install versions.  In case it is set to "uki" skip initrd generation.

The related systemd update is here:
https://github.com/systemd/systemd/commit/3d5f0bfe4e72fdc4d8f8d65f96dc5501dfed8a64

## Checklist
- [x ] I have tested it locally
