### PR TITLE
fix(memstrack): change memstrack report hook during kdump

### DIFF
--- a/modules.d/99memstrack/memstrack-report.service
+++ b/modules.d/99memstrack/memstrack-report.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Memstrack Report Service
+DefaultDependencies=no
+Before=dracut-cmdline.service systemd-udevd.service local-fs-pre.target
+After=memstrack.service
+IgnoreOnIsolate=true
+ConditionKernelCommandLine=|rd.memdebug=4
+ConditionKernelCommandLine=|rd.memdebug=5
+
+[Service]
+Type=forking
+ExecStart=/bin/memstrack-report
+StandardInput=null
+StandardOutput=journal+console
+StandardError=journal+console

--- a/modules.d/99memstrack/module-setup.sh
+++ b/modules.d/99memstrack/module-setup.sh
@@ -20,9 +20,15 @@ install() {
     inst "/bin/memstrack" "/bin/memstrack"
 
     inst "$moddir/memstrack-start.sh" "/bin/memstrack-start"
-    inst_hook cleanup 99 "$moddir/memstrack-report.sh"
-
     inst "$moddir/memstrack.service" "$systemdsystemunitdir/memstrack.service"
-
     $SYSTEMCTL -q --root "$initdir" add-wants initrd.target memstrack.service
+
+    pid=$$
+    if grep -wq "kdumpbase" <<< $(cat /proc/"$pid"/cmdline | tr '\0' ' '); then
+        inst "$moddir/memstrack-report.sh" "/bin/memstrack-report"
+        inst "$moddir/memstrack-report.service" "$systemdsystemunitdir/memstrack-report.service"
+        $SYSTEMCTL -q --root "$initdir" add-wants initrd.target memstrack-report.service
+    else
+        inst_hook cleanup 99 "$moddir/memstrack-report.sh"
+    fi
 }


### PR DESCRIPTION
Previously memstrack report is attached to the cleanup hook. It is OK if memstrack is enabled for the 1st kernel. However if we want to memstrack the 2nd kernel during kdump process, the cleanup hook may not get triggered before the kdump finishes vmcore dumping and forcing reboot. As a result, the log collected by memstrack analyze service will not be outputted.

For example in fedora, the kdump-capture.service is wanted by initrd.target, same as memstrack.service. After the successful vmcore dumping, it will force reboot by 'reboot -f' by default [1], which will not wait for cleanup hook to finish.

In this patch, we will replace memstrack report cleanup hook with memstrack-report.service in kdump case, and make it wanted by initrd.target. So memstrack report will be triggered earlier.

[1]: https://src.fedoraproject.org/rpms/kexec-tools/blob/rawhide/f/dracut-kdump.sh#_29

This pull request changes...

## Changes

## Checklist
- [Y] I have tested it locally
- [Y] I have reviewed and updated any documentation if relevant
- [N] I am providing new code and test(s) for it

Fixes #
