### PR TITLE
fix(dracut.sh): Handle ImageBase for uefi

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -1037,12 +1037,30 @@ pe_file_format() {
     return 1
 }
 
-# Get the sectionAlignment data from the PE header
+# Get specific data from the PE header
+pe_get_header_data() {
+    local data_header
+    [[ $# -ne "2" ]] && return 1
+    [[ $(pe_file_format "$1") -eq 1 ]] && return 1
+    data_header=$(objdump -p "$1" \
+        | awk -v data="$2" '{if ($1 == data){print $2}}')
+    echo "$data_header"
+}
+
+# Get the SectionAlignment data from the PE header
 pe_get_section_align() {
     local align_hex
     [[ $# -ne "1" ]] && return 1
-    [[ $(pe_file_format "$1") -eq 1 ]] && return 1
-    align_hex=$(objdump -p "$1" \
-        | awk '{if ($1 == "SectionAlignment"){print $2}}')
+    align_hex=$(pe_get_header_data "$1" "SectionAlignment")
+    [[ $? -eq 1 ]] && return 1
     echo "$((16#$align_hex))"
+}
+
+# Get the ImageBase data from the PE header
+pe_get_image_base() {
+    local base_image
+    [[ $# -ne "1" ]] && return 1
+    base_image=$(pe_get_header_data "$1" "ImageBase")
+    [[ $? -eq 1 ]] && return 1
+    echo "$((16#$base_image))"
 }

--- a/dracut.sh
+++ b/dracut.sh
@@ -2472,7 +2472,7 @@ if [[ $uefi == yes ]]; then
     fi
     align=$(pe_get_section_align "$uefi_stub")
     if [[ $? -eq 1 ]]; then
-        dfatal "Failed to get the sectionAlignment of the stub PE header to create the UEFI image file"
+        dfatal "Failed to get the SectionAlignment of the stub PE header to create the UEFI image file"
         exit 1
     fi
     offs=$((offs + "$align" - offs % "$align"))
@@ -2509,12 +2509,19 @@ if [[ $uefi == yes ]]; then
     offs=$((offs + "$align" - offs % "$align"))
     uefi_initrd_offs="${offs}"
 
+    base_image=$(pe_get_image_base "$uefi_stub")
+    if [[ $? -eq 1 ]]; then
+        dfatal "Failed to get ImageBase data of $uefi_stub to create UEFI image file"
+        exit 1
+    fi
+
     if objcopy \
         ${uefi_osrelease:+--add-section .osrel="$uefi_osrelease" --change-section-vma .osrel=$(printf 0x%x "$uefi_osrelease_offs")} \
         ${uefi_cmdline:+--add-section .cmdline="$uefi_cmdline" --change-section-vma .cmdline=$(printf 0x%x "$uefi_cmdline_offs")} \
         ${uefi_splash_image:+--add-section .splash="$uefi_splash_image" --change-section-vma .splash=$(printf 0x%x "$uefi_splash_offs")} \
         --add-section .linux="$kernel_image" --change-section-vma .linux="$(printf 0x%x "$uefi_linux_offs")" \
         --add-section .initrd="${DRACUT_TMPDIR}/initramfs.img" --change-section-vma .initrd="$(printf 0x%x "$uefi_initrd_offs")" \
+        --image-base="$(printf 0x%x "$base_image")" \
         "$uefi_stub" "${uefi_outdir}/linux.efi"; then
         if [[ -n ${uefi_secureboot_key} && -n ${uefi_secureboot_cert} ]]; then
             if sbsign \


### PR DESCRIPTION
* UEFI creation didn't handle the ImageBase data for the PE file generation.
Create an UKI thanks a stub file with a non zero ImageBase logs some warning and
generate a bad file offset management:

```bash
objcopy: /var/tmp/dracut.lwbXWb/uefi/linux.efi:.osrel: section below image base
objcopy: /var/tmp/dracut.lwbXWb/uefi/linux.efi:.cmdline: section below image base
objcopy: /var/tmp/dracut.lwbXWb/uefi/linux.efi:.linux: section below image base
objcopy: /var/tmp/dracut.lwbXWb/uefi/linux.efi:.initrd: section below image base
```

* This Patch parse the PE file header, get the data and apply the ImageBase on
the objcopy command. To test, A kind of stub file can be created directly with
the build on systemd project. See  description of dracutdevs#2284.


## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes dracutdevs#2284
