### PR TITLE
ci: add gawk and more test dependencies to Debian container

### DIFF
--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -3,7 +3,10 @@ FROM docker.io/debian:latest
 MAINTAINER https://github.com/dracutdevs/dracut
 
 # Install needed packages for the dracut CI container
-RUN apt-get update -y -qq && apt-get upgrade -y -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
+# Install dracut as a linux-initramfs-tool provider so that the default initramfs-tool package does not get installed
+# Uninstall initramfs-tools-core as a workaround for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=994492
+RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --no-install-recommends dracut && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
     asciidoc \
     astyle \
     btrfs-progs \
@@ -17,11 +20,13 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && DEBIAN_FRONTEND=nonintera
     dash \
     debhelper \
     debhelper-compat \
+    dmraid \
     docbook \
     docbook-xml \
     docbook-xsl \
     fdisk \
     g++ \
+    gawk \
     git \
     iputils-arping \
     iputils-ping \
@@ -37,6 +42,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && DEBIAN_FRONTEND=nonintera
     mdadm \
     multipath-tools \
     nbd-client \
+    nbd-server \
     network-manager \
     nfs-kernel-server \
     ntfs-3g \
@@ -52,15 +58,8 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && DEBIAN_FRONTEND=nonintera
     strace \
     sudo \
     tcpdump \
+    tgt \
     thin-provisioning-tools \
     vim \
     wget \
-    && apt-get clean
-
-# workaround for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=962300
-RUN DEBIAN_FRONTEND=noninteractive apt-get download dmraid \
-    && DEBIAN_FRONTEND=noninteractive dpkg --unpack dmraid*.deb \
-    && rm -rf /var/lib/dpkg/info/dmraid.postinst -f \
-    && DEBIAN_FRONTEND=noninteractive dpkg --configure dmraid \
-    && apt-get install -yf \
-    && apt-get clean
+    && apt-get clean && dpkg -P --force-depends dracut dracut-core initramfs-tools-core


### PR DESCRIPTION
Allow more test coverage for manual test runs.

- tgt is needed for test 30 and 35
- nbd-server is needed for test 40
- gawk dependency has been introduced by https://github.com/dracutdevs/dracut/commit/f32e95bcadbc5158843530407adc1e7b700561b1
- install dracut instead of avoid installation of initramfs-tools to match actual dracut usage environment for testing
- remove workaround for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=962300 as it is now fixed on Debian 12.

No additional test will run as part of CI, this PR only impacts test container generation.