### PR TITLE
ci: change the order of lint jobs as lint_shell is more likely to fail

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,21 +7,6 @@ on:
     branches: [ master ]
 
 jobs:
-  lint-c:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: install tools
-        run: sudo apt-get install astyle
-
-      - name: indent
-        run: make indent-c
-
-      - name: check formatting
-        run: git diff --exit-code
-
   lint-shell:
     runs-on: ubuntu-latest
 
@@ -36,3 +21,18 @@ jobs:
         with:
           sh_checker_shellcheck_disable: false
           sh_checker_comment: true
+
+  lint-c:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: install tools
+        run: sudo apt-get install astyle
+
+      - name: indent
+        run: make indent-c
+
+      - name: check formatting
+        run: git diff --exit-code


### PR DESCRIPTION
ci: change the order of lint jobs as lint_shell is more likely to fail..

Now the lint_shell test result is "above the scroll" on the page.

<img width="841" alt="Screen Shot 2023-07-29 at 2 49 15 PM" src="https://github.com/dracutdevs/dracut/assets/32078711/1f6f57ae-6dd2-47bd-a0f1-7c3355b63532">
