### PR TITLE
fix(dmsquash-live): allow other fstypes

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+type det_fs > /dev/null 2>&1 || . /lib/fs-lib.sh
 
 command -v unpack_archive > /dev/null || . /lib/img-lib.sh
 
@@ -61,7 +62,7 @@ get_check_dev() {
 # Find the right device to run check on
 check_dev=$(get_check_dev "$livedev")
 # CD/DVD media check
-[ -b "$check_dev" ] && fs=$(blkid -s TYPE -o value "$check_dev")
+[ -b "$check_dev" ] && fs=$(det_fs "$check_dev")
 if [ "$fs" = "iso9660" -o "$fs" = "udf" ]; then
     check="yes"
 fi
@@ -110,7 +111,7 @@ if [ -f "$livedev" ]; then
     esac
     [ -e /sys/fs/"$fstype" ] || modprobe "$fstype"
 else
-    livedev_fstype=$(blkid -o value -s TYPE "$livedev")
+    livedev_fstype=$(det_fs "$livedev")
     if [ "$livedev_fstype" = "squashfs" ]; then
         # no mount needed - we've already got the LiveOS image in $livedev
         SQUASHED=$livedev

--- a/test/TEST-16-DMSQUASH/create-root.sh
+++ b/test/TEST-16-DMSQUASH/create-root.sh
@@ -26,6 +26,16 @@ mkdir -p /root/run /root/testdir
 cp -a -t /root /source/*
 echo "Creating squashfs"
 mksquashfs /source /root/testdir/rootfs.img -quiet
+
+# Copy rootfs.img to the NTFS drive if exists
+if [ -e "/dev/disk/by-id/ata-disk_root_ntfs" ]; then
+    mkfs.ntfs -F -L dracut_ntfs /dev/disk/by-id/ata-disk_root_ntfs
+    mkdir -p /root_ntfs
+    mount -t ntfs3 /dev/disk/by-id/ata-disk_root_ntfs /root_ntfs
+    mkdir -p /root_ntfs/run /root_ntfs/testdir
+    cp /root/testdir/rootfs.img /root_ntfs/testdir/rootfs.img
+fi
+
 umount /root
 echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 poweroff -f

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -16,15 +16,21 @@ test_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -boot order=d \
-        -append "rd.live.overlay.overlayfs=1 root=LABEL=dracut console=ttyS0,115200n81 quiet selinux=0 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 $DEBUGFAIL" \
+        -append "rd.live.overlay.overlayfs=1 root=live:/dev/disk/by-label/dracut console=ttyS0,115200n81 quiet selinux=0 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing
 
+    test_marker_check || return 1
+
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -boot order=d \
         -append "rd.live.image rd.live.overlay.overlayfs=1 root=LABEL=dracut console=ttyS0,115200n81 quiet selinux=0 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing
 
+    test_marker_check || return 1
+
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -boot order=d \
@@ -33,6 +39,7 @@ test_run() {
 
     test_marker_check || return 1
 
+    test_marker_reset
     rootPartitions=$(sfdisk -d "$TESTDIR"/root.img | grep -c 'root\.img[0-9]')
     [ "$rootPartitions" -eq 1 ] || return 1
 


### PR DESCRIPTION
This PR is a rebase of https://github.com/dracutdevs/dracut/pull/2130 on top of latest default branch and resolves conflicts.

This PR provides a test case that currently fails. It than fixes the dmsquash-live module which than make the test case to pass.

