### PR TITLE
fix(systemd-networkd): add missing conf files and services

### DIFF
--- a/modules.d/01systemd-networkd/module-setup.sh
+++ b/modules.d/01systemd-networkd/module-setup.sh
@@ -32,6 +32,7 @@ depends() {
 install() {
 
     inst_multiple -o \
+        "$tmpfilesdir"/systemd-network.conf \
         "$dbussystem"/org.freedesktop.network1.conf \
         "$dbussystemservices"/org.freedesktop.network1.service \
         "$systemdutildir"/networkd.conf \
@@ -39,7 +40,9 @@ install() {
         "$systemdutildir"/systemd-networkd \
         "$systemdutildir"/systemd-network-generator \
         "$systemdutildir"/systemd-networkd-wait-online \
+        "$systemdnetwork"/80-6rd-tunnel.network \
         "$systemdnetwork"/80-container-host0.network \
+        "$systemdnetwork"/80-container-vb.network \
         "$systemdnetwork"/80-container-ve.network \
         "$systemdnetwork"/80-container-vz.network \
         "$systemdnetwork"/80-vm-vt.network \
@@ -49,6 +52,7 @@ install() {
         "$systemdsystemunitdir"/systemd-networkd.socket \
         "$systemdsystemunitdir"/systemd-network-generator.service \
         "$systemdsystemunitdir"/systemd-networkd-wait-online.service \
+        "$systemdsystemunitdir"/systemd-networkd-wait-online@.service \
         "$systemdsystemunitdir"/systemd-network-generator.service \
         "$sysusers"/systemd-network.conf \
         networkctl ip
@@ -76,6 +80,8 @@ install() {
             "$systemdsystemconfdir/systemd-network-generator.service/*.conf" \
             "$systemdsystemconfdir"/systemd-networkd-wait-online.service \
             "$systemdsystemconfdir/systemd-networkd-wait-online.service/*.conf" \
+            "$systemdsystemconfdir"/systemd-networkd-wait-online@.service \
+            "$systemdsystemconfdir/systemd-networkd-wait-online@.service.d/*.conf" \
             "$sysusersconfdir"/systemd-network.conf
     fi
 }


### PR DESCRIPTION
This pull request adds missing configuration files and services to the `systemd-networkd` module.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
