### PR TITLE
fix(systemd): correct typos in override paths

### DIFF
--- a/modules.d/01systemd-networkd/module-setup.sh
+++ b/modules.d/01systemd-networkd/module-setup.sh
@@ -73,13 +73,13 @@ install() {
             "$systemdutilconfdir/networkd.conf.d/*.conf" \
             "$systemdnetworkconfdir/*" \
             "$systemdsystemconfdir"/systemd-networkd.service \
-            "$systemdsystemconfdir/systemd-networkd.service/*.conf" \
+            "$systemdsystemconfdir/systemd-networkd.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-networkd.socket \
-            "$systemdsystemconfdir/systemd-networkd.socket/*.conf" \
+            "$systemdsystemconfdir/systemd-networkd.socket.d/*.conf" \
             "$systemdsystemconfdir"/systemd-network-generator.service \
-            "$systemdsystemconfdir/systemd-network-generator.service/*.conf" \
+            "$systemdsystemconfdir/systemd-network-generator.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-networkd-wait-online.service \
-            "$systemdsystemconfdir/systemd-networkd-wait-online.service/*.conf" \
+            "$systemdsystemconfdir/systemd-networkd-wait-online.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-networkd-wait-online@.service \
             "$systemdsystemconfdir/systemd-networkd-wait-online@.service.d/*.conf" \
             "$sysusersconfdir"/systemd-network.conf

--- a/modules.d/01systemd-resolved/module-setup.sh
+++ b/modules.d/01systemd-resolved/module-setup.sh
@@ -52,7 +52,7 @@ install() {
             "$systemdutilconfdir"/resolved.conf \
             "$systemdutilconfdir/resolved.conf.d/*.conf" \
             "$systemdsystemconfdir"/systemd-resolved.service \
-            "$systemdsystemconfdir/systemd-resolved.service/*.conf" \
+            "$systemdsystemconfdir/systemd-resolved.service.d/*.conf" \
             "$sysusersconfdir"/systemd-resolve.conf
     fi
 }

--- a/modules.d/01systemd-timedated/module-setup.sh
+++ b/modules.d/01systemd-timedated/module-setup.sh
@@ -41,6 +41,6 @@ install() {
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$systemdsystemconfdir"/systemd-timedated.service \
-            "$systemdsystemconfdir/systemd-timedated.service/*.conf"
+            "$systemdsystemconfdir/systemd-timedated.service.d/*.conf"
     fi
 }


### PR DESCRIPTION
Fix multiple typos in systemd override paths.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
