### PR TITLE
feat(35-network): add rd.net.dhcp6.stateless to run dhclient with -S

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -739,6 +739,12 @@ NFS
     If this option is set, dracut will try to connect via dhcp <cnt> times before failing.
     Default is 1.
 
+**rd.net.dhcp6.stateless=**__<cnt>__::
+    If this option is set, dracut will run dhclient with -S option to make an
+    information-only request over DHCPv6. This is useful if the IP is defined
+    via SLAAC and the DHCPv6 server is not configured to provide the IP address.
+    Default is 0.
+
 **rd.net.timeout.dhcp=**__<arg>__::
     If this option is set, dhclient is called with "--timeout <arg>".
 

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -478,7 +478,11 @@ for p in $(getargs ip=); do
                 ;;
             dhcp6)
                 load_ipv6
-                do_dhcp -6
+                if getargbool 0 rd.net.dhcp6.stateless; then
+                    do_dhcp -6 -S
+                else
+                    do_dhcp -6
+                fi
                 ;;
             auto6)
                 do_ipv6auto


### PR DESCRIPTION
## Changes

- add `rd.net.dhcp6.stateless=0` to run dhclient -6 -S if IP is to be provided by SLAAC only
- Reshape dhclient-script to allow `/tmp/net.$netif.resolvconf` write if we have a `RENEW6` (which is obtained by `dhclient -S -6`) so we can still have /etc/resolv.conf in the end

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
