### PR TITLE
fix(man): add missing initrd-root-device.target to flow chart

### DIFF
--- a/man/dracut.bootup.7.asc
+++ b/man/dracut.bootup.7.asc
@@ -60,6 +60,9 @@ local-fs-pre.target                dracut-pre-trigger.service
                         ______________________/|
                        /                       |
                        |                       v
+                       |            initrd-root-device.target
+                       |                       |
+                       |                       v
                        |            dracut-pre-mount.service
                        |                       |
                        |                       v


### PR DESCRIPTION
This target was added since https://github.com/dracutdevs/dracut/commit/d4efc0ae and is ordered between `basic.target` and `sysroot.mount`, see `man bootup.7` (`dracut-pre-mount.service` starts after).

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
