### PR TITLE
fix(bluetooth): add missing files

### DIFF
--- a/modules.d/62bluetooth/module-setup.sh
+++ b/modules.d/62bluetooth/module-setup.sh
@@ -11,7 +11,8 @@ check() {
         # Warn user if a Peripheral (0x500) is found of minor class:
         #  * Keyboard (0x40)
         #  * Keyboard/pointing (0xC0)
-        grep -qiE 'Class=0x[0-9a-f]{3}5[4c]0' /var/lib/bluetooth/*/*/info 2> /dev/null \
+        # and if Appearance is set to the value defined for keyboard (0x03C1)
+        grep -qiE -e 'Class=0x[0-9a-f]{3}5[4c]0' -e 'Appearance=0x03c1' /var/lib/bluetooth/*/*/info 2> /dev/null \
             && dwarn "If you need to use bluetooth, please include it explicitly."
     fi
 

--- a/modules.d/62bluetooth/module-setup.sh
+++ b/modules.d/62bluetooth/module-setup.sh
@@ -8,11 +8,12 @@ check() {
     require_any_binary /usr/lib/bluetooth/bluetoothd /usr/libexec/bluetooth/bluetoothd || return 1
 
     if [[ $hostonly ]]; then
-        # Warn user if a Peripheral (0x500) is found of minor class:
+        # Warn user if bluetooth kernel module is loaded
+        # and if Peripheral (0x500) is found of minor class:
         #  * Keyboard (0x40)
         #  * Keyboard/pointing (0xC0)
         # and if Appearance is set to the value defined for keyboard (0x03C1)
-        grep -qiE -e 'Class=0x[0-9a-f]{3}5[4c]0' -e 'Appearance=0x03c1' /var/lib/bluetooth/*/*/info 2> /dev/null \
+        [ -d "/sys/class/bluetooth" ] && grep -qiE -e 'Class=0x[0-9a-f]{3}5[4c]0' -e 'Appearance=0x03c1' /var/lib/bluetooth/*/*/info 2> /dev/null \
             && dwarn "If you need to use bluetooth, please include it explicitly."
     fi
 

--- a/modules.d/62bluetooth/module-setup.sh
+++ b/modules.d/62bluetooth/module-setup.sh
@@ -58,6 +58,7 @@ install() {
 
     inst_multiple -o \
         "$dbussystem"/bluetooth.conf \
+        "$dbussystemservices"/org.bluez.service \
         "${systemdsystemunitdir}/bluetooth.target" \
         "${systemdsystemunitdir}/bluetooth.service" \
         bluetoothctl
@@ -72,6 +73,8 @@ install() {
         inst_multiple -o \
             /etc/bluetooth/main.conf \
             "$dbussystemconfdir"/bluetooth.conf \
+            "$systemdsystemconfdir"/bluetooth.service \
+            "$systemdsystemconfdir/bluetooth.service.d/*.conf" \
             "${var_lib_files[@]#"$dracutsysrootdir"}"
     fi
 


### PR DESCRIPTION
This PR is a rebase of #2234 and #2330 on top of latest default branch and resolves conflicts.

- Add missing org.bluez.service dbus system service and bluetooth.service override conf.
- Check if Appearance matches the value assigned for keyboard.
- Check if bluetooth kernel module is loaded