### PR TITLE
fix(dracut.sh): use dynamically uefi's sections offset

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -1023,3 +1023,26 @@ get_dev_module() {
     fi
     echo "$dev_drivers"
 }
+
+# Check if file is in PE format
+pe_file_format() {
+    if [[ $# -eq 1 ]]; then
+        local magic
+        magic=$(objdump -p "$1" \
+            | awk '{if ($1 == "Magic"){print strtonum("0x"$2)}}')
+        magic=$(printf "0x%x" "$magic")
+        # 0x10b (PE32), 0x20b (PE32+)
+        [[ $magic == 0x20b || $magic == 0x10b ]] && return 0
+    fi
+    return 1
+}
+
+# Get the sectionAlignment data from the PE header
+pe_get_section_align() {
+    local align_hex
+    [[ $# -ne "1" ]] && return 1
+    [[ $(pe_file_format "$1") -eq 1 ]] && return 1
+    align_hex=$(objdump -p "$1" \
+        | awk '{if ($1 == "SectionAlignment"){print $2}}')
+    echo "$((16#$align_hex))"
+}


### PR DESCRIPTION
* Uefi section are creating by `objcopy` with hardcoded sections offset. This patch allow to have a dynamic set of offsets between each part of the efi file, needed to create an UKI. Offsets are simply calculated so no sections overlap, see https://wiki.archlinux.org/title/Unified_kernel_image#Manually
Moreover, efi stub file's header is parsed to apply the correct offsets according to the section alignment factor. More information here: https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#optional-header-windows-specific-fields-image-only
* Remove EFI_SECTION_VMA_INITRD, no need anymore as initrd section offset dynamically calculated.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2275
