### PR TITLE
fix(caps): multiple fixes

### DIFF
--- a/modules.d/02caps/caps.sh
+++ b/modules.d/02caps/caps.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
 capsmode=$(getarg rd.caps)
 
 if [ "$capsmode" = "1" ]; then

--- a/modules.d/02caps/caps.sh
+++ b/modules.d/02caps/caps.sh
@@ -19,9 +19,9 @@ if [ "$capsmode" = "1" ]; then
         echo "$CAPS_MODULES_DISABLED" > /proc/sys/kernel/modules_disabled
     fi
 
-    if [ "$CAPS_KEXEC_DISABLED" = "1" -a -e /proc/sys/kernel/kexec_disabled ]; then
+    if [ "$CAPS_KEXEC_DISABLED" = "1" -a -e /proc/sys/kernel/kexec_load_disabled ]; then
         info "Disabling kexec."
-        echo "$CAPS_KEXEC_DISABLED" > /proc/sys/kernel/kexec_disabled
+        echo "$CAPS_KEXEC_DISABLED" > /proc/sys/kernel/kexec_load_disabled
     fi
 
     info "CAPS_USERMODEHELPER_BSET=$CAPS_USERMODEHELPER_BSET"

--- a/modules.d/02caps/module-setup.sh
+++ b/modules.d/02caps/module-setup.sh
@@ -17,8 +17,6 @@ install() {
     if ! dracut_module_included "systemd"; then
         inst_hook pre-pivot 00 "$moddir/caps.sh"
         inst "$(find_binary capsh 2> /dev/null)" /usr/sbin/capsh
-        # capsh wants bash and we need bash also
-        inst /bin/bash
     else
         dwarning "caps: does not work with systemd in the initramfs"
     fi

--- a/modules.d/02caps/module-setup.sh
+++ b/modules.d/02caps/module-setup.sh
@@ -8,7 +8,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo bash
+    echo base bash
     return 0
 }
 


### PR DESCRIPTION
**NOTE: still a draft, because I don't know if it's worth fixing this module nowadays.**

Fixes:

- fix(caps): `/bin/bash` is already installed by the `bash` module

- fix(caps): add missing dependency from `base` module
The `caps.sh` script calls `getarg`, which is in `dracut-lib.sh`.

- fix(caps): replace `kexec_disabled` with `kexec_load_disabled`
The original patch [1] with `kexec_disabled` was not merged, but it was
patch [2] with `kexec_load_disabled`. Also, the kernel admin guide [3] only
mentions the latter.

[1] https://lore.kernel.org/lkml/20131210001620.GA7938@www.outflux.net/
[2] https://lore.kernel.org/lkml/20131211235427.GA23999@www.outflux.net/
[3] https://github.com/torvalds/linux/blob/fdf0eaf11452d72945af31804e2a1048ee1b574c/Documentation/admin-guide/sysctl/kernel.rst?plain=1#L453-L465

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

