### PR TITLE
fix(dracut-lib.sh): remove successful finished initqueue scripts

### DIFF
--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -410,13 +410,17 @@ source_hook() {
 }
 
 check_finished() {
-    local f
+    local f rc=0
     for f in "$hookdir"/initqueue/finished/*.sh; do
         [ "$f" = "$hookdir/initqueue/finished/*.sh" ] && return 0
         # shellcheck disable=SC1090
-        { [ -e "$f" ] && (. "$f"); } || return 1
+        if [ -e "$f" ] && (. "$f"); then
+            rm -f "$f"
+        else
+            rc=1
+        fi
     done
-    return 0
+    return $rc
 }
 
 source_conf() {


### PR DESCRIPTION
## Changes

If some "finished" initscripts keep failing, dracut will start printing warnings after a while. But it will warn about all scripts in the finished initqueue, not only those that have failed. That makes it difficult to identify the script that has actually caused the failure.

Example: Here, all but the last script `net.nbft1.did-setup` had actually succeeded.
```
Apr 21 19:38:18 localhost dracut-initqueue[1515]: Warning: dracut-initqueue: timeout, still waiting for following initqueue hooks:
Apr 21 19:38:18 localhost dracut-initqueue[1515]: Warning: /lib/dracut/hooks/initqueue/finished/devexists-\x2fdev\x2fdisk\x2fby-uuid\x2f2EBB-2E90.sh: "[ -e "/dev/disk/by-uuid/2EBB-2E90" ]"
Apr 21 19:38:18 localhost dracut-initqueue[1515]: Warning: /lib/dracut/hooks/initqueue/finished/devexists-\x2fdev\x2fdisk\x2fby-uuid\x2f393ee7b7-d819-49a5-8a78-c44d264cc0c8.sh: "if ! grep -q After=remote-fs-pre.target /run/systemd/generator/systemd-cryptsetup@*.service 2>/dev/null; then
Apr 21 19:38:18 localhost dracut-initqueue[1515]:     [ -e "/dev/disk/by-uuid/393ee7b7-d819-49a5-8a78-c44d264cc0c8" ]
Apr 21 19:38:18 localhost dracut-initqueue[1515]: fi"
Apr 21 19:38:18 localhost dracut-initqueue[1515]: Warning: /lib/dracut/hooks/initqueue/finished/wait-nbft0.sh: "[ -f /tmp/net.nbft0.did-setup ]"
Apr 21 19:38:18 localhost dracut-initqueue[1515]: Warning: /lib/dracut/hooks/initqueue/finished/wait-nbft1.sh: "[ -f /tmp/net.nbft1.did-setup ]"
```

To avoid this, delete finished initqueue scripts when they succeed. Also, instead of returning as soon as one of the scripts fails, try all scripts, deleting those that succeed, and return failure if at least one script failed.

If a previously deleted script is recreated by some other part of the code, it will be re-run the next time the check_finished() function is called, and will be re-deleted if it still succeeds.

The only case where I see that this might cause issues is if some condition needs to be tested over and over again, because it succeeds and then fails later (for example, a device showing up and then being removed again). But I think that this is not the intended logic. In general, when a device shows up or another "finished" condition is met, we assume that this condition will hold at least until the initramfs switches root and exits. If all conditions are met, the current code will also exit the initqueue without retrying any of the conditions again.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
