### PR TITLE
feat(assure_command_shell): assure proper installation of a shell

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -174,6 +174,18 @@ dracut_install_dir/modules.d/
        which rely on the network module to detect and configure network
        interfaces.
 
+`postprocess()`:
+       This function of module-setup.sh is invoked by dracut in a
+       postprocessing loop (after all module files have been installed and all
+       other module scripts have run) if the variable _$mods_to_postprocess_
+       is enrolled with module information structured in a space-separated list
+       like `" module:moddir[@action@...] ... "`. For example, the squash
+       module employs this feature with action 'installpost' like this,
+       `mods_to_postprocess+=" squash:$moddir@installpost@ "`, in order to move
+       files into a `../squash/root/` directory in preparation for squashing
+       the image. A second call to `postprocess()` is made after striping
+       object files when the image is ready for squashing.
+
 Any other files in the module will not be touched by dracut directly.
 
 You are encouraged to provide a README that describes what the module is for.

--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -949,10 +949,12 @@ check_mount() {
     [[ " $mods_to_load " == *\ $_mod\ * ]] && return 0
     [[ " $mods_checked_as_dep " == *\ $_mod\ * ]] && return 1
 
-    # This should never happen, but...
-    [[ -d $_moddir ]] || return 1
-
     [[ $2 ]] || mods_checked_as_dep+=" $_mod "
+
+    [[ -d $_moddir ]] || {
+        dwarn "Module '$_mod' cannot be installed without a source directory, '$_moddir'."
+        return 1
+    }
 
     # shellcheck disable=SC2154
     if [[ " $omit_dracutmodules " == *\ $_mod\ * ]]; then
@@ -1015,10 +1017,12 @@ check_module() {
     [[ " $mods_to_load " == *\ $_mod\ * ]] && return 0
     [[ " $mods_checked_as_dep " == *\ $_mod\ * ]] && return 1
 
-    # This should never happen, but...
-    [[ -d $_moddir ]] || return 1
-
     [[ $2 ]] || mods_checked_as_dep+=" $_mod "
+
+    [[ -d $_moddir ]] || {
+        dwarn "Module '$_mod' cannot be installed without a source directory, '$_moddir'."
+        return 1
+    }
 
     if [[ " $omit_dracutmodules " == *\ $_mod\ * ]]; then
         ddebug "Module '$_mod' will not be installed, because it's in the list to be omitted!"
@@ -1083,6 +1087,7 @@ for_each_module_dir() {
     local _moddir
     local _func
     local _reason
+    LC_COLLATE=C
     _func=$1
     for _moddir in "$dracutbasedir/modules.d"/[0-9][0-9]*; do
         [[ -d $_moddir ]] || continue

--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -916,6 +916,22 @@ module_installkernel() {
     fi
 }
 
+# [action=<action>] module_postprocess <dracut module> <module path>
+# Execute the postprocess() function of module-setup.sh of <dracut module> with
+# optional action directive.
+module_postprocess() {
+    local _moddir=$2
+    local _ret
+    unset -f 'postprocess'
+    postprocess() { true; }
+    # shellcheck disable=SC1090
+    . "$_moddir"/module-setup.sh
+    moddir=$_moddir postprocess
+    _ret=$?
+    unset -f 'postprocess'
+    return $_ret
+}
+
 # check_mount <dracut module> [<use_as_dep>] [<module path>]
 # check_mount checks, if a dracut module is needed for the given
 # device and filesystem types in "${host_fs_types[@]}"

--- a/dracut.sh
+++ b/dracut.sh
@@ -1799,6 +1799,8 @@ mods_to_postprocess=""
 # This builds a list of modules that we will install next.
 for_each_module_dir check_module
 for_each_module_dir check_mount
+# Assure an explicit command shell or ~no~sh.
+[[ $dracutmodules == all ]] || module_depends ~sh "$(dracut_module_path ~sh)"
 
 dracut_module_included "fips" && export DRACUT_FIPS_MODE=1
 

--- a/man/dracut.modules.7.asc
+++ b/man/dracut.modules.7.asc
@@ -22,16 +22,23 @@ point of time in which they are executed, are described in <<stages>>.
 
 The main script, which creates the initramfs is dracut itself. It parses all
 arguments and sets up the directory, in which everything is installed. It then
-executes all check, install, installkernel scripts found in the modules, which
-are to be processed. After everything is installed, the install directory is
-archived and compressed to the final initramfs image. All helper functions used
-by check, install and installkernel are found in in the file _dracut-functions_.
-These shell functions are available to all module installer (install,
-installkernel) scripts, without the need to source _dracut-functions_.
+executes all check, install, installkernel, or module_setup scripts found in
+the modules, which are to be processed. After everything is installed and
+before the install directory is archived and compressed to the final initramfs
+image, a postprocessing loop will run any postprocess() functions in a module's
+module_setup.sh that has been enrolled in the variable $mods_to_postprocess.
+This enables adjustments to be made to the installed image once all other
+module scripts have completed. All helper functions used by check, install,
+installkernel, and module_setup are found in in the file _dracut-functions_.
+These shell functions are available to all module installer (check, install,
+installkernel, module_setup) scripts, without the need to source
+_dracut-functions_.
 
 A module can check the preconditions for install and installkernel with the
-check script. Also dependencies can be expressed with check. If a module passed
-check, install and installkernel will be called to install all of the necessary
+check or module_setup script. Also dependencies can be expressed with check or
+within module_setup with the depends() function. If a module passed check or
+module_setup:check(), then install and installkernel or module_setup:install()
+and module_setup:installkernel() will be called to install all of the necessary
 files for the module. To split between kernel and non-kernel parts of the
 installation, all kernel module related parts have to be in installkernel. All
 other files found in a module directory are module specific and mostly are hook

--- a/man/dracut.modules.7.asc
+++ b/man/dracut.modules.7.asc
@@ -44,6 +44,19 @@ installation, all kernel module related parts have to be in installkernel. All
 other files found in a module directory are module specific and mostly are hook
 scripts and udev rules.
 
+=== Command Shells ===
+A dracut build runs in Bash. Command scripts installed in the initramfs should
+be POSIX compliant. DASH, Bash, mksh, and BusyBox are supported as command
+shells and have dracut modules, _00dash_, _00bash_, _00mksh_, and _05busybox_.
+The meta module _99&#126;sh_ is provided to assure that a command shell is properly
+installed during a build.  An alternative command shell may be specified by
+adding a module for it into the `../dracut/modules.d/` directory and linking
+its executable to `/bin/sh` of the host.  After dracut installs all specified
+and dependent modules, it will loop through all installed executables and
+install any dynamic dependencies found by _ldd_ and any command interpreters
+found in shebang directives.  The meta module _99&#126;no&#126;sh_ may be used to
+opt out of automatic shell installation should that be desired during an
+incremental or `-m`, `--modules` exclusive build.
 
 [[stages]]
 == Boot Process Stages

--- a/modules.d/00bash/module-setup.sh
+++ b/modules.d/00bash/module-setup.sh
@@ -5,6 +5,11 @@
 # Prerequisite check(s) for module.
 check() {
 
+    # Enroll module for postprocessing.
+    strstr " $mods_to_postprocess " " bash:$moddir@installpost@ " || {
+        mods_to_postprocess+=" bash:$moddir@installpost@ "
+    }
+
     # If the binary(s) requirements are not fulfilled the module can't be installed.
     require_binaries bash || return 1
 
@@ -29,4 +34,26 @@ install() {
     # Prefer bash as default shell if no other shell is preferred.
     [[ -L $initdir/bin/sh ]] || ln -sf bash "${initdir}/bin/sh"
 
+}
+
+# Execute any postprocessing requirements.
+postprocess() {
+
+    [[ $action == installpost ]] && {
+        [[ $(readlink "${initdir}"/bin/sh) == bash ]] && {
+            local version ver0 ver1
+
+            # local - (available since bash-4.4 2016-09-15) automates the
+            #         restoration of local xtrace & other set options.
+            IFS=' ' read -r -a version <<< "$(command /bin/bash --version)"
+            IFS=. read -r ver0 ver1 _ <<< "${version[3]}"
+            if ((${ver0}${ver1} < 44)); then
+                dfatal "Installed Bash ${version[3]} ${version[4]}.
+        At least Bash 4.4 is required for proper xtrace logging
+        when Bash is the initramfs command shell."
+                exit 1
+            fi
+        }
+    }
+    return 0
 }

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -24,11 +24,6 @@ install() {
     ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
     ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
 
-    if [ ! -e "${initdir}/bin/sh" ]; then
-        inst_multiple bash
-        (ln -s bash "${initdir}/bin/sh" || :)
-    fi
-
     # add common users in /etc/passwd, it will be used by nfs/ssh currently
     # use password for hostonly images to facilitate secure sulogin in emergency console
     [[ $hostonly ]] && pwshadow='x'

--- a/modules.d/99~no~sh/module-setup.sh
+++ b/modules.d/99~no~sh/module-setup.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# This meta module is included when no command shell is desired.
+
+check() {
+
+    # We only want to return 255 since this is a meta module.
+    return 255
+
+}
+
+install() {
+
+    # Enroll module for postprocessing.
+    mods_to_postprocess+=" ~no~sh:$moddir@installpost@ "
+
+    # Installing a null link satisfies the executable dependency check.
+    ln -sf ../../dev/null "${initdir}"/bin/sh
+
+}
+
+postprocess() {
+
+    [[ $action == installpost ]] && {
+        # Remove the faked installation link.
+        rm "${initdir}"/usr/bin/sh
+        return $?
+    }
+    return 0
+}

--- a/modules.d/99~sh/module-setup.sh
+++ b/modules.d/99~sh/module-setup.sh
@@ -39,6 +39,9 @@ depends() {
         }
     }
 
+    # Always module_check bash to enroll it for postprocessing.
+    module_check bash
+
     [[ " $mods_to_load " == @(${_shells_pattern%|}) ]] || {
         for _sh in $_shells; do
             add_dracutmodules+=" $_sh "

--- a/modules.d/99~sh/module-setup.sh
+++ b/modules.d/99~sh/module-setup.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# This meta module is called from dracut.
+
+check() {
+
+    depends
+    # We only want to return 255 since this is a meta module.
+    return 255
+
+}
+
+depends() {
+
+    local _sh _shells _shells_pattern
+
+    # Assure an explicitly installed command shell.
+
+    # An alternative command shell may be specified by adding a module to
+    # ../dracut/modules.d/ and linking its executable to /bin/sh of the host.
+    _sh=$(realpath -e /bin/sh)
+    _sh=${_sh##*/}
+    _shells='dash bash mksh busybox ~no~sh'
+    strstr " $_shells " " $_sh " || _shells="${_sh:+$_sh }$_shells"
+
+    for _sh in $_shells; do
+        _shells_pattern+="* $_sh *|"
+    done
+
+    strstr " $mods_to_load " " ~no~sh " && {
+        # If a shell is queued (explicitly or by a module level dependency,
+        # but not an executable dependency), then ignore ~no~sh.
+        # ~no~sh masks executable dependencies for /bin/sh.
+        [[ ${mods_to_load/ ~no~sh/} == @(${_shells_pattern%|}) ]] && {
+            mods_to_load=${mods_to_load/ ~no~sh/}
+            mods_to_postprocess=${mods_to_postprocess/ ~no~sh:* /}
+        }
+    }
+
+    [[ " $mods_to_load " == @(${_shells_pattern%|}) ]] || {
+        for _sh in $_shells; do
+            add_dracutmodules+=" $_sh "
+            check_module "$_sh"
+            [[ $? == @(0|255) ]] || {
+                add_dracutmodules=${add_dracutmodules/" $_sh "/}
+                continue
+            }
+            [[ $dracutmodules == all ]] && echo "$_sh"
+            # We only want to return 255 since this is a meta module.
+            return 255
+        done
+        dfatal "One of the command shells, '$_shells', must be made available."
+        exit 1
+    }
+    # We only want to return 255 since this is a meta module.
+    return 255
+}


### PR DESCRIPTION
Introduce a new meta module, 99~sh, that will check that a command shell has been specified after module checks have been performed and before executable dependencies are checked.  This avoids implicit installations of a command shell that skip the dracut module checks that the shell might need.

This PR now includes 5 commits to implement the feature:
1. feat(module-postprocess): provide a postprocessing loop for modules
2. feat(99~sh): assure explicit installation of a command shell 
3. feat(99~no&#126;sh): allow a build without any command shell
4. fix(00bash): fail if Bash below version 4.4 is linked to /bin/sh 
5. refactor(99squash): gather code into the squash module

2 (indirectly) and 3, 4, & 5 above use the postprocessing feature directly to achieve the intention.


Completes fix to #1530 augmenting #1534.

An alternative command shell, for example, _zsh_ can be installed by providing an appropriate `module-setup.sh` at `../modules.d/00zsh/` and running dracut with `ln -sf zsh /bin/sh`.

### Checklist
- [✔] I have tested it locally
-  [✔] I have reviewed and updated documentation in dracut.modules.7.asc & HACKING.md