### PR TITLE
ci: improve Gentoo container 

### DIFF
--- a/test/container/Dockerfile-Gentoo
+++ b/test/container/Dockerfile-Gentoo
@@ -40,12 +40,15 @@ RUN emerge -qv \
     net-misc/dhcp \
     sys-apps/busybox \
     sys-block/nbd \
+    sys-block/open-iscsi \
     sys-block/parted \
     sys-block/thin-provisioning-tools \
     sys-fs/btrfs-progs \
+    sys-fs/cryptsetup \
     sys-fs/dmraid \
     sys-fs/lvm2 \
     sys-fs/mdadm \
+    sys-fs/multipath-tools \
     sys-fs/ntfs3g \
     sys-fs/squashfs-tools \
     && rm -rf /var/cache/* /usr/share/doc/* /usr/share/man/*

--- a/test/container/Dockerfile-Gentoo
+++ b/test/container/Dockerfile-Gentoo
@@ -25,13 +25,11 @@ COPY --from=efistub /usr/lib/systemd/boot/efi /usr/lib/systemd/boot/efi
 
 MAINTAINER https://github.com/dracutdevs/dracut
 
-# Only install `dmsetup`: attempting to install all of lvm2 fails due to missing kernel headers.
-RUN echo 'sys-fs/lvm2 device-mapper-only -thin' > /etc/portage/package.use/lvm2
+# required by sys-fs/dmraid
+RUN echo '>=sys-fs/lvm2-2.03.20 lvm thin' > /etc/portage/package.use/lvm2
 
 # workaround for https://bugs.gentoo.org/734022 whereby Gentoo does not support NFS4 with musl
 RUN echo 'net-fs/nfs-utils -nfsv4' > /etc/portage/package.use/nfs-utils
-
-RUN echo '>=sys-fs/lvm2-2.03.17-r1 lvm' > /etc/portage/package.use/dmraid
 
 # Install needed packages for the dracut CI container
 RUN emerge -qv \
@@ -44,7 +42,6 @@ RUN emerge -qv \
     sys-block/nbd \
     sys-block/open-iscsi \
     sys-block/parted \
-    sys-block/thin-provisioning-tools \
     sys-fs/btrfs-progs \
     sys-fs/cryptsetup \
     sys-fs/dmraid \

--- a/test/container/Dockerfile-Gentoo
+++ b/test/container/Dockerfile-Gentoo
@@ -13,6 +13,8 @@ RUN mkdir -p /etc/portage/package.accept_keywords && \
 # kernel and its dependencies in a separate builder
 FROM docker.io/gentoo/stage3:musl as kernel
 COPY --from=portage /var/db/repos/gentoo /var/db/repos/gentoo
+# disable initramfs generation, only need the kernel image itself
+RUN echo 'sys-kernel/gentoo-kernel-bin -initramfs' > /etc/portage/package.use/kernel
 RUN emerge -qv sys-kernel/gentoo-kernel-bin
 
 FROM docker.io/gentoo/stage3:musl

--- a/test/container/Dockerfile-Gentoo
+++ b/test/container/Dockerfile-Gentoo
@@ -1,3 +1,4 @@
+ARG TAG=musl
 FROM docker.io/gentoo/portage:latest as portage
 
 # uefi stub in a separate builder
@@ -11,17 +12,18 @@ RUN mkdir -p /etc/portage/package.accept_keywords && \
     emerge -qv sys-boot/systemd-boot
 
 # kernel and its dependencies in a separate builder
-FROM docker.io/gentoo/stage3:musl as kernel
+FROM docker.io/gentoo/stage3:$TAG as kernel
 COPY --from=portage /var/db/repos/gentoo /var/db/repos/gentoo
 # disable initramfs generation, only need the kernel image itself
 RUN echo 'sys-kernel/gentoo-kernel-bin -initramfs' > /etc/portage/package.use/kernel
 RUN emerge -qv sys-kernel/gentoo-kernel-bin
 
-FROM docker.io/gentoo/stage3:musl
+FROM docker.io/gentoo/stage3:$TAG
 COPY --from=portage /var/db/repos/gentoo /var/db/repos/gentoo
 COPY --from=kernel /boot /boot
 COPY --from=kernel /lib/modules /lib/modules
 COPY --from=efistub /usr/lib/systemd/boot/efi /usr/lib/systemd/boot/efi
+ARG TAG
 
 MAINTAINER https://github.com/dracutdevs/dracut
 
@@ -29,7 +31,10 @@ MAINTAINER https://github.com/dracutdevs/dracut
 RUN echo '>=sys-fs/lvm2-2.03.20 lvm thin' > /etc/portage/package.use/lvm2
 
 # workaround for https://bugs.gentoo.org/734022 whereby Gentoo does not support NFS4 with musl
-RUN echo 'net-fs/nfs-utils -nfsv4' > /etc/portage/package.use/nfs-utils
+RUN if [[ "$TAG" == 'musl' ]]; then echo 'net-fs/nfs-utils -nfsv4' > /etc/portage/package.use/nfs-utils ; fi
+
+# workaround for https://bugs.gentoo.org/713490 whereby Gentoo does not support tgt with musl
+RUN if [[ "$TAG" != 'musl' ]]; then emerge -qv sys-block/tgt ; fi
 
 # Install needed packages for the dracut CI container
 RUN emerge -qv \


### PR DESCRIPTION
- Add cryptsetup, multipath-tools, open-scsi to Gentoo container
- Disabling initramfs generation saves installing 4 additional packages.
- re-enable lvm on Gentoo container
- conditionally add tgt to Gentoo container
