### PR TITLE
RFC: feat(livenet): add memory size check depending on live image size

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1117,6 +1117,13 @@ NOTE: There must be enough free RAM available to hold the complete image.
 +
 This method is very suitable for diskless boots.
 
+**rd.minmem=**__<megabyte>__::
+Specify minimum free RAM in MB after copying a live disk image into memory.
+The default is 1024.
++
+This parameter only applies together with the parameters rd.writable.fsimg
+or rd.live.ram.
+
 **root=**live:__<url>__::
 Boots a live image retrieved from __<url>__.  Requires the dracut 'livenet'
 module.  Valid handlers: __http, https, ftp, torrent, tftp__.

--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -314,6 +314,8 @@ if [ -e /run/initramfs/live/${live_dir}/${squash_image} ]; then
 fi
 if [ -e "$SQUASHED" ]; then
     if [ -n "$live_ram" ]; then
+        imgsize=$(($(stat -c %s -- $SQUASHED) / (1024 * 1024)))
+        check_live_ram $imgsize
         echo 'Copying live image to RAM...' > /dev/kmsg
         echo ' (this may take a minute)' > /dev/kmsg
         dd if=$SQUASHED of=/run/initramfs/squashed.img bs=512 2> /dev/null

--- a/modules.d/90livenet/livenetroot.sh
+++ b/modules.d/90livenet/livenetroot.sh
@@ -16,6 +16,13 @@ netroot="$2"
 liveurl="${netroot#livenet:}"
 info "fetching $liveurl"
 
+if getargbool 0 'rd.writable.fsimg'; then
+
+    imgsize=$(($(curl -sIL "$liveurl" | sed -n 's/Content-Length: *\([[:digit:]]*\).*/\1/p') / (1024 * 1024)))
+
+    check_live_ram $imgsize
+fi
+
 imgfile=
 #retry until the imgfile is populated with data or the max retries
 i=1

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -1151,3 +1151,28 @@ load_fstype() {
     done < /proc/filesystems
     modprobe "$1"
 }
+
+# parameter: size of live image
+# calls emergency shell if ram size is too small for the image
+check_live_ram() {
+    minmem=$(getarg rd.minmem)
+    minmem=${minmem:-1024}
+    imgsize=$1
+    memsize=$(($(sed -n 's/MemTotal: *\([[:digit:]]*\).*/\1/p' /proc/meminfo) / 1024))
+
+    if [ -z "$imgsize" ]; then
+        warn "Image size could not be determined"
+        return 0
+    fi
+
+    if [ $((memsize - imgsize)) -lt "$minmem" ]; then
+        sed -i "N;/and attach it to a bug report./s/echo$/echo\n\
+         echo \n\
+         echo 'Warning!!!'\n\
+         echo 'The memory size of your system is too small for this live image.'\n\
+         echo 'Expect killed processes due to out of memory conditions.'\n\
+         echo \n/" /usr/bin/dracut-emergency
+
+        emergency_shell
+    fi
+}


### PR DESCRIPTION
For writeable live images, the memory must hold the complete image. That means it must be at least the size of the image plus some RAM necessary to run processes.
With too small RAM, the OOM Killer steps in and makes the boot hang. This patch lets the system go into the emergency shell instead.

The minimum RAM of 512Mb is just arbitrarily choosen. We could set any other number that appears appropriate instead. Alternatively, we could add a new parameter rd.min.ram or such.

This pull request changes...

## Changes

livenet module

## Checklist
- [X ] I have tested it locally
- [X ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
OOM in livenetboot with too low memory.