### PR TITLE
fix(mksh): implicit install requires printf

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2080,6 +2080,15 @@ for ((i = 0; i < ${#include_src[@]}; i++)); do
     fi
 done
 
+[[ $(readlink "$initdir"/bin/sh) == mksh ]] && [[ ! -f "$initdir"/bin/printf ]] && {
+    # Handle mksh's dependency on printf when mksh is installed implicitly.
+    require_binaries printf || {
+        dfatal "printf is required when mksh is /bin/sh in the initramfs."
+        exit 1
+    }
+    inst printf
+}
+
 if [[ $do_hardlink == yes ]] && command -v hardlink > /dev/null; then
     dinfo "*** Hardlinking files ***"
     hardlink "$initdir" 2>&1 | dinfo


### PR DESCRIPTION
Check for and install _printf_, when missing, and _mksh_ is `/bin/sh`.

When these conditions apply,
1. host has `ln -sf mksh /bin/sh`, and
2. if a shell program is NOT specified, and
3. if NO modules are called with a dependency for the `99base` module (where _bash_ would be specified), then

_resolve_deps()_ will install _mksh_, as the source for `/bin/sh` as in Script installs with a shebang.

### Checklist
- [✔] I have tested it locally

Fixes #1530; finishes #1534.
