### PR TITLE
fix(url-lib): remove junk before path to ca-bundle

### DIFF
--- a/modules.d/45url-lib/module-setup.sh
+++ b/modules.d/45url-lib/module-setup.sh
@@ -34,7 +34,9 @@ install() {
             if ! [[ $_nssckbi ]]; then
                 read -r -d '' _nssckbi < <(grep -F --binary-files=text -z libnssckbi "$_lib")
             fi
-            read -r -d '' _crt < <(grep -E --binary-files=text -z "\.(pem|crt)" "$_lib" | sed 's/\x0//g')
+            # Last sed expression removes all symbols before first '/' to clean up junk (https://askubuntu.com/a/438393)
+            # Junk may contain a line break
+            read -r -d '' _crt < <(grep -E --binary-files=text -z "\.(pem|crt)" "$_lib" | sed -e 's/\x0//g' -e 's,^[^/]*/,/,' | grep '^/' | head -n1)
             [[ $_crt ]] || continue
             [[ $_crt == /*/* ]] || continue
             if [[ -e $_crt ]]; then


### PR DESCRIPTION
grep -F --binary-files=text -z .crt extracts junk before the path to the ca-bundle from /usr/lib64/libcurl.so.4 from RPM lib64curl4-7.86.0-1.x86_64 on ROSA Linux rosa2021.1.

Such a path is invalid, remove all junk before first slash (/) to make the path be valid.

libcurl.so.4: https://file-store.rosalinux.ru/download/ff55031fdd35038563dbc09f65040e7dbc9026fb
dracut log: https://file-store.rosalinux.ru/download/560b42b8f3b0819194a53c984d94fd9df773fbdc
