### PR TITLE
fix(dmsquash-live): update documentation

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1159,9 +1159,9 @@ device LABEL, and _<uuid>_ is the device UUID.
 * _none_ (the word itself) specifies that no overlay will be used, such as when
 an uncompressed, writable live root filesystem is available.
 +
-If a persistent overlay __is detected__ at the standard LiveOS path, the
-overlay & overlay type detected, whether Device-mapper or OverlayFS, will be
-used.
+If a persistent overlay __is detected__ at the standard LiveOS path,
+and rd.live.overlay.overlayfs is not set to 1, the overlay type (either
+Device-mapper or OverlayFS) will be detected and it will be used.
 --
 +
 [listing]
@@ -1215,9 +1215,6 @@ extended attributes and provides a valid d_type in readdir responses, such as
 with ext4 and xfs.  On non-vfat-formatted devices, a persistent OverlayFS
 overlay can extend the available root filesystem storage up to the capacity of
 the LiveOS disk device.
-+
-If a persistent overlay is detected at the standard LiveOS path, the overlay &
-overlay type detected, whether OverlayFS or Device-mapper, will be used.
 +
 The **rd.live.overlay.readonly** option, which allows a persistent overlayfs to
 be mounted read-only through a higher level transient overlay directory, has


### PR DESCRIPTION
Command line should have preference over image content driven configuration when there is a conflict between the two.

Follow-up to 0e780720efe6488c4e07af39926575ee12f40339 .

## Checklist
- [ ] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes [#2233](https://github.com/dracutdevs/dracut/issues/2232)
