### PR TITLE
RFC: perf(base): do not unconditionally process cmdline with each `getcmdline` call

### DIFF
--- a/modules.d/35connman/cm-config.sh
+++ b/modules.d/35connman/cm-config.sh
@@ -4,6 +4,7 @@ type cm_generate_connections > /dev/null 2>&1 || . /lib/cm-lib.sh
 
 if [ -n "$netroot" ] || [ -e /tmp/net.ifaces ]; then
     echo rd.neednet >> /etc/cmdline.d/connman.conf
+    setcmdline
 fi
 
 if getargbool 0 rd.debug -d -y rdinitdebug -d -y rdnetdebug; then

--- a/modules.d/35connman/cm-lib.sh
+++ b/modules.d/35connman/cm-lib.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-type getcmdline > /dev/null 2>&1 || . /lib/dracut-lib.sh
+type getargbool > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 cm_generate_connections() {
     if getargbool 0 rd.neednet; then

--- a/modules.d/35network-legacy/parse-ip-opts.sh
+++ b/modules.d/35network-legacy/parse-ip-opts.sh
@@ -43,6 +43,7 @@ BOOTDEV=$(getarg bootdev=)
 if [ -n "$NEEDBOOTDEV" ] && getargbool 1 rd.neednet; then
     #[ -z "$BOOTDEV" ] && warn "Please supply bootdev argument for multiple ip= lines"
     echo "rd.neednet=1" > /etc/cmdline.d/dracut-neednet.conf
+    setcmdline
     info "Multiple ip= arguments: assuming rd.neednet=1"
 else
     unset NEEDBOOTDEV
@@ -131,6 +132,7 @@ for p in $(getargs ip=); do
             "$(expr substr "$dev" 11 2)" \
             "$(expr substr "$dev" 13 2)" \
             >> /etc/cmdline.d/80-enx.conf
+        setcmdline
     fi
 done
 

--- a/modules.d/35network-manager/nm-config.sh
+++ b/modules.d/35network-manager/nm-config.sh
@@ -4,6 +4,7 @@ type nm_generate_connections > /dev/null 2>&1 || . /lib/nm-lib.sh
 
 if [ -n "$netroot" ] || [ -e /tmp/net.ifaces ]; then
     echo rd.neednet >> /etc/cmdline.d/35-neednet.conf
+    setcmdline
 fi
 
 if getargbool 0 rd.debug -d -y rdinitdebug -d -y rdnetdebug; then

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -237,6 +237,7 @@ set_ifname() {
         break
     done
     echo "ifname=$name$num:$mac" >> /etc/cmdline.d/45-ifname.conf
+    setcmdline
     echo "$num" > "/tmp/set_ifname_$name"
     echo "$name$num"
 }
@@ -356,6 +357,7 @@ ibft_to_cmdline() {
 
         done
     ) >> /etc/cmdline.d/40-ibft.conf
+    setcmdline
 }
 
 parse_iscsi_root() {

--- a/modules.d/80cms/cmsifup.sh
+++ b/modules.d/80cms/cmsifup.sh
@@ -29,6 +29,7 @@ fi
         echo "nameserver=$i"
     done
 } > /etc/cmdline.d/80-cms.conf
+setcmdline
 
 [ -e "/tmp/net.ifaces" ] && read -r IFACES < /tmp/net.ifaces
 IFACES="$IFACES $DEVICE"

--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -90,8 +90,8 @@ det_img_fs() {
 }
 
 load_fstype squashfs
-CMDLINE=$(getcmdline)
-for arg in $CMDLINE; do
+cmdline=$(getcmdline)
+for arg in $cmdline; do
     case $arg in
         ro | rw) liverw=$arg ;;
     esac
@@ -405,6 +405,7 @@ ROOTFLAGS="$(getarg rootflags)"
 
 if [ "$overlayfs" = required ]; then
     echo "rd.live.overlay.overlayfs=1" > /etc/cmdline.d/dmsquash-need-overlay.conf
+    setcmdline
 fi
 
 if [ -n "$overlayfs" ]; then

--- a/modules.d/91zipl/install_zipl_cmdline.sh
+++ b/modules.d/91zipl/install_zipl_cmdline.sh
@@ -19,6 +19,7 @@ fi
 
 if [ -f ${MNT}/dracut-cmdline.conf ]; then
     cp ${MNT}/dracut-cmdline.conf /etc/cmdline.d/99zipl.conf
+    setcmdline
 fi
 
 if [ -f ${MNT}/active_devices.txt ]; then

