### PR TITLE
fix(resolve-deps): check the existing file—not the source

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -823,7 +823,7 @@ static int dracut_install(const char *orig_src, const char *orig_dst, bool isdir
         if (ret == 0) {
                 if (resolvedeps && S_ISREG(sb.st_mode) && (sb.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH))) {
                         log_debug("'%s' already exists, but checking for any deps", fulldstpath);
-                        ret = resolve_deps(fullsrcpath + sysrootdirlen);
+                        ret = resolve_deps(fulldstpath + sysrootdirlen);
                 } else
                         log_debug("'%s' already exists", fulldstpath);
 


### PR DESCRIPTION
Check for dependencies on the file actually installed, otherwise, such as when the shebang is a link not equal to the initramfs link, the wrong file may be tested.

This bug surfaced when testing with
`ln -sf mksh /bin/sh`
and, although dash had been specified and installed,
```shell
/usr/bin/dracut@1912(): module_install dash /usr/lib/dracut/modules.d/00dash
/usr/lib/dracut/dracut-init.sh@873(module_install): local _moddir=/usr/lib/dracut/modules.d/00dash
/usr/lib/dracut/dracut-init.sh@874(module_install): local _ret
/usr/lib/dracut/dracut-init.sh@875(module_install): [[ -z /usr/lib/dracut/modules.d/00dash ]]
/usr/lib/dracut/dracut-init.sh@876(module_install): [[ -d /usr/lib/dracut/modules.d/00dash ]]
/usr/lib/dracut/dracut-init.sh@877(module_install): [[ ! -f /usr/lib/dracut/modules.d/00dash/module-setup.sh ]]
/usr/lib/dracut/dracut-init.sh@882(module_install): unset check depends cmdline install installkernel
/usr/lib/dracut/dracut-init.sh@885(module_install): . /usr/lib/dracut/modules.d/00dash/module-setup.sh
/usr/lib/dracut/dracut-init.sh@886(module_install): moddir=/usr/lib/dracut/modules.d/00dash
/usr/lib/dracut/dracut-init.sh@886(module_install): install
/usr/lib/dracut/modules.d/00dash/module-setup.sh@27(install): inst /bin/dash
/usr/lib/dracut/dracut-init.sh@249(inst): local _ret _hostonly_install
/usr/lib/dracut/dracut-init.sh@250(inst): [[ /bin/dash == \-\H ]]
/usr/lib/dracut/dracut-init.sh@254(inst): [[ -e /var/tmp/dracut.krRWoP/initramfs//bin/dash ]]
/usr/lib/dracut/dracut-init.sh@255(inst): /usr/lib/dracut/dracut-install -D /var/tmp/dracut.krRWoP/initramfs /bin/dash
dracut-install: Program arguments:
dracut-install: /usr/lib/dracut/dracut-install
dracut-install: -D
dracut-install: /var/tmp/dracut.krRWoP/initramfs
dracut-install: /bin/dash
dracut-install: PATH=/usr/sbin:/usr/bin
dracut-install: LDD=ldd
dracut-install: Handle '/bin/dash'
dracut-install: dracut_install('/bin/dash', '/bin/dash', 0, 0, 1)
dracut-install: dracut_install ret = 0
dracut-install: cp '/bin/dash' '/var/tmp/dracut.krRWoP/initramfs/bin/dash'
dracut-install: cp ret = 0
dracut-install: dracut_install ret = 0
/usr/lib/dracut/dracut-init.sh@256(inst): return 0
/usr/lib/dracut/modules.d/00dash/module-setup.sh@30(install): [[ -L /var/tmp/dracut.krRWoP/initramfs/bin/sh ]]
/usr/lib/dracut/modules.d/00dash/module-setup.sh@30(install): ln -sf dash /var/tmp/dracut.krRWoP/initramfs/bin/sh
/usr/lib/dracut/dracut-init.sh@887(module_install): _ret=0
/usr/lib/dracut/dracut-init.sh@888(module_install): unset check depends cmdline install installkernel
/usr/lib/dracut/dracut-init.sh@889(module_install): return 0
```
debug output showed the following:
```shell
dracut-install: resolve_deps('/var/tmp/dracut.DN8ih3/initramfs/usr/bin/vi') -> get_real_file('/var/tmp/dracut.DN8ih3/initramfs/usr/bin/vi', true) = '/var/tmp/dracut.DN8ih3/initramfs/usr/bin/vi'
dracut-install: Script install: '/usr/bin/sh'
dracut-install: dracut_install('/usr/bin/sh', '/usr/bin/sh', 0, 1, 0)
dracut-install: '/var/tmp/dracut.DN8ih3/initramfs/usr/bin/sh' already exists, but checking for any deps
dracut-install: get_real_file('/usr/bin/sh')
dracut-install: get_real_file: readlink('/usr/bin/sh') returns 'mksh'
dracut-install: get_real_file('/usr/bin/sh') => '/usr/bin/mksh'
dracut-install: resolve_deps('/usr/bin/sh') -> get_real_file('/usr/bin/sh', true) = '/usr/bin/mksh'
dracut-install: ldd /usr/bin/mksh
dracut-install: ldd: '	linux-vdso.so.1 (0x00007ffd5abbc000)
dracut-install: '
dracut-install: ldd: '	libc.so.6 => /lib64/libc.so.6 (0x00007f6abffec000)
dracut-install: '
dracut-install: dracut_install('/lib64/libc.so.6', '/lib64/libc.so.6', 0, 0, 1)
```
with the code change, the installed file is tested.
```shell
dracut-install: resolve_deps('/var/tmp/dracut.MRT6ue/initramfs/usr/bin/vi') -> get_real_file('/var/tmp/dracut.MRT6ue/initramfs/usr/bin/vi', true) = '/var/tmp/dracut.MRT6ue/initramfs/usr/bin/vi'
dracut-install: Script install: '/usr/bin/sh'
dracut-install: dracut_install('/usr/bin/sh', '/usr/bin/sh', 0, 1, 0)
dracut-install: '/var/tmp/dracut.MRT6ue/initramfs/usr/bin/sh' already exists, but checking for any deps
dracut-install: get_real_file('/var/tmp/dracut.MRT6ue/initramfs/usr/bin/sh')
dracut-install: get_real_file: readlink('/var/tmp/dracut.MRT6ue/initramfs/usr/bin/sh') returns 'dash'
dracut-install: get_real_file('/var/tmp/dracut.MRT6ue/initramfs/usr/bin/sh') => '/var/tmp/dracut.MRT6ue/initramfs/usr/bin/dash'
dracut-install: resolve_deps('/var/tmp/dracut.MRT6ue/initramfs/usr/bin/sh') -> get_real_file('/var/tmp/dracut.MRT6ue/initramfs/usr/bin/sh', true) = '/var/tmp/dracut.MRT6ue/initramfs/usr/bin/dash'
dracut-install: ldd /var/tmp/dracut.MRT6ue/initramfs/usr/bin/dash
dracut-install: ldd: '	linux-vdso.so.1 (0x00007ffe04fdb000)
dracut-install: '
dracut-install: ldd: '	libc.so.6 => /lib64/libc.so.6 (0x00007f80ca6af000)
dracut-install: '
dracut-install: dracut_install('/lib64/libc.so.6', '/lib64/libc.so.6', 0, 0, 1)
```
Although, in this case, the dependencies were the same, this may not always be the case.

### Checklist
- [✔] I have tested it locally

