### PR TITLE
test(LVM-THIN): avoid thin pool size warning

### DIFF
--- a/test/TEST-17-LVM-THIN/create-root.sh
+++ b/test/TEST-17-LVM-THIN/create-root.sh
@@ -16,8 +16,8 @@ for dev in /dev/disk/by-id/ata-disk_disk[123]; do
 done
 
 lvm vgcreate dracut /dev/disk/by-id/ata-disk_disk[123]
-lvm lvcreate --ignoremonitoring -l 17 -T dracut/mythinpool
-lvm lvcreate --ignoremonitoring -V1G -T dracut/mythinpool -n root
+lvm lvcreate --ignoremonitoring -l 100%FREE -T dracut/mythinpool
+lvm lvcreate --ignoremonitoring -V100M -T dracut/mythinpool -n root
 lvm vgchange --ignoremonitoring -ay
 mkfs.ext4 /dev/dracut/root
 mkdir -p /sysroot


### PR DESCRIPTION
Avoid the following warning by reducing thin pool size

> "Sum of all thin volume sizes exceeds the size of thin pool
> and the size of whole volume group.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
