### PR TITLE
fix(dracut.sh): shellcheck warning SC1004

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2467,7 +2467,7 @@ if [[ $uefi == yes ]]; then
         fi
     fi
 
-    offs=$(objdump -h "$uefi_stub" 2> /dev/null | gawk 'NF==7 {size=strtonum("0x"$3);\
+    offs=$(objdump -h "$uefi_stub" 2> /dev/null | gawk 'NF==7 {size=strtonum("0x"$3);
                 offset=strtonum("0x"$4)} END {print size + offset}')
     if [[ $offs -eq 0 ]]; then
         dfatal "Failed to get the size of $uefi_stub to create UEFI image file"


### PR DESCRIPTION
As stated in [1] it should work without literal backslash+linefeed.

[1] https://github.com/koalaman/shellcheck/issues/1246

## Changes

Shellcheck warning should be mitigated.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
