### PR TITLE
Fixes related to `rd.driver.pre`

### DIFF
--- a/modules.d/90btrfs/module-setup.sh
+++ b/modules.d/90btrfs/module-setup.sh
@@ -26,13 +26,22 @@ depends() {
 cmdline() {
     # Hack for slow machines
     # see https://github.com/dracutdevs/dracut/issues/658
-    printf " rd.driver.pre=btrfs"
+    if grep -m 1 -q -w btrfs /proc/modules; then
+        printf " rd.driver.pre=btrfs"
+    fi
 }
 
 # called by dracut
 installkernel() {
     instmods btrfs
-    printf "%s\n" "$(cmdline)" > "${initdir}/etc/cmdline.d/00-btrfs.conf"
+
+    if [[ $hostonly_cmdline == "yes" ]]; then
+        local _conf
+        _conf=$(cmdline)
+        [[ $_conf ]] && printf "%s\n" "$(cmdline)" > "${initdir}/etc/cmdline.d/00-btrfs.conf"
+    fi
+
+    return 0
 }
 
 # called by dracut

--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -58,6 +58,14 @@ installkernel() {
     fi
 
     hostonly='' dracut_instmods -o -s "$_funcs" "=drivers/scsi" "=drivers/md" ${_s390drivers:+"$_s390drivers"}
+
+    if [[ $hostonly_cmdline == "yes" ]]; then
+        local _conf
+        _conf=$(cmdline)
+        [[ $_conf ]] && echo "$_conf" >> "${initdir}/etc/cmdline.d/90multipath.conf"
+    fi
+
+    return 0
 }
 
 mpathconf_installed() {
@@ -125,12 +133,6 @@ install() {
 
     inst_libdir_file "libmultipath*" "multipath/*"
     inst_libdir_file 'libgcc_s.so*'
-
-    if [[ $hostonly_cmdline ]]; then
-        local _conf
-        _conf=$(cmdline)
-        [[ $_conf ]] && echo "$_conf" >> "${initdir}/etc/cmdline.d/90multipath.conf"
-    fi
 
     if dracut_module_included "systemd"; then
         if mpathconf_installed; then


### PR DESCRIPTION
This is a follow up to #2410:

- fix(btrfs): do not add `rd.driver.pre` to cmdline if the kernel has `btrfs` built-in
- fix(multipath): do not add `rd.driver.pre` to cmdline with `--no-kernel`

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
