### PR TITLE
fix(dracut-init.sh): correct check in `is_qemu_virtualized` function

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -1190,7 +1190,7 @@ is_qemu_virtualized() {
     # 1 if a virt environment could not be detected
     # 255 if any error was encountered
     if type -P systemd-detect-virt > /dev/null 2>&1; then
-        if ! vm=$(systemd-detect-virt --vm > /dev/null 2>&1); then
+        if ! vm=$(systemd-detect-virt --vm 2> /dev/null); then
             return 255
         fi
         [[ $vm == "qemu" ]] && return 0


### PR DESCRIPTION
Do not redirect `systemd-detect-virt` to /dev/null, otherwise, the `vm` variable is always empty. This function was working only thanks to the following /sys check.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
