### PR TITLE
Fix handling of `quiet` in loginit

### DIFF
--- a/modules.d/99base/loginit.sh
+++ b/modules.d/99base/loginit.sh
@@ -18,6 +18,6 @@ while read -r line || [ -n "$line" ]; do
     fi
     echo "<31>dracut: $line" >&5
     # if "quiet" is specified we output to /dev/console
-    [ -n "$QUIET" ] || echo "dracut: $line"
+    [ "$QUIET" = "yes" ] || echo "dracut: $line"
     echo "$line" >&6
 done


### PR DESCRIPTION
`dracut-lib.sh` can [set `DRACUT_QUIET=no`](https://github.com/dracutdevs/dracut/blob/e9b477423/modules.d/99base/dracut-lib.sh#L459)
and passes this to `loginit`


This pull request changes...

## Changes
* handling of `quiet` in `loginit`

## Checklist
- [ ] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #