### PR TITLE
feat(hwdb): install hwdb on demand when module is needed

### DIFF
--- a/modules.d/95hwdb/module-setup.sh
+++ b/modules.d/95hwdb/module-setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+check() {
+    return 255
+}
+
+# called by dracut
+install() {
+    local hwdb_bin
+
+    # systemd-hwdb ships the file in /etc, with /usr/lib as an alternative.
+    # The alternative location is preferred, as we can consider it being user
+    # configuration.
+    hwdb_bin="${udevdir}"/hwdb.bin
+
+    if [[ ! -r "${hwdb_bin}" ]]; then
+        hwdb_bin="${udevconfdir}"/hwdb.bin
+    fi
+
+    if [[ $hostonly ]]; then
+        inst_multiple -H "${hwdb_bin}"
+    else
+        inst_multiple "${hwdb_bin}"
+    fi
+}


### PR DESCRIPTION
## Changes

Adding a module to install hwdb. Further extensions might make only selected part of hwdb installable, to save space. The module is not included by default.

Including the module adds 2MB of compressed data (on Fedora, the file has 12MB).

hwdb is needed in case of custom HW, like a keyboard/mouse or various interfaces.

Original PR: https://github.com/dracutdevs/dracut/pull/1681
Downstream Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1968118

Please note that `hwdb.bin` is similarly installed by `systemd-udevd`, which could instead pull in this module as dependency.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it