### PR TITLE
fix(kernel-modules): add interconnect drivers

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -71,6 +71,7 @@ installkernel() {
                 "=drivers/gpio" \
                 "=drivers/hwmon" \
                 "=drivers/hwspinlock" \
+                "=drivers/interconnect" \
                 "=drivers/i2c/busses" \
                 "=drivers/mailbox" \
                 "=drivers/memory" \


### PR DESCRIPTION
Many devicetree based systems require interconnect drivers to function properly. Include those in the initramfs.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
