### PR TITLE
fix(dracut-init.sh): `module_check` method ignores `forced` option

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -764,7 +764,7 @@ module_check() {
     local _forced=0
     local _hostonly=$hostonly
     [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
-    [ $# -eq 2 ] && _forced=$2
+    [ $# -ge 2 ] && _forced=$2
     [[ -d $_moddir ]] || return 1
     if [[ ! -f $_moddir/module-setup.sh ]]; then
         # if we do not have a check script, we are unconditionally included


### PR DESCRIPTION
When the `module_check` method is called passing 3 arguments (all calls right now), the `forced` option is ignored, so the `hostonly` variable is never unset before the module's `check` method is called.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
