### PR TITLE
fix(99base): adjust to allow mksh as initrd shell

### DIFF
--- a/modules.d/99base/dracut-dev-lib.sh
+++ b/modules.d/99base/dracut-dev-lib.sh
@@ -17,7 +17,7 @@ str_replace() {
         out="${out}${chop}$r"
         in="${in#*"$s"}"
     done
-    echo "${out}${in}"
+    printf -- '%s' "${out}${in}"
 }
 
 # get a systemd-compatible unit name from a path

--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -299,6 +299,9 @@ udevadm info --cleanup-db
 
 debug_off # Turn off debugging for this section
 
+CAPSH=$(command -v capsh)
+SWITCH_ROOT=$(command -v switch_root)
+
 # unexport some vars
 export_n root rflags fstype netroot NEWROOT
 unset CMDLINE
@@ -368,8 +371,6 @@ info "Switching root"
 
 unset PS4
 
-CAPSH=$(command -v capsh)
-SWITCH_ROOT=$(command -v switch_root)
 PATH=$OLDPATH
 export PATH
 
@@ -378,10 +379,10 @@ if [ -f /etc/capsdrop ]; then
     info "Calling $INIT with capabilities $CAPS_INIT_DROP dropped."
     unset RD_DEBUG
     exec "$CAPSH" --drop="$CAPS_INIT_DROP" -- \
-        -c "exec switch_root \"$NEWROOT\" \"$INIT\" $initargs" \
+        -c "exec \"$SWITCH_ROOT\" \"$NEWROOT\" \"$INIT\" $initargs" \
         || {
             warn "Command:"
-            warn capsh --drop="$CAPS_INIT_DROP" -- -c exec switch_root "$NEWROOT" "$INIT" "$initargs"
+            warn capsh --drop="$CAPS_INIT_DROP" -- -c exec "$SWITCH_ROOT" "$NEWROOT" "$INIT" "$initargs"
             warn "failed."
             emergency_shell
         }


### PR DESCRIPTION
Use printf instead of echo in str_replace() to preserve escapes.
Find command paths while PATH includes `/usr/sbin`. (switch_root was
not found after the original environment is restored on Fedora.)

### Checklist
- [✔] I have tested it locally.