### PR TITLE
feat(resume): also consider resume= in the cmdline for hibernation

### DIFF
--- a/modules.d/99base/dracut-dev-lib.sh
+++ b/modules.d/99base/dracut-dev-lib.sh
@@ -137,3 +137,31 @@ cancel_wait_for_dev() {
         /sbin/initqueue --onetime --unique --name daemon-reload systemctl daemon-reload
     fi
 }
+
+getcmdline() {
+    local _line
+    local _i
+    local CMDLINE_ETC_D
+    local CMDLINE_ETC
+    local CMDLINE_PROC
+    unset _line
+
+    if [ -e /etc/cmdline ]; then
+        while read -r _line || [ -n "$_line" ]; do
+            CMDLINE_ETC="$CMDLINE_ETC $_line"
+        done < /etc/cmdline
+    fi
+    for _i in /etc/cmdline.d/*.conf; do
+        [ -e "$_i" ] || continue
+        while read -r _line || [ -n "$_line" ]; do
+            CMDLINE_ETC_D="$CMDLINE_ETC_D $_line"
+        done < "$_i"
+    done
+    if [ -e /proc/cmdline ]; then
+        while read -r _line || [ -n "$_line" ]; do
+            CMDLINE_PROC="$CMDLINE_PROC $_line"
+        done < /proc/cmdline
+    fi
+    CMDLINE="$CMDLINE_ETC_D $CMDLINE_ETC $CMDLINE_PROC"
+    printf "%s" "$CMDLINE"
+}

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -123,34 +123,6 @@ killall_proc_mountpoint() {
     return $_killed
 }
 
-getcmdline() {
-    local _line
-    local _i
-    local CMDLINE_ETC_D
-    local CMDLINE_ETC
-    local CMDLINE_PROC
-    unset _line
-
-    if [ -e /etc/cmdline ]; then
-        while read -r _line || [ -n "$_line" ]; do
-            CMDLINE_ETC="$CMDLINE_ETC $_line"
-        done < /etc/cmdline
-    fi
-    for _i in /etc/cmdline.d/*.conf; do
-        [ -e "$_i" ] || continue
-        while read -r _line || [ -n "$_line" ]; do
-            CMDLINE_ETC_D="$CMDLINE_ETC_D $_line"
-        done < "$_i"
-    done
-    if [ -e /proc/cmdline ]; then
-        while read -r _line || [ -n "$_line" ]; do
-            CMDLINE_PROC="$CMDLINE_PROC $_line"
-        done < /proc/cmdline
-    fi
-    CMDLINE="$CMDLINE_ETC_D $CMDLINE_ETC $CMDLINE_PROC"
-    printf "%s" "$CMDLINE"
-}
-
 getarg() {
     debug_off
     local _deprecated _newoption


### PR DESCRIPTION
Move getcmdline from dracut-lib.sh to dracut-dev-lib.sh to make it available on the host as well.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #924
