### PR TITLE
fix(DRACUT_INSTALL): test variable properly, show failing input

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -220,8 +220,8 @@ for i in $DRACUT_INSTALL; do
     DRINSTALLPARTS=$((DRINSTALLPARTS + 1))
 done
 
-if [[ $DRINSTALLPARTS == 1 ]] && ! command -v "$DRACUT_INSTALL" > /dev/null 2>&1; then
-    dfatal "dracut-install not found!"
+if ((DRINSTALLPARTS >= 1)) && ! command -v "${DRACUT_INSTALL/ --debug/}" > /dev/null 2>&1; then
+    dfatal "'$DRACUT_INSTALL' not found!"
     exit 10
 fi
 


### PR DESCRIPTION
Test for part/word counts greater than or equal to 1 and command excluding ' --debug', at least.

### Checklist
- [✔] I have tested it locally

Note: `command -v "${DRACUT_INSTALL/ --debug/}"` may still fail with other arguments in DRACUT_INSTALL.
At least the example at line [#216](https://github.com/FGrose/dracut/blob/e6687df3feb3ac406221cb902eecacb34f574446/dracut-init.sh#L216) will work with an absolute path.