### PR TITLE
fix(systemd-ac-power): correct systemd-ac-power binary path

### DIFF
--- a/modules.d/01systemd-ac-power/module-setup.sh
+++ b/modules.d/01systemd-ac-power/module-setup.sh
@@ -22,7 +22,7 @@ depends() {
 install() {
 
     inst_rules "$moddir/99-initrd-power-targets.rules"
-    inst_simple "$systemdutildir"/systemd-ac-power
+    inst systemd-ac-power
     inst_simple "$moddir/initrd-on-ac-power.target" "$systemdsystemunitdir/initrd-on-ac-power.target"
     inst_simple "$moddir/initrd-on-battery-power.target" "$systemdsystemunitdir/initrd-on-battery-power.target"
 


### PR DESCRIPTION
`systemd-ac-power` has been moved from `/usr/lib/systemd` to `/usr/bin/` since https://github.com/systemd/systemd/commit/251dc2f1

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
