### PR TITLE
fix(memstrack): change memstrack startup hook

### DIFF
--- a/modules.d/99memstrack/memstrack-report.sh
+++ b/modules.d/99memstrack/memstrack-report.sh
@@ -14,4 +14,10 @@ else
     done
 fi
 
-cat /.memstrack
+if ! [ -e /proc/vmcore ]; then
+    if [ -e /.memstrack ]; then
+        IFS= vwarn < /.memstrack
+    else
+        warn 'No memstrack log generated!'
+   fi
+fi


### PR DESCRIPTION
Previously memstrack start is wanted by initrd.target, which is a pretty late stage in bootup. To have a good memory allocation record and a good analysis report, memstrack should start as early and finish as late as possible.

This patch mainly has 2 modifications:

1) We will start memstrack at the cmdline hook of dracut, and end memstrack
   at the cleanup hook. So the memstrack.service file is no longer needed.

2) If memstrack works in 1st kernel, we will use vwarn instead of cat to
   output the content of /.memstrack, becasue it is a wrapper of stderr,
   and more stable to have outputs in console.

   If memstrack works in 2nd kernel, aka in kdump case, we will not print
   /.memstrack here, the output will be handled in kexec-tools side [1].
   The reason is, for example in fedora, after vmcore dumping, kdump will
   use 'reboot -f' by default, which leaves no stable target to print
   /.memstrack. So the output is better handled in kexec-tools side.

[1]: https://lists.fedoraproject.org/archives/list/kexec@lists.fedoraproject.org/thread/YXSXU2A25QGHZHUMG3WH6H7ARH2L7NWS/

This pull request changes...

## Changes

## Checklist
- [Y] I have tested it locally
- [Y] I have reviewed and updated any documentation if relevant
- [N] I am providing new code and test(s) for it

Fixes #