--- a/modules.d/95fcoe-uefi/parse-uefifcoe.sh
+++ b/modules.d/95fcoe-uefi/parse-uefifcoe.sh
@@ -29,5 +29,7 @@ print_fcoe_uefi_conf() {
 
 for i in /sys/firmware/efi/efivars/FcoeBootDevice-*; do
     [ -e "$i" ] || continue
-    print_fcoe_uefi_conf "$i" > /etc/cmdline.d/40-fcoe-uefi.conf && break
+    print_fcoe_uefi_conf "$i" > /etc/cmdline.d/40-fcoe-uefi.conf \
+        && setcmdline \
+        && break
 done

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -104,6 +104,7 @@ done
 
 if [ -e /tmp/nvmf_needs_network ]; then
     echo "rd.neednet=1" > /etc/cmdline.d/nvmf-neednet.conf
+    setcmdline
     rm -f /tmp/nvmf_needs_network
 fi
 

--- a/modules.d/98dracut-systemd/dracut-cmdline-ask.sh
+++ b/modules.d/98dracut-systemd/dracut-cmdline-ask.sh
@@ -18,5 +18,6 @@ while read -r -p "> " ${BASH:+-e} line || [ -n "$line" ]; do
     [ "$line" = "." ] && break
     [ -n "$line" ] && printf -- "%s\n" "$line" >> /etc/cmdline.d/99-cmdline-ask.conf
 done
+setcmdline
 
 exit 0

--- a/modules.d/98dracut-systemd/dracut-cmdline.sh
+++ b/modules.d/98dracut-systemd/dracut-cmdline.sh
@@ -12,7 +12,9 @@ if ! getargbool 1 'rd.hostonly'; then
     [ -f /etc/cmdline.d/99-cmdline-ask.conf ] && mv /etc/cmdline.d/99-cmdline-ask.conf /tmp/99-cmdline-ask.conf
     remove_hostonly_files
     systemctl --no-block daemon-reload
-    [ -f /tmp/99-cmdline-ask.conf ] && mv /tmp/99-cmdline-ask.conf /etc/cmdline.d/99-cmdline-ask.conf
+    [ -f /tmp/99-cmdline-ask.conf ] \
+        && mv /tmp/99-cmdline-ask.conf /etc/cmdline.d/99-cmdline-ask.conf \
+        && setcmdline
 fi
 
 info "Using kernel command line parameters:" "$(getcmdline)"

--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -113,12 +113,15 @@ if getarg "rd.cmdline=ask"; then
         [ "$line" = "." ] && break
         echo "$line" >> /etc/cmdline.d/99-cmdline-ask.conf
     done
+    setcmdline
 fi
 
 if ! getargbool 1 'rd.hostonly'; then
     [ -f /etc/cmdline.d/99-cmdline-ask.conf ] && mv /etc/cmdline.d/99-cmdline-ask.conf /tmp/99-cmdline-ask.conf
     remove_hostonly_files
-    [ -f /tmp/99-cmdline-ask.conf ] && mv /tmp/99-cmdline-ask.conf /etc/cmdline.d/99-cmdline-ask.conf
+    [ -f /tmp/99-cmdline-ask.conf ] \
+        && mv /tmp/99-cmdline-ask.conf /etc/cmdline.d/99-cmdline-ask.conf \
+        && setcmdline
 fi
 
 # run scriptlets to parse the command line

--- a/modules.d/99fs-lib/fs-lib.sh
+++ b/modules.d/99fs-lib/fs-lib.sh
@@ -212,6 +212,7 @@ write_fs_tab() {
     local _rootfstype
     local _rootflags
     local _fspassno
+    local _cmdline
 
     _fspassno="0"
     _root="$1"
@@ -230,8 +231,8 @@ write_fs_tab() {
 
     _rw=0
 
-    CMDLINE=$(getcmdline)
-    for _o in $CMDLINE; do
+    _cmdline=$(getcmdline)
+    for _o in $_cmdline; do
         case $_o in
             rw)
                 _rw=1

--- a/test/TEST-98-GETARG/test.sh
+++ b/test/TEST-98-GETARG/test.sh
@@ -97,25 +97,19 @@ test_run() {
             :
         }
 
-        getcmdline() {
-            echo "rdbreak=cmdline rd.lvm rd.auto=0 rd.auto rd.retry=10"
-        }
+        export CMDLINE="rdbreak=cmdline rd.lvm rd.auto=0 rd.auto rd.retry=10"
         RDRETRY=$(getarg rd.retry -d 'rd_retry=')
         [[ $RDRETRY == "10" ]] || ret=$((ret + 1))
         getarg rd.break=cmdline -d rdbreak=cmdline || ret=$((ret + 1))
         getargbool 1 rd.lvm -d -n rd_NO_LVM || ret=$((ret + 1))
         getargbool 0 rd.auto || ret=$((ret + 1))
 
-        getcmdline() {
-            echo "rd.break=cmdlined rd.lvm=0 rd.auto rd.auto=1 rd.auto=0"
-        }
+        export CMDLINE="rd.break=cmdlined rd.lvm=0 rd.auto rd.auto=1 rd.auto=0"
         getarg rd.break=cmdline -d rdbreak=cmdline && ret=$((ret + 1))
         getargbool 1 rd.lvm -d -n rd_NO_LVM && ret=$((ret + 1))
         getargbool 0 rd.auto && ret=$((ret + 1))
 
-        getcmdline() {
-            echo "ip=a ip=b ip=dhcp6"
-        }
+        export CMDLINE="ip=a ip=b ip=dhcp6"
         getargs "ip=dhcp6" &> /dev/null || ret=$((ret + 1))
         readarray -t args < <(getargs "ip=")
         RESULT=("a" "b" "dhcp6")
@@ -124,9 +118,7 @@ test_run() {
             [[ ${args[$i]} == "${RESULT[$i]}" ]] || ret=$((ret + 1))
         done
 
-        getcmdline() {
-            echo "bridge bridge=val"
-        }
+        export CMDLINE="bridge bridge=val"
         readarray -t args < <(getargs bridge=)
         RESULT=("bridge" "val")
         ((${#RESULT[@]} == ${#args[@]})) || ret=$((ret + 1))
@@ -134,9 +126,7 @@ test_run() {
             [[ ${args[$i]} == "${RESULT[$i]}" ]] || ret=$((ret + 1))
         done
 
-        getcmdline() {
-            echo "rd.break rd.md.uuid=bf96e457:230c9ad4:1f3e59d6:745cf942 rd.md.uuid=bf96e457:230c9ad4:1f3e59d6:745cf943 rd.shell"
-        }
+        export CMDLINE="rd.break rd.md.uuid=bf96e457:230c9ad4:1f3e59d6:745cf942 rd.md.uuid=bf96e457:230c9ad4:1f3e59d6:745cf943 rd.shell"
         readarray -t args < <(getargs rd.md.uuid -d rd_MD_UUID=)
         RESULT=("bf96e457:230c9ad4:1f3e59d6:745cf942" "bf96e457:230c9ad4:1f3e59d6:745cf943")
         ((${#RESULT[@]} == ${#args[@]})) || ret=$((ret + 1))


### PR DESCRIPTION
At boot, every time a script calls a `getarg` function, the `getcmdline` function is called, which parses /etc/cmdline, /etc/cmdline.d/*.conf and /proc/cmdline.

Although a call only takes a few ns, this is quite inefficient due to the large number of times a `getarg` function is called. Only to show this number, I added a warning every time `getcmdline` is called in two vms, one with a minimal setup and other using the NetworkManager to get internet connection at boot (in both cases the content returned by `getcmdline` is always the same, i.e., no hook script is adding new content at boot). These are the results:

```
localhost:/home/dev # journalctl -b | grep -c getcmdline
43
nm:/home/dev # journalctl -b | grep -c getcmdline
67
```

This patch adds a new function `setcmdline`, which parses command line options, exports the `CMDLINE` variable (required by `dracut-util`), and persists its content in a temporary file, so that different processes can access it (e.g. systemd generators).

With this change, if a hook script adds new content in /etc/cmdline.d at boot, it must explicitly call `setcmdline` to update the content of the `CMDLINE` variable.

Let's compare the performance when calling 67 times the old version and the new one (with the new version, `setcmdline` is called only once, no cmdline changes at boot):

```
sh-5.2# hyperfine -S'bash --norc' '. /lib/dracut-lib.sh ; for ((i=1;i<=67;i++)); do getcmdline_v0; done' '. /lib/dracut-lib.sh ; for ((i=1;i<=67;i++)); do getcmdline_v1; done'
Benchmark 1: . /lib/dracut-lib.sh ; for ((i=1;i<=67;i++)); do getcmdline_v0; done
  Time (mean ± σ):       4.7 ms ±   0.6 ms    [User: 3.9 ms, System: 1.1 ms]
  Range (min … max):     4.3 ms …  11.6 ms    380 runs

  Warning: Command took less than 5 ms to complete. Note that the results might be inaccurate because hyperfine can not calibrate the shell startup time much more precise than this limit. You can try to use the `-N`/`--shell=none` option to disable the shell completely.
  Warning: The first benchmarking run for this command was significantly slower than the rest (6.6 ms). This could be caused by (filesystem) caches that were not filled until after the first run. You should consider using the '--warmup' option to fill those caches before the actual benchmark. Alternatively, use the '--prepare' option to clear the caches before each timing run.

Benchmark 2: . /lib/dracut-lib.sh ; for ((i=1;i<=67;i++)); do getcmdline_v1; done
  Time (mean ± σ):       1.1 ms ±   0.3 ms    [User: 1.2 ms, System: 0.2 ms]
  Range (min … max):     0.8 ms …   2.4 ms    991 runs

  Warning: Command took less than 5 ms to complete. Note that the results might be inaccurate because hyperfine can not calibrate the shell startup time much more precise than this limit. You can try to use the `-N`/`--shell=none` option to disable the shell completely.
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Summary
  '. /lib/dracut-lib.sh ; for ((i=1;i<=67;i++)); do getcmdline_v1; done' ran
    4.44 ± 1.29 times faster than '. /lib/dracut-lib.sh ; for ((i=1;i<=67;i++)); do getcmdline_v0; done'
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
