### PR TITLE
fix(base): add missing cmdline function

### DIFF
--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -272,7 +272,7 @@ source_hook cleanup
 
 # By the time we get here, the root filesystem should be mounted.
 # Try to find init.
-for i in "$(getarg real_init=)" "$(getarg init=)" $(getargs rd.distroinit=) /sbin/init; do
+for i in "$(getarg real_init=)" "$(getarg init=)" /sbin/init; do
     [ -n "$i" ] || continue
 
     __p="${NEWROOT}/${i}"

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -58,12 +58,6 @@ install() {
         inst_hook cmdline 10 "$moddir/parse-root-opts.sh"
     fi
 
-    if [[ $realinitpath ]]; then
-        for i in $realinitpath; do
-            echo "rd.distroinit=$i"
-        done > "${initdir}/etc/cmdline.d/distroinit.conf"
-    fi
-
     ln -fs /proc/self/mounts "$initdir/etc/mtab"
     if [[ $ro_mnt == yes ]]; then
         echo ro >> "${initdir}/etc/cmdline.d/base.conf"

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -12,6 +12,13 @@ depends() {
 }
 
 # called by dracut
+cmdline() {
+    if [[ $ro_mnt == yes ]]; then
+        printf " ro"
+    fi
+}
+
+# called by dracut
 install() {
     inst_multiple mount mknod mkdir sleep chown \
         sed ls flock cp mv dmesg rm ln rmmod mkfifo umount readlink setsid \
@@ -59,9 +66,10 @@ install() {
     fi
 
     ln -fs /proc/self/mounts "$initdir/etc/mtab"
-    if [[ $ro_mnt == yes ]]; then
-        echo ro >> "${initdir}/etc/cmdline.d/base.conf"
-    fi
+
+    local _baseconf
+    _baseconf=$(cmdline)
+    [[ $_baseconf ]] && printf "%s\n" "$_baseconf" > "${initdir}/etc/cmdline.d/99base.conf"
 
     [ -e "${initdir}/usr/lib" ] || mkdir -m 0755 -p "${initdir}"/usr/lib
 


### PR DESCRIPTION
Otherwise `dracut --print-cmdline` does not print the command line option added by the base module.

Also, remove the undocumented `realinitpath` configuration option (which was also writing the `rd.distroinit` command line option):
- Added in February 2012: https://github.com/dracutdevs/dracut/commit/4951a1199d5404b380e4beaf602e67744f82c8d1
- Not needed since March 2013 (systemd v198): https://github.com/dracutdevs/dracut/commit/348baca3e401f2526b0f936cb172874f4bbe9dcd

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
