### PR TITLE
fix(watchdog-modules): add missing cmdline function

### DIFF
--- a/modules.d/04watchdog-modules/module-setup.sh
+++ b/modules.d/04watchdog-modules/module-setup.sh
@@ -10,32 +10,48 @@ depends() {
     return 0
 }
 
-# called by dracut
-install() {
-    return 0
-}
-
-installkernel() {
-    local -A _drivers
-    local _wdtdrv
+get_watchdog_drivers() {
+    local _wd _wdtdrv
 
     for _wd in /sys/class/watchdog/*; do
         ! [ -e "$_wd" ] && continue
         _wdtdrv=$(get_dev_module "$_wd")
         if [[ $_wdtdrv ]]; then
-            instmods "$_wdtdrv"
-            for i in $_wdtdrv; do
-                _drivers[$i]=1
-            done
+            echo "$_wdtdrv"
         fi
     done
+}
 
-    # ensure that watchdog module is loaded as early as possible
-    if [[ ${!_drivers[*]} ]]; then
-        echo "rd.driver.pre=\"$(
-            IFS=,
-            echo "${!_drivers[*]}"
-        )\"" > "${initdir}"/etc/cmdline.d/00-watchdog.conf
+# called by dracut
+cmdline() {
+    local -a _drivers
+    local _drivers_joined
+
+    if [[ $# -gt 0 ]]; then
+        printf -v _drivers_joined '%s,' "$@"
+    else
+        mapfile -t _drivers < <(get_watchdog_drivers)
+        if ((${#_drivers[@]})); then
+            printf -v _drivers_joined '%s,' "${_drivers[@]}"
+        fi
     fi
+    [[ $_drivers_joined ]] && printf ' rd.driver.pre="%s"' "${_drivers_joined%,}"
+}
+
+# called by dracut
+installkernel() {
+    local -a _drivers
+    local _wdconf
+
+    mapfile -t _drivers < <(get_watchdog_drivers)
+    if ((${#_drivers[@]})); then
+        instmods "${_drivers[@]}"
+        # shellcheck disable=SC2068
+        _wdconf=$(cmdline ${_drivers[@]})
+        if [[ $_wdconf ]]; then
+            printf "%s\n" "$_wdconf" > "${initdir}/etc/cmdline.d/00-watchdog.conf"
+        fi
+    fi
+
     return 0
 }


### PR DESCRIPTION
Otherwise `dracut --print-cmdline` does not print the command line option added by the `watchdog-modules` module.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it