### PR TITLE
fix(integrity): do not require ls

### DIFF
--- a/modules.d/98integrity/module-setup.sh
+++ b/modules.d/98integrity/module-setup.sh
@@ -13,7 +13,7 @@ depends() {
 
 # called by dracut
 install() {
-    dracut_install evmctl keyctl ls
+    dracut_install evmctl keyctl
     inst_hook pre-pivot 61 "$moddir/evm-enable.sh"
     inst_hook pre-pivot 61 "$moddir/ima-keys-load.sh"
     inst_hook pre-pivot 62 "$moddir/ima-policy-load.sh"


### PR DESCRIPTION
`ls` is not used by the integrity dracut module.

