### PR TITLE
RFC: feat(dracut): add option to disable automatic guessing of output file

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -946,6 +946,13 @@ for f in $(dropindirs_sort ".conf" "$confdir" "$dracutbasedir/dracut.conf.d"); d
     [[ -e $f ]] && . "$f"
 done
 
+# check if automatic guessing of the output file is disabled.
+if [[ $force_output_file == "yes" && -z $outfile ]]; then
+    printf "%s\n" "dracut[F]: dracut is configured with force_output_file=yes" >&2
+    printf "%s\n" "dracut[F]: so it is required to specify the file path of the generated initramfs image." >&2
+    exit 1
+fi
+
 # regenerate_all shouldn't be set in conf files
 regenerate_all=$regenerate_all_l
 if [[ $parallel_l == "yes" ]]; then

--- a/man/dracut.conf.5.asc
+++ b/man/dracut.conf.5.asc
@@ -320,6 +320,13 @@ Logging levels:
    If set to _yes_, try to execute tasks in parallel (currently only supported
    for _--regenerate-all_).
 
+*force_output_file=*"__{yes|no}__"::
+   If set to _yes_, require to specify a file path for the generated initramfs
+   image, disabling automatic guessing of the location (default=no).
+   In some complex scenarios, distribution owners may want to disable the logic
+   for guessing the location of the output file, to prevent users from calling
+   dracut directly to create useless initramfs that won't be used at boot.
+
 Files
 -----
 _/etc/dracut.conf_::


### PR DESCRIPTION
This patch allows forcing the input of the file path for the generated initramfs image (disabling automatic guessing of the location) using a new configuration option `force_output_file=yes`.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it