### PR TITLE
fix(base): correct handling of quiet in loginit

### DIFF
--- a/modules.d/99base/loginit.sh
+++ b/modules.d/99base/loginit.sh
@@ -18,6 +18,6 @@ while read -r line || [ -n "$line" ]; do
     fi
     echo "<31>dracut: $line" >&5
     # if "quiet" is specified we output to /dev/console
-    [ -n "$QUIET" ] || echo "dracut: $line"
+    [ "$QUIET" = "yes" ] || echo "dracut: $line"
     echo "$line" >&6
 done


### PR DESCRIPTION
`dracut-lib.sh` [sets `DRACUT_QUIET` to `yes` or `no`](https://github.com/dracutdevs/dracut/blob/a804945f27a0ccc2f69ae694599b1afec2afe8b1/modules.d/99base/dracut-lib.sh#L460-L470) and [passes this to `loginit`](https://github.com/dracutdevs/dracut/blob/a804945f27a0ccc2f69ae694599b1afec2afe8b1/modules.d/99base/init.sh#L99).

Follow up to #2281 with the commit message fixed.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
