### PR TITLE
perf(dracut.sh): do not call find_mp_fstype twice

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1664,12 +1664,13 @@ if [[ $hostonly ]] && [[ $hostonly_default_device != "no" ]]; then
         [[ -b $_bdev ]] && _dev=$_bdev
         [[ $mp == "/" ]] && root_devs+=("$_dev")
         push_host_devs "$_dev"
-        if [[ $(find_mp_fstype "$mp") == btrfs ]]; then
+        _mp_fstype=$(find_mp_fstype "$mp")
+        if [[ $_mp_fstype == btrfs ]]; then
             for i in $(btrfs_devs "$mp"); do
                 [[ $mp == "/" ]] && root_devs+=("$i")
                 push_host_devs "$i"
             done
-        elif [[ $(find_mp_fstype "$mp") == zfs ]]; then
+        elif [[ $_mp_fstype == zfs ]]; then
             for i in $(zfs_devs "$(findmnt -n -o SOURCE "$mp")"); do
                 [[ $mp == "/" ]] && root_devs+=("$i")
                 push_host_devs "$i"


### PR DESCRIPTION
Instead, save the return value in a temporary variable.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
