### PR TITLE
ci: release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "release version number (3 digits)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Build
+        run: bash ${GITHUB_WORKSPACE}/tools/release.sh ${{ inputs.tag }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v0.1.15
+        with:
+          tag_name: ${{ inputs.tag }}
+          name: dracut-${{ inputs.tag }}
+          body_path: ${{ github.workspace }}/release.md

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+LAST_VERSION=$(git describe --abbrev=0 --tags --always 2> /dev/null)
+
+# CONTRIBUTORS
+printf "#### Contributors\n\n" > CONTRIBUTORS.md
+git log | git shortlog "$LAST_VERSION.." --numbered --summary -e | while read -r a rest || [ -n "$rest" ]; do echo "- $rest"; done >> CONTRIBUTORS.md
+
+# Update AUTHORS
+# shellcheck disable=SC2034
+git log | git shortlog --numbered --summary -e | while read -r a rest || [ -n "$rest" ]; do echo "$rest"; done > AUTHORS
+
+# Update NEWS.md
+cargo install clog-cli
+head -2 NEWS.md > NEWS_header.md
+tail +2 NEWS.md > NEWS_body.md
+printf "dracut-%s\n==========\n" "$1" > NEWS_header_new.md
+cat CONTRIBUTORS.md NEWS_body.md > NEWS_body_with_conttributors.md
+
+# clog will always output both the new release and old release information together
+clog -F --infile NEWS_body_with_conttributors.md -r https://github.com/dracutdevs/dracut | sed '1,2d' > NEWS_body_full.md
+
+# Use diff to separate new release information and remove repeated empty lines
+diff NEWS_body_with_conttributors.md NEWS_body_full.md | grep -e ^\>\  | sed s/^\>\ // | cat -s > NEWS_body_new.md
+cat NEWS_header.md NEWS_header_new.md NEWS_body_new.md NEWS_body_with_conttributors.md > NEWS.md
+
+# message for https://github.com/dracutdevs/dracut/releases/tag
+cat -s NEWS_body_new.md CONTRIBUTORS.md > release.md
+
+# Check in AUTHORS and NEWS.md
+git config user.name "Dracut Release Bot"
+git config user.email "<>"
+git commit -m "docs: update NEWS.md and AUTHORS" NEWS.md AUTHORS
+git push origin master
+git tag "$1" -m "$1"
+git push --tags


### PR DESCRIPTION
This pull request allows making a release using a Github Action.

I tested it on my personal fork. 

This is how a release page turned out - https://github.com/Henrik66/dracut/releases/tag/060

This is the commit the release process generated - https://github.com/Henrik66/dracut/commit/d340ceaef2276b4dba8217967f1340510a0974b7

Fixes #2416 