### PR TITLE
docs(README.md): remove reference to old kernel mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Documentation:
  - [Introduction](man/dracut.asc)
  - [User Manual](man/dracut.usage.asc)
 
-Currently dracut is developed on [github.com](https://github.com/dracutdevs/dracut).
+dracut is developed on [GitHub](https://github.com/dracutdevs/dracut).
 
 The release tarballs are [here](https://github.com/dracutdevs/dracut/releases).
 
@@ -40,11 +40,10 @@ Gitter (chat):
 See [News](NEWS.md) for information about changes in the releases and
 the [Wiki](https://github.com/dracutdevs/dracut/wiki) to share information.
 
-See the github issue tracker for things which still need to be done and [Hacking](docs/HACKING.md)
-for some instructions on how to get started.  There is also a mailing list
-that is being used for the discussion -- initramfs@vger.kernel.org.
-It is a typical vger list, send mail to majordomo@vger.kernel.org with body
-of 'subscribe initramfs email@host.com'
+See the [GitHub issue tracker](https://github.com/dracutdevs/dracut/issues) for
+things which still need to be done. This is also the main place used for
+discussions.
+See [Hacking](docs/HACKING.md) for some instructions on how to get started.
 
 
 Licensed under the GPLv2


### PR DESCRIPTION
Fixes #2135
