### PR TITLE
fix(debug xtrace): failures with mksh and with rd.live.debug

### DIFF
--- a/modules.d/90crypt/parse-crypt.sh
+++ b/modules.d/90crypt/parse-crypt.sh
@@ -3,7 +3,7 @@
 type crypttab_contains > /dev/null 2>&1 || . /lib/dracut-crypt-lib.sh
 
 _cryptgetargsname() {
-    debug_off
+    set +x
     local _o _found _key
     unset _o
     unset _found

--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -34,6 +34,7 @@ RD_DEBUG=""
 . /lib/dracut-lib.sh
 
 setdebug
+[ "$RD_DEBUG" = "yes" ] && set -x
 
 if ! ismounted /dev; then
     mount -t devtmpfs -o mode=0755,noexec,nosuid,strictatime devtmpfs /dev > /dev/null
@@ -297,7 +298,7 @@ done
 udevadm control --exit
 udevadm info --cleanup-db
 
-debug_off # Turn off debugging for this section
+set +x # Turn off debugging for this section
 
 CAPSH=$(command -v capsh)
 SWITCH_ROOT=$(command -v switch_root)
@@ -342,7 +343,7 @@ if getarg init= > /dev/null; then
     done
     unset CLINE
 else
-    debug_off # Turn off debugging for this section
+    set +x # Turn off debugging for this section
     # shellcheck disable=SC2086
     set -- $CLINE
     for x in "$@"; do
@@ -353,7 +354,7 @@ else
         esac
     done
 fi
-debug_on
+[ "$RD_DEBUG" = "yes" ] && set -x
 
 if ! [ -d "$NEWROOT"/run ]; then
     NEWRUN=/dev/.initramfs

--- a/test/TEST-98-GETARG/test.sh
+++ b/test/TEST-98-GETARG/test.sh
@@ -14,7 +14,8 @@ test_setup() {
     make -C "$basedir" dracut-util
     ln -sfnr "$basedir"/dracut-util "$TESTDIR"/dracut-getarg
     ln -sfnr "$basedir"/dracut-util "$TESTDIR"/dracut-getargs
-    ln -sfnr "$basedir"/modules.d/99base/dracut-lib.sh "$TESTDIR"/dracut-lib.sh
+    cp "$basedir"/modules.d/99base/dracut-lib.sh "$TESTDIR"
+    sed -i -r '/[^\s+]set\s+\+\S*x.*/ s//&; set -x/' "$TESTDIR"/dracut-lib.sh
     ln -sfnr "$basedir"/modules.d/99base/dracut-dev-lib.sh "$TESTDIR"/dracut-dev-lib.sh
     return 0
 }
@@ -88,14 +89,6 @@ test_run() {
 
         . dracut-dev-lib.sh
         . dracut-lib.sh
-
-        debug_off() {
-            :
-        }
-
-        debug_on() {
-            :
-        }
 
         getcmdline() {
             echo "rdbreak=cmdline rd.lvm rd.auto=0 rd.auto rd.retry=10"


### PR DESCRIPTION
Drop _debug_on()_ _debug_off()_ project-wide as setting xtrace is only
local in mksh.  Use `set -x` directly instead. And use the shell's
`local -` feature to automate the restoration of local xtrace
option changes on function returns.

This fixes the bug with `rd.live.debug` where the _debug_on()_ call
in the first _getarg()_ call would fail to restore xtracing because
`RD_DEBUG` was not set. This also allows `rd.live.debug` to be
independent of `rd.debug` and eliminates 18 _debug_off/debug_on_ calls.

This feature is present in bash and dash and not needed in mksh.
In mksh, `local -` (`-` alone) is an alias for `typeset -p` (synonymous
with `declare -p` in bash). Use `local -` with additional arguments to
avoid this alternate behavior in mksh.

This code works with dash since v0.5.2 (2005-09-26) and with bash
since v4.4 (2016-09-15).

Replace the nulling of _debug_on()/debug_off()_ functions in
TEST-98-GETARG by overriding `set +x` in a temporary working copy of
the relevant code to aid in debugging a _getarg()_ failure.

### Checklist
- [✔] I have tested it locally.
- [✔] I have provided new testing code to replace the dropped functions.