### PR TITLE
 install.d/*.install: Fix kernel install with uefi=yes

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2594,6 +2594,9 @@ freeze_ok_for_fstype() {
         zfs)
             return 1
             ;;
+        tmpfs)
+            return 1
+            ;;
         btrfs)
             freeze_ok_for_btrfs "$outfile"
             ;;

--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -12,18 +12,18 @@ if ! [[ ${KERNEL_INSTALL_MACHINE_ID-x} ]]; then
 fi
 
 # Mismatching the install layout and the --uefi/--no-uefi opts just creates a mess.
-if [[ "$KERNEL_INSTALL_LAYOUT" == "uki" && -n "$KERNEL_INSTALL_STAGING_AREA" ]]; then
+if [[ $KERNEL_INSTALL_LAYOUT == "uki" && -n $KERNEL_INSTALL_STAGING_AREA ]]; then
     BOOT_DIR_ABS="$KERNEL_INSTALL_STAGING_AREA"
     IMAGE="uki.efi"
     UEFI_OPTS="--uefi"
-elif [[ "$KERNEL_INSTALL_LAYOUT" == "bls" && -n "$KERNEL_INSTALL_STAGING_AREA" ]]; then
+elif [[ $KERNEL_INSTALL_LAYOUT == "bls" && -n $KERNEL_INSTALL_STAGING_AREA ]]; then
     BOOT_DIR_ABS="$KERNEL_INSTALL_STAGING_AREA"
     IMAGE="initrd"
     UEFI_OPTS="--no-uefi"
 else
     # No layout information, use users --uefi/--no-uefi preference
     UEFI_OPTS=""
-    if [[ -d "$BOOT_DIR_ABS" ]]; then
+    if [[ -d $BOOT_DIR_ABS ]]; then
         IMAGE="initrd"
     else
         BOOT_DIR_ABS="/boot"
@@ -32,9 +32,10 @@ else
 fi
 
 ret=0
+
 case "$COMMAND" in
     add)
-        if [[ "$IMAGE" == "uki.efi" ]]; then
+        if [[ $IMAGE == "uki.efi" ]]; then
             IMAGE_PREGENERATED=${KERNEL_IMAGE%/*}/uki.efi
         else
             IMAGE_PREGENERATED=${KERNEL_IMAGE%/*}/initrd
@@ -42,13 +43,19 @@ case "$COMMAND" in
         if [[ -f ${IMAGE_PREGENERATED} ]]; then
             # we found an initrd or uki.efi at the same place as the kernel
             # use this and don't generate a new one
+            [[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo \
+                "There is an ${IMAGE} image at the same place as the kernel, skipping generating a new one"
             cp --reflink=auto "$IMAGE_PREGENERATED" "$BOOT_DIR_ABS/$IMAGE" \
                 && chown root:root "$BOOT_DIR_ABS/$IMAGE" \
                 && chmod 0600 "$BOOT_DIR_ABS/$IMAGE" \
                 && exit 0
         fi
 
-        if [[ -f /etc/kernel/cmdline ]]; then
+        if [ -n "$KERNEL_INSTALL_CONF_ROOT" ]; then
+            if [ -f "$KERNEL_INSTALL_CONF_ROOT/cmdline" ]; then
+                read -r -d '' -a BOOT_OPTIONS < "$KERNEL_INSTALL_CONF_ROOT/cmdline"
+            fi
+        elif [[ -f /etc/kernel/cmdline ]]; then
             read -r -d '' -a BOOT_OPTIONS < /etc/kernel/cmdline
         elif [[ -f /usr/lib/kernel/cmdline ]]; then
             read -r -d '' -a BOOT_OPTIONS < /usr/lib/kernel/cmdline
@@ -57,14 +64,14 @@ case "$COMMAND" in
 
             read -r -d '' -a line < /proc/cmdline
             for i in "${line[@]}"; do
-                [[ "${i#initrd=*}" != "$i" ]] && continue
+                [[ ${i#initrd=*} != "$i" ]] && continue
                 BOOT_OPTIONS+=("$i")
             done
         fi
 
         unset noimageifnotneeded
 
-        for ((i=0; i < "${#BOOT_OPTIONS[@]}"; i++)); do
+        for ((i = 0; i < "${#BOOT_OPTIONS[@]}"; i++)); do
             # shellcheck disable=SC1001
             if [[ ${BOOT_OPTIONS[$i]} == root\=PARTUUID\=* ]]; then
                 noimageifnotneeded="yes"
@@ -72,18 +79,21 @@ case "$COMMAND" in
             fi
         done
 
+        # shellcheck disable=SC2046
         dracut -f \
             ${noimageifnotneeded:+--noimageifnotneeded} \
-            $([[ "$KERNEL_INSTALL_VERBOSE" == 1 ]] && echo --verbose) \
-            $([[ -n "$KERNEL_IMAGE" ]] && echo --kernel-image "${KERNEL_IMAGE}") \
+            $([[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo --verbose) \
+            $([[ -n $KERNEL_IMAGE ]] && echo --kernel-image "$KERNEL_IMAGE") \
             "$UEFI_OPTS" \
-            "$BOOT_DIR_ABS/$IMAGE" \
-            "$KERNEL_VERSION"
+            --kver "$KERNEL_VERSION" \
+            "$BOOT_DIR_ABS/$IMAGE"
         ret=$?
-	;;
+        ;;
+
     remove)
         rm -f -- "$BOOT_DIR_ABS/$IMAGE"
         ret=$?
-	;;
+        ;;
 esac
+
 exit $ret

--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -11,23 +11,40 @@ if ! [[ ${KERNEL_INSTALL_MACHINE_ID-x} ]]; then
     exit 0
 fi
 
-if [[ -d "$BOOT_DIR_ABS" ]]; then
-    INITRD="initrd"
+# Mismatching the install layout and the --uefi/--no-uefi opts just creates a mess.
+if [[ "$KERNEL_INSTALL_LAYOUT" == "uki" && -n "$KERNEL_INSTALL_STAGING_AREA" ]]; then
+    BOOT_DIR_ABS="$KERNEL_INSTALL_STAGING_AREA"
+    IMAGE="uki.efi"
+    UEFI_OPTS="--uefi"
+elif [[ "$KERNEL_INSTALL_LAYOUT" == "bls" && -n "$KERNEL_INSTALL_STAGING_AREA" ]]; then
+    BOOT_DIR_ABS="$KERNEL_INSTALL_STAGING_AREA"
+    IMAGE="initrd"
+    UEFI_OPTS="--no-uefi"
 else
-    BOOT_DIR_ABS="/boot"
-    INITRD="initramfs-${KERNEL_VERSION}.img"
+    # No layout information, use users --uefi/--no-uefi preference
+    UEFI_OPTS=""
+    if [[ -d "$BOOT_DIR_ABS" ]]; then
+        IMAGE="initrd"
+    else
+        BOOT_DIR_ABS="/boot"
+        IMAGE="initramfs-${KERNEL_VERSION}.img"
+    fi
 fi
 
 ret=0
 case "$COMMAND" in
     add)
-        INITRD_IMAGE_PREGENERATED=${KERNEL_IMAGE%/*}/initrd
-        if [[ -f ${INITRD_IMAGE_PREGENERATED} ]]; then
-            # we found an initrd at the same place as the kernel
+        if [[ "$IMAGE" == "uki.efi" ]]; then
+            IMAGE_PREGENERATED=${KERNEL_IMAGE%/*}/uki.efi
+        else
+            IMAGE_PREGENERATED=${KERNEL_IMAGE%/*}/initrd
+        fi
+        if [[ -f ${IMAGE_PREGENERATED} ]]; then
+            # we found an initrd or uki.efi at the same place as the kernel
             # use this and don't generate a new one
-            cp --reflink=auto "$INITRD_IMAGE_PREGENERATED" "$BOOT_DIR_ABS/$INITRD" \
-                && chown root:root "$BOOT_DIR_ABS/$INITRD" \
-                && chmod 0600 "$BOOT_DIR_ABS/$INITRD" \
+            cp --reflink=auto "$IMAGE_PREGENERATED" "$BOOT_DIR_ABS/$IMAGE" \
+                && chown root:root "$BOOT_DIR_ABS/$IMAGE" \
+                && chmod 0600 "$BOOT_DIR_ABS/$IMAGE" \
                 && exit 0
         fi
 
@@ -58,12 +75,14 @@ case "$COMMAND" in
         dracut -f \
             ${noimageifnotneeded:+--noimageifnotneeded} \
             $([[ "$KERNEL_INSTALL_VERBOSE" == 1 ]] && echo --verbose) \
-            "$BOOT_DIR_ABS/$INITRD" \
+            $([[ -n "$KERNEL_IMAGE" ]] && echo --kernel-image "${KERNEL_IMAGE}") \
+            "$UEFI_OPTS" \
+            "$BOOT_DIR_ABS/$IMAGE" \
             "$KERNEL_VERSION"
         ret=$?
 	;;
     remove)
-        rm -f -- "$BOOT_DIR_ABS/$INITRD"
+        rm -f -- "$BOOT_DIR_ABS/$IMAGE"
         ret=$?
 	;;
 esac

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -7,13 +7,12 @@ KERNEL_VERSION="$2"
 BOOT_DIR_ABS="${3%/*}/0-rescue"
 KERNEL_IMAGE="$4"
 
-
-dropindirs_sort()
-{
-    suffix=$1; shift
+dropindirs_sort() {
+    suffix=$1
+    shift
     args=("$@")
     files=$(
-        while (( $# > 0 )); do
+        while (($# > 0)); do
             for i in "${1}"/*"${suffix}"; do
                 [[ -f $i ]] && echo "${i##*/}"
             done
@@ -31,11 +30,17 @@ dropindirs_sort()
     done
 }
 
-[[ -f /etc/os-release ]] && . /etc/os-release
+if [[ -f /etc/os-release ]]; then
+    . /etc/os-release
+elif [[ -f /usr/lib/os-release ]]; then
+    . /usr/lib/os-release
+fi
+
+[[ -n $PRETTY_NAME ]] || PRETTY_NAME="Linux $KERNEL_VERSION"
 
 if [[ ${KERNEL_INSTALL_MACHINE_ID+x} ]]; then
     MACHINE_ID=$KERNEL_INSTALL_MACHINE_ID
-elif [[ -f /etc/machine-id ]] ; then
+elif [[ -f /etc/machine-id ]]; then
     read -r MACHINE_ID < /etc/machine-id
 fi
 
@@ -43,7 +48,11 @@ if ! [[ $MACHINE_ID ]]; then
     exit 0
 fi
 
-if [[ -f /etc/kernel/cmdline ]]; then
+if [ -n "$KERNEL_INSTALL_CONF_ROOT" ]; then
+    if [ -f "$KERNEL_INSTALL_CONF_ROOT/cmdline" ]; then
+        read -r -d '' -a BOOT_OPTIONS < "$KERNEL_INSTALL_CONF_ROOT/cmdline"
+    fi
+elif [[ -f /etc/kernel/cmdline ]]; then
     read -r -d '' -a BOOT_OPTIONS < /etc/kernel/cmdline
 elif [[ -f /usr/lib/kernel/cmdline ]]; then
     read -r -d '' -a BOOT_OPTIONS < /usr/lib/kernel/cmdline
@@ -52,14 +61,14 @@ else
 
     read -r -d '' -a line < /proc/cmdline
     for i in "${line[@]}"; do
-        [[ "${i#initrd=*}" != "$i" ]] && continue
+        [[ ${i#initrd=*} != "$i" ]] && continue
         BOOT_OPTIONS+=("$i")
     done
 fi
 
-if [[ -d "${BOOT_DIR_ABS%/*}" ]]; then
+if [[ -d ${BOOT_DIR_ABS%/*} ]]; then
     BOOT_DIR="/${MACHINE_ID}/0-rescue"
-    BOOT_ROOT=${BOOT_DIR_ABS%$BOOT_DIR}
+    BOOT_ROOT=${BOOT_DIR_ABS%"$BOOT_DIR"}
     LOADER_ENTRY="$BOOT_ROOT/loader/entries/${MACHINE_ID}-0-rescue.conf"
     KERNEL="linux"
     INITRD="initrd"
@@ -75,8 +84,12 @@ ret=0
 
 case "$COMMAND" in
     add)
-        [[ -f "$LOADER_ENTRY" ]] && [[ -f "$BOOT_DIR_ABS/$KERNEL" ]] \
-            && [[ -f "$BOOT_DIR_ABS/$INITRD" ]] && exit 0
+        if [[ -f $LOADER_ENTRY ]] && [[ -f "$BOOT_DIR_ABS/$KERNEL" ]] \
+            && [[ -f "$BOOT_DIR_ABS/$INITRD" ]]; then
+            [[ $KERNEL_INSTALL_VERBOSE == 1 ]] \
+                && echo "Skipping, there is already a rescue image generated with the same input parameters"
+            exit 0
+        fi
 
         # source our config dir
         for f in $(dropindirs_sort ".conf" "/etc/dracut.conf.d" "/usr/lib/dracut/dracut.conf.d"); do
@@ -87,22 +100,30 @@ case "$COMMAND" in
         done
 
         # shellcheck disable=SC2154
-        [[ $dracut_rescue_image != "yes" ]] && exit 0
+        if [[ $dracut_rescue_image != "yes" ]]; then
+            [[ $KERNEL_INSTALL_VERBOSE == 1 ]] \
+                && echo "Skipping, 'dracut_rescue_image' not set to 'yes' in any dracut configuration file"
+            exit 0
+        fi
 
-        [[ -d "$BOOT_DIR_ABS" ]] || mkdir -p "$BOOT_DIR_ABS"
+        [[ -d $BOOT_DIR_ABS ]] || mkdir -p "$BOOT_DIR_ABS"
 
         if ! cp --reflink=auto "$KERNEL_IMAGE" "$BOOT_DIR_ABS/$KERNEL"; then
             echo "Can't copy '$KERNEL_IMAGE to '$BOOT_DIR_ABS/$KERNEL'!" >&2
         fi
 
         if [[ ! -f "$BOOT_DIR_ABS/$INITRD" ]]; then
+            # shellcheck disable=SC2046
             dracut -f --no-hostonly --no-uefi \
-                $([[ -n "$KERNEL_IMAGE" ]] && echo --kernel-image "${KERNEL_IMAGE}") \
-                -a "rescue" "$BOOT_DIR_ABS/$INITRD" "$KERNEL_VERSION"
-            ((ret+=$?))
+                -a "rescue" \
+                $([[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo --verbose) \
+                --kver "$KERNEL_VERSION" \
+                "$BOOT_DIR_ABS/$INITRD"
+            ((ret += $?))
         fi
 
-        if [[ "${BOOT_DIR_ABS}" != "/boot" ]]; then
+        [[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo "Creating $LOADER_ENTRY"
+        if [[ ${BOOT_DIR_ABS} != "/boot" ]]; then
             {
                 echo "title      $PRETTY_NAME - Rescue Image"
                 echo "version    $KERNEL_VERSION"
@@ -120,16 +141,13 @@ case "$COMMAND" in
             sed -i "s/${KERNEL_VERSION}/0-rescue-${MACHINE_ID}/" "$LOADER_ENTRY"
         fi
 
-        ((ret+=$?))
+        ((ret += $?))
         ;;
 
     remove)
         exit 0
         ;;
 
-    *)
-        usage
-        ret=1;;
 esac
 
 exit $ret

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -96,7 +96,9 @@ case "$COMMAND" in
         fi
 
         if [[ ! -f "$BOOT_DIR_ABS/$INITRD" ]]; then
-            dracut -f --no-hostonly -a "rescue" "$BOOT_DIR_ABS/$INITRD" "$KERNEL_VERSION"
+            dracut -f --no-hostonly --no-uefi \
+                $([[ -n "$KERNEL_IMAGE" ]] && echo --kernel-image "${KERNEL_IMAGE}") \
+                -a "rescue" "$BOOT_DIR_ABS/$INITRD" "$KERNEL_VERSION"
             ((ret+=$?))
         fi
 


### PR DESCRIPTION
This pull request fixes installing a kernel with uefi=yes in dracut config and layout=uki in kernel/install.conf.

Before this change this would fail because dracut needs a `--kernel-image` argument if uefi=yes. Additionally, if `kernel-install` has defined a `KERNEL_INSTALL_STAGING_AREA` for us we put the generated initrd/uki.efi there so the actual install can be handled by the appropriate plugins. This simplifies the code, otherwise we would need some extra logic that is already present in `90-loaderentry.install` and `90-uki-copy-install`. 

If we are dealing with some unknown `KERNEL_INSTALL_LAYOUT` or `KERNEL_INSTALL_STAGING_AREA` is not defined we revert to the old behaviour for backwards compatibility. This can happen if we have defined some custom `KERNEL_INSTALL_LAYOUT` or if we aren't using systemd's `kernel-install` (e.g. Gentoo's `installkernel-gentoo` for use on non-systemd systems).

## Changes

- If kernel-install has defined a staging area for us (KERNEL_INSTALL_STAGING_AREA) install generated initrd/uki.efi there. The actual install is then handled by `90-loaderentry.install` or `90-uki-copy-install`.

- Also skip regeneration if an uki.efi already exists in the kernel image directory.

- Pass --kernel-image to dracut, this is required to generate an uki (uefi=yes)

- Don't fsfreeze a tmpfs, this does not work (KERNEL_INSTALL_STAGING_AREA is often on a tmpfs)

- For `51-dracut-rescue.install` we simply add `--no-uefi`. Getting this to work with uki's requires some additional work here and/or in `90-uki-copy-install`. `--no-uefi` is a quick fix for now to ensure that install will at least not error out if `dracut_rescue_image=yes`, `uefi=yes` and `layout=uki`.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Signed-off-by: Andrew Ammerlaan <andrewammerlaan@gentoo.org>