### PR TITLE
fix(systemd-udevd): add missing override paths

### DIFF
--- a/modules.d/01systemd-udevd/module-setup.sh
+++ b/modules.d/01systemd-udevd/module-setup.sh
@@ -96,7 +96,9 @@ install() {
             "$systemdsystemconfdir"/systemd-udev-settle.service \
             "$systemdsystemconfdir/systemd-udev-settle.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-udevd-control.socket \
+            "$systemdsystemconfdir/systemd-udevd-control.socket.d/*.conf" \
             "$systemdsystemconfdir"/systemd-udevd-kernel.socket \
+            "$systemdsystemconfdir/systemd-udevd-kernel.socket.d/*.conf" \
             "$systemdsystemconfdir"/sockets.target.wants/systemd-udevd-control.socket \
             "$systemdsystemconfdir"/sockets.target.wants/systemd-udevd-kernel.socket \
             "$systemdsystemconfdir"/sysinit.target.wants/systemd-udevd.service \


### PR DESCRIPTION
Fix override paths of `systemd-udevd-control.socket` and `systemd-udevd-kernel.socket`.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
