### PR TITLE
RFC: perf(dracut): do not unconditionally call check_mount for each module

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -926,8 +926,6 @@ check_mount() {
     local _moddep
 
     [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
-    # shellcheck disable=SC2154
-    [ "${#host_fs_types[@]}" -le 0 ] && return 1
 
     # If we are already scheduled to be loaded, no need to check again.
     [[ " $mods_to_load " == *\ $_mod\ * ]] && return 0

--- a/dracut.sh
+++ b/dracut.sh
@@ -1794,7 +1794,9 @@ mods_to_load=""
 # check all our modules to see if they should be sourced.
 # This builds a list of modules that we will install next.
 for_each_module_dir check_module
-for_each_module_dir check_mount
+if ! [[ $hostonly ]] && ((${#host_fs_types[@]})); then
+    for_each_module_dir check_mount
+fi
 
 dracut_module_included "fips" && export DRACUT_FIPS_MODE=1
 

--- a/modules.d/90qemu-net/module-setup.sh
+++ b/modules.d/90qemu-net/module-setup.sh
@@ -6,11 +6,6 @@ check() {
         return 255
     fi
 
-    if [[ $mount_needs ]]; then
-        is_qemu_virtualized && return 0
-        return 255
-    fi
-
     return 0
 }
 


### PR DESCRIPTION
Currently, dracut calls `check_module` and `check_mount` for each dracut module. Both functions call the `check()` method of each module, but `check_mount` also sets `mount_needs=1` before the call.

This patch includes two simple performance improvements:

- Instead of checking if `host_fs_types` is empty on the `check_mount` function for each module, do not start the iteration `for_each_module_dir` if `host_fs_types` is empty.

- Do not call `check_mount` in hostonly mode. After analyzing the `check()` methods of all modules, we can find three different usages when the `mount_needs` variable is set:
  - `[[ "$mount_needs" ]] && return 1` => do not include the module with the `check_mount` call. In this case, if the module is included it is thanks to the `check_module` call.
  - `[[ $hostonly ]] || [[ $mount_needs ]] && { ... }` => run the same specific check to include the module when building a hostonly initrd or with the `check_mount` call. So, in this case, in hostonly mode `check_module` and `check_mount` perform the same action.
  - A different check for `$hostonly` and `$mount_needs`. This case is specific to the `qemu-net` module. In hostonly mode, it can only be added as a dependency by the `network` module. But in non-hostonly mode, it's always included, making the `$mount_needs` check useless.

Furthermore, this change does not break any 3rd-party modules under my radar.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
