### PR TITLE
test(ISCSI): make test-30 use the test dracut modules

### DIFF
--- a/test/TEST-30-ISCSI/finished-false.sh
+++ b/test/TEST-30-ISCSI/finished-false.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exit 1

--- a/test/TEST-30-ISCSI/hard-off.sh
+++ b/test/TEST-30-ISCSI/hard-off.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-getargbool 0 rd.shell || poweroff -f
-getargbool 0 failme && poweroff -f

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -62,7 +62,7 @@ run_client() {
         -net nic,macaddr=52:54:00:12:34:01,model=e1000 \
         -net socket,connect=127.0.0.1:12330 \
         -acpitable file=ibft.table \
-        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot rw rd.auto rd.retry=50 console=ttyS0,115200n81 selinux=0 rd.debug=0 rd.shell=0 $DEBUGFAIL $*" \
+        -append "$*" \
         -initrd "$TESTDIR"/initramfs.testing
 
     # shellcheck disable=SC2181
@@ -129,57 +129,26 @@ test_check() {
 }
 
 test_setup() {
-    kernel=$KVERSION
-    # Create what will eventually be our root filesystem onto an overlay
-    rm -rf -- "$TESTDIR"/overlay
-    (
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay/source
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        (
-            cd "$initdir" || exit
-            mkdir -p -- dev sys proc etc var/run tmp
-            mkdir -p root usr/bin usr/lib usr/lib64 usr/sbin
-            mkdir -p -- var/lib/nfs/rpc_pipefs
-        )
-        inst_multiple sh shutdown poweroff stty cat ps ln ip \
-            mount dmesg mkdir cp ping grep setsid dd sync
-        for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
-            [ -f ${_terminfodir}/l/linux ] && break
-        done
-        inst_multiple -o ${_terminfodir}/l/linux
-        inst_simple /etc/os-release
+    # Create what will eventually be the client root filesystem onto an overlay
+    "$basedir"/dracut.sh -l --keep --tmpdir "$TESTDIR" \
+        -m "test-root" \
+        -i ./client-init.sh /sbin/init \
+        -I "ip ping grep setsid" \
+        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
+        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
+        --no-hostonly --no-hostonly-cmdline --nohardlink \
+        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+    mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
-        inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
-        inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
-        inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
-
-        inst ./client-init.sh /sbin/init
-        cp -a /etc/ld.so.conf* "$initdir"/etc
-        ldconfig -r "$initdir"
-    )
-
-    # second, install the files needed to make the root filesystem
-    (
-        # shellcheck disable=SC2031
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext4 poweroff cp umount setsid dd sync blockdev
-        inst_hook initqueue 01 ./create-client-root.sh
-        inst_hook initqueue/finished 01 ./finished-false.sh
-    )
+    mkdir -p -- "$TESTDIR"/overlay/source/var/lib/nfs/rpc_pipefs
 
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -m "dash crypt lvm mdraid kernel-modules qemu" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -m "test-makeroot crypt lvm mdraid" \
+        -I "mkfs.ext4 setsid blockdev" \
+        -i ./create-client-root.sh /lib/dracut/hooks/initqueue/01-create-client-root.sh \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
@@ -199,72 +168,31 @@ test_setup() {
     test_marker_check dracut-root-block-created || return 1
     rm -- "$TESTDIR"/marker.img
 
-    # shellcheck disable=SC2031
-    export kernel=$KVERSION
-    rm -rf -- "$TESTDIR"/overlay
-    (
-        mkdir -p "$TESTDIR"/overlay/source
-        # shellcheck disable=SC2031
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay/source
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        (
-            cd "$initdir" || exit
-            mkdir -p dev sys proc etc var/run tmp var/lib/dhcpd /etc/iscsi
-        )
-        inst /etc/passwd /etc/passwd
-        inst_multiple sh ls shutdown poweroff stty cat ps ln ip \
-            dmesg mkdir cp ping modprobe tcpdump setsid \
-            sleep mount chmod pidof
-        inst_multiple tgtd tgtadm
-        for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
-            [ -f ${_terminfodir}/l/linux ] && break
-        done
-        inst_multiple -o ${_terminfodir}/l/linux
-        instmods iscsi_tcp crc32c ipv6 af_packet
-        [ -f /etc/netconfig ] && inst_multiple /etc/netconfig
-        type -P dhcpd > /dev/null && inst_multiple dhcpd
-        inst ./server-init.sh /sbin/init
-        inst ./hosts /etc/hosts
-        inst ./dhcpd.conf /etc/dhcpd.conf
-        inst_multiple -o {,/usr}/etc/nsswitch.conf {,/usr}/etc/rpc \
-            {,/usr}/etc/protocols {,/usr}/etc/services \
-            /etc/group /etc/os-release
+    # Create what will eventually be the server root filesystem onto an overlay
+    "$basedir"/dracut.sh -l --keep --tmpdir "$TESTDIR" \
+        -m "test-root network network-legacy" \
+        -d "iscsi_tcp crc32c ipv6" \
+        -i ./server-init.sh /sbin/init \
+        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
+        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
+        -I "modprobe chmod ip ping tcpdump setsid pidof tgtd tgtadm /etc/passwd" \
+        --install-optional "/etc/netconfig dhcpd /etc/group /etc/nsswitch.conf /etc/rpc /etc/protocols /etc/services /usr/etc/nsswitch.conf /usr/etc/rpc /usr/etc/protocols /usr/etc/services" \
+        -i "./hosts" "/etc/hosts" \
+        -i "./dhcpd.conf" "/etc/dhcpd.conf" \
+        --no-hostonly --no-hostonly-cmdline --nohardlink \
+        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+    mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
-        _nsslibs=$(
-            cat "$dracutsysrootdir"/{,usr/}etc/nsswitch.conf 2> /dev/null \
-                | sed -e '/^#/d' -e 's/^.*://' -e 's/\[NOTFOUND=return\]//' \
-                | tr -s '[:space:]' '\n' | sort -u | tr -s '[:space:]' '|'
-        )
-        _nsslibs=${_nsslibs#|}
-        _nsslibs=${_nsslibs%|}
-
-        inst_libdir_file -n "$_nsslibs" 'libnss_*.so*'
-
-        cp -a /etc/ld.so.conf* "$initdir"/etc
-        ldconfig -r "$initdir"
-        dracut_kernel_post
-    )
+    mkdir -p "$TESTDIR"/overlay/source/var/lib/dhcpd
 
     # second, install the files needed to make the root filesystem
-    (
-        # shellcheck disable=SC2031
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext4 poweroff cp umount sync dd
-        inst_hook initqueue 01 ./create-server-root.sh
-        inst_hook initqueue/finished 01 ./finished-false.sh
-    )
-
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -m "dash rootfs-block kernel-modules qemu" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -m "test-makeroot" \
+        -I "mkfs.ext4" \
+        -i ./create-server-root.sh /lib/dracut/hooks/initqueue/01-create-server-root.sh \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
@@ -274,7 +202,7 @@ test_setup() {
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root 60
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root 240
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -284,43 +212,21 @@ test_setup() {
     test_marker_check dracut-root-block-created || return 1
     rm -- "$TESTDIR"/marker.img
 
-    # Make an overlay with needed tools for the test harness
-    (
-        # shellcheck disable=SC2031
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        inst_multiple poweroff shutdown
-        inst_hook shutdown-emergency 000 ./hard-off.sh
-        inst_hook emergency 000 ./hard-off.sh
-        inst_simple ./client.link /etc/systemd/network/01-client.link
-    )
-    # Make client's dracut image
-    "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -o "plymouth dmraid nfs" \
-        -a "debug ${USE_NETWORK}" \
-        --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
-
-    (
-        # shellcheck disable=SC2031
-        export initdir="$TESTDIR"/overlay
-        # shellcheck disable=SC1090
-        . "$basedir"/dracut-init.sh
-        rm "$initdir"/etc/systemd/network/01-client.link
-        inst_simple ./server.link /etc/systemd/network/01-server.link
-        inst_hook pre-mount 99 ./wait-if-server.sh
-        inst_multiple sysctl
-    )
     # Make server's dracut image
-    "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
-        -a "dash rootfs-block debug kernel-modules network network-legacy" \
-        -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod e1000 drbg" \
+    "$basedir"/dracut.sh -l \
+        -a "dash rootfs-block test kernel-modules network network-legacy" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod e1000 drbg" \
+        -i "./server.link" "/etc/systemd/network/01-server.link" \
+        -i ./wait-if-server.sh /lib/dracut/hooks/pre-mount/99-wait-if-server.sh \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
 
-    rm -rf -- "$TESTDIR"/overlay
+    # Make client's dracut image
+    test_dracut \
+        --add "$USE_NETWORK" \
+        --include "./client.link" "/etc/systemd/network/01-client.link" \
+        --kernel-cmdline "rw rd.auto rd.retry=50" \
+        "$TESTDIR"/initramfs.testing
 }
 
 test_cleanup() {

--- a/test/test-functions
+++ b/test/test-functions
@@ -16,6 +16,17 @@ KVERSION=${KVERSION-$(uname -r)}
 
 if [[ -z $basedir ]]; then basedir="$(realpath ../..)"; fi
 
+test_dracut() {
+    TEST_DRACUT_ARGS+=" --local --no-hostonly --no-early-microcode --add test --kver $KVERSION"
+
+    # shellcheck disable=SC2162
+    IFS=' ' read -a TEST_DRACUT_ARGS_ARRAY <<< "$TEST_DRACUT_ARGS"
+
+    "$basedir"/dracut.sh "$@" \
+        --kernel-cmdline "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot selinux=0 console=ttyS0,115200n81 $DEBUGFAIL" \
+        "${TEST_DRACUT_ARGS_ARRAY[@]}" || return 1
+}
+
 command -v test_check &> /dev/null || test_check() {
     :
 }


### PR DESCRIPTION
Introduce test_dracut that is meant to be shared between tests in test-functions.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
