### PR TITLE
fix(systemd-journald): add systemd-sysusers dependency

### DIFF
--- a/modules.d/01systemd-journald/module-setup.sh
+++ b/modules.d/01systemd-journald/module-setup.sh
@@ -19,6 +19,8 @@ check() {
 # Module dependency requirements.
 depends() {
 
+    # This module has external dependency on other module(s).
+    echo systemd-sysusers
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 


### PR DESCRIPTION
The `systemd-journald` module installs its own system group, so add the missing the dependency.

https://github.com/dracutdevs/dracut/blob/a804945f27a0ccc2f69ae694599b1afec2afe8b1/modules.d/01systemd-journald/module-setup.sh#L48

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
