### PR TITLE
fix(dmsquash-live-autooverlay): specify filesystemtype when it is already known

### DIFF
--- a/modules.d/90dmsquash-live-autooverlay/create-overlay.sh
+++ b/modules.d/90dmsquash-live-autooverlay/create-overlay.sh
@@ -98,7 +98,7 @@ createFilesystem() {
     baseDir=/run/initramfs/create-overlayfs
     mkdir -p ${baseDir}
     # shellcheck disable=SC2086
-    mount -t auto ${overlayPartition} ${baseDir}
+    mount -t ${filesystem} ${overlayPartition} ${baseDir}
 
     mkdir -p ${baseDir}/${live_dir}/ovlwork
     # shellcheck disable=SC2086


### PR DESCRIPTION
Do not use "auto" mount when filesystetype is already known.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
