### PR TITLE
ci: do not run test container generation on forked repos by default

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
     push_to_registry:
+        if: github.repository == 'dracutdevs/dracut' || vars.CONTAINER == 'enabled'
         name: Build and push containers image to GitHub Packages
         runs-on: ubuntu-latest
         concurrency:


### PR DESCRIPTION
Container GitHub Action runs daily for dracutdevs developers. Every time dracut repo get's forked this daily github action runs on all forked repo's.

Some people know (and remember) to disable this action manually, but for the most this is just wasting significant resources as currently there is at east [300+ forked version of dracut](https://github.com/dracutdevs/dracut/forks) on Github.

As suggested by @mwilck  at https://github.com/dracutdevs/dracut/issues/1865#issue-1293154830
> The workflow should be made conditional in some way.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1865
