### PR TITLE
perf(dracut-init.sh): optimize inst_rule_initqueue function

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -507,6 +507,7 @@ inst_rule_group_owner() {
 }
 
 inst_rule_initqueue() {
+    [[ -e "$initdir/lib/dracut/need-initqueue" ]] && return
     if grep -q -F initqueue "$1"; then
         dracut_need_initqueue
     fi


### PR DESCRIPTION
There is no need to grep inside each rule if the `/lib/dracut/need-initqueue` flag is already set.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
