### PR TITLE
fix(dracut-lib): use poweroff instead of halt

### DIFF
--- a/modules.d/98dracut-systemd/dracut-emergency.sh
+++ b/modules.d/98dracut-systemd/dracut-emergency.sh
@@ -39,7 +39,7 @@ else
     export hook="shutdown-emergency"
     warn "$action has failed. To debug this issue add \"rd.shell rd.debug\" to the kernel command line."
     source_hook "$hook"
-    [ -z "$_emergency_action" ] && _emergency_action=halt
+    [ -z "$_emergency_action" ] && _emergency_action=poweroff
 fi
 
 /bin/rm -f -- /.console_lock

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -447,7 +447,7 @@ die() {
     fi
 
     if [ -n "$DRACUT_SYSTEMD" ]; then
-        systemctl --no-block --force halt
+        systemctl --no-block --force poweroff
     fi
 
     exit 1
@@ -969,14 +969,14 @@ emergency_shell() {
     _emergency_action=$(getarg rd.emergency)
     [ -z "$_emergency_action" ] \
         && [ -e /run/initramfs/.die ] \
-        && _emergency_action=halt
+        && _emergency_action=poweroff
 
     if getargbool 1 rd.shell -d -y rdshell || getarg rd.break -d rdbreak; then
         _emergency_shell "$_rdshell_name"
     else
         source_hook "$hook"
         warn "$action has failed. To debug this issue add \"rd.shell rd.debug\" to the kernel command line."
-        [ -z "$_emergency_action" ] && _emergency_action=halt
+        [ -z "$_emergency_action" ] && _emergency_action=poweroff
     fi
 
     case "$_emergency_action" in


### PR DESCRIPTION
Using halt will keep the HW still powered on. This can be confusing for users. The screen is blank, but for example, the fan is still running, and they have no idea what is going on. So let's call poweroff.

