### PR TITLE
fix(systemd-network-management): fix module dependencies

### DIFF
--- a/modules.d/00systemd-network-management/module-setup.sh
+++ b/modules.d/00systemd-network-management/module-setup.sh
@@ -14,7 +14,7 @@ check() {
 depends() {
 
     # This module has external dependency on other module(s).
-    echo systemd systemd-hostnamed systemd-networkd systemd-resolved systemd-timedated systemd-timesyncd
+    echo dracut-systemd systemd-hostnamed systemd-networkd systemd-resolved systemd-timedated systemd-timesyncd
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 


### PR DESCRIPTION
`dracut -m "systemd-network-management network base"` leads to boot failure. This can be resolved by improving dracut module dependencies.

Fixes #2278
