### PR TITLE
fix(dracut-functions): avoid calling grep with PCRE (-P)

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -244,7 +244,7 @@ get_maj_min() {
     local _out
 
     if [[ $get_maj_min_cache_file ]]; then
-        _out="$(grep -m1 -oP "^$1 \K\S+$" "$get_maj_min_cache_file")"
+        _out="$(grep -m1 -oE "^$1 \S+$" "$get_maj_min_cache_file" | awk '{print $NF}')"
     fi
 
     if ! [[ "$_out" ]]; then


### PR DESCRIPTION
Invoking grep in Perl mode requires JIT'ing the Perl regex. This can run into issues with SELinix policy which will generally try to limit use of execmem in general purpose scripts/tools. This occurs since the JIT'd code will live in executable memory.

The PCRE only '\K' command in the Perl REGEX can be replaced by a call to awk instead.

## Changes
- Swap the use of `\K` Perl regex to a separate call to `awk` when doing device cache lookups to avoid using executable memory in grep which can generate SELinux permission errors.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2323
