### PR TITLE
fix(dracut.sh): Make uki's reproducible

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2519,6 +2519,7 @@ if [[ $uefi == yes ]]; then
     fi
 
     if objcopy \
+        ${DRACUT_REPRODUCIBLE:+--enable-deterministic-archives --preserve-dates} \
         ${uefi_osrelease:+--add-section .osrel="$uefi_osrelease" --change-section-vma .osrel=$(printf 0x%x "$uefi_osrelease_offs")} \
         ${uefi_cmdline:+--add-section .cmdline="$uefi_cmdline" --change-section-vma .cmdline=$(printf 0x%x "$uefi_cmdline_offs")} \
         ${uefi_splash_image:+--add-section .splash="$uefi_splash_image" --change-section-vma .splash=$(printf 0x%x "$uefi_splash_offs")} \


### PR DESCRIPTION
If the user asks for the dracut output to be reproducible, we should ensure objcopy produces a reproducible uki to.

# Changes

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it