### PR TITLE
fix(multipath): enable service but disable socket

### DIFF
--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -137,7 +137,6 @@ install() {
             inst_simple "${moddir}/multipathd-configure.service" "${systemdsystemunitdir}/multipathd-configure.service"
             $SYSTEMCTL -q --root "$initdir" enable multipathd-configure.service
         fi
-        inst_simple "${systemdsystemunitdir}/multipathd.socket"
         inst_simple "${moddir}/multipathd.service" "${systemdsystemunitdir}/multipathd.service"
         $SYSTEMCTL -q --root "$initdir" enable multipathd.service
     else

--- a/modules.d/90multipath/multipathd.service
+++ b/modules.d/90multipath/multipathd.service
@@ -25,4 +25,3 @@ TasksMax=infinity
 
 [Install]
 WantedBy=sysinit.target
-Also=multipathd.socket


### PR DESCRIPTION
## Changes

This fixes a hang in the cleanup hook: running multipath binary triggers activation of `multipathd.service` after it is (and must remain) stopped as dracut prepares to switch root in `initrd-cleanup.service`.

An earlier fix from PR #2010 was based on an old systemd behavior where missing socket will prevent the service from being enabled. This does not seem to be the case anymore. For completeness, I'm disabling the socket alone after enabling service.

At the end of the day we should probably remove `Also=multipathd.socket` from `multipathd.service` and upsteam this change. The whole point of having a socket enabled separately from the service is that systemd can start the service as-needed. Binding enable/disable status together would not be very sane.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2289, #2175
