### PR TITLE
docs: Make the purpose of fw_dir explicit

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -113,7 +113,7 @@ Creates initial ramdisk images for preloading modules
   -k, --kmoddir [DIR]   Specify the directory where to look for kernel
                          modules.
   --fwdir [DIR]         Specify additional colon-separated list of directories
-                         where to look for firmware files.
+                         where to look for CPU firmware (microcode) files.
   --libdirs [LIST]      Specify a space-separated list of directories
                          where to look for libraries.
   --kernel-only         Only install kernel drivers and firmware files.

--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -198,8 +198,8 @@ example:
     Specify the directory, where to look for kernel modules.
 
 **--fwdir** _<dir>[:<dir>...]++_::
-    Specify additional directories, where to look for firmwares. This parameter
-    can be specified multiple times.
+    Specify additional directories, where to look for CPU firmwares
+    (microcode). This parameter can be specified multiple times.
 
 **--libdirs** _<list of directories>_::
     Specify a space-separated list of directories to look for libraries to

--- a/man/dracut.conf.5.asc
+++ b/man/dracut.conf.5.asc
@@ -77,7 +77,7 @@ Configuration files must have the extension .conf; other extensions are ignored.
 
 *fw_dir+=*" :__<dir>__[:__<dir>__ ...] "::
     Specify additional colon-separated list of directories where to look for
-    firmware files.
+    CPU firmware (microcode) files.
 
 *libdirs+=*" __<dir>__[ __<dir>__ ...] "::
     Specify a space-separated list of directories where to look for libraries.


### PR DESCRIPTION
Updated documentation and usage text to make it explicit that `fw_dir` is only for CPU firmware.

I'm new to dracut, played around with it for a while today and got stuck trying to figure out why this configuration option wasn't working, until I read the script and realized it's working fine, it's just not named well.