### PR TITLE
ci: install util-linux-systemd and systemd-boot into openSUSE container

### DIFF
--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -9,5 +9,5 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     sudo kernel dhcp-client qemu-kvm /usr/bin/qemu-system-$(uname -m) e2fsprogs \
     tcpdump iproute iputils kbd NetworkManager btrfsprogs tgt dbus-broker \
     iscsiuio open-iscsi which ShellCheck shfmt procps pigz parted squashfs ntfsprogs \
-    multipath-tools \
+    multipath-tools util-linux-systemd systemd-boot \
     && dnf -y remove dracut && dnf -y update && dnf clean all


### PR DESCRIPTION
- `findmnt` is installed by `util-linux-systemd`. E.g.:

https://github.com/dracutdevs/dracut/actions/runs/5424796254/jobs/10097178325#step:4:53

- `/usr/lib/systemd/boot/efi/linuxx64.efi.stub` is installed by `systemd-boot`. E.g.:

https://github.com/dracutdevs/dracut/actions/runs/5424796254/jobs/10097178325#step:4:55

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
