### PR TITLE
fix(DRACUT_TESTBIN): fail if test binary is not found

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -83,6 +83,11 @@ export srcmods
 
 DRACUT_LDD=${DRACUT_LDD:-ldd}
 DRACUT_TESTBIN=${DRACUT_TESTBIN:-/bin/sh}
+[[ -e $DRACUT_TESTBIN ]] || {
+    [[ -L $DRACUT_TESTBIN ]] && read -r -a L < <(ls -l "$DRACUT_TESTBIN")
+    dfatal "DRACUT_TESTBIN '$DRACUT_TESTBIN' ${L:+(${L[@]:8:3}) }not found."
+    exit 1
+}
 DRACUT_LDCONFIG=${DRACUT_LDCONFIG:-ldconfig}
 
 # shellcheck source=./dracut-functions.sh


### PR DESCRIPTION
Fail and report when test binary is not found as it is needed to detect library paths.

### Checklist
- [✔] I have tested it locally