### PR TITLE
fix(btrfs): add missing cmdline function

### DIFF
--- a/modules.d/90btrfs/module-setup.sh
+++ b/modules.d/90btrfs/module-setup.sh
@@ -23,6 +23,13 @@ depends() {
 }
 
 # called by dracut
+cmdline() {
+    # Hack for slow machines
+    # see https://github.com/dracutdevs/dracut/issues/658
+    printf " rd.driver.pre=btrfs"
+}
+
+# called by dracut
 installkernel() {
     instmods btrfs
 }
@@ -49,7 +56,6 @@ install() {
 
     inst_multiple -o btrfsck btrfs-zero-log
     inst "$(command -v btrfs)" /sbin/btrfs
-    # Hack for slow machines
-    # see https://github.com/dracutdevs/dracut/issues/658
-    echo "rd.driver.pre=btrfs" > "${initdir}"/etc/cmdline.d/00-btrfs.conf
+
+    printf "%s\n" "$(cmdline)" > "${initdir}/etc/cmdline.d/00-btrfs.conf"
 }


### PR DESCRIPTION
Otherwise `dracut --print-cmdline` does not print the command line option added by the btrfs module.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it