### PR TITLE
ci: migrate from systemd-boot to systemd-utils in Gentoo container

### DIFF
--- a/test/container/Dockerfile-Gentoo
+++ b/test/container/Dockerfile-Gentoo
@@ -6,10 +6,8 @@ FROM docker.io/gentoo/stage3 as efistub
 COPY --from=portage /var/db/repos/gentoo /var/db/repos/gentoo
 
 # systemd-boot
-RUN mkdir -p /etc/portage/package.accept_keywords && \
-    echo "sys-boot/systemd-boot" >> /etc/portage/package.accept_keywords/systemd-boot && \
-    echo '>=sys-apps/systemd-utils-251.10 boot' > /etc/portage/package.use/systemd-boot && \
-    emerge -qv sys-boot/systemd-boot
+RUN echo 'sys-apps/systemd-utils boot' > /etc/portage/package.use/systemd-utils && \
+    emerge -qv sys-apps/systemd-utils
 
 # kernel and its dependencies in a separate builder
 FROM docker.io/gentoo/stage3:$TAG as kernel
@@ -28,13 +26,15 @@ ARG TAG
 MAINTAINER https://github.com/dracutdevs/dracut
 
 # required by sys-fs/dmraid
-RUN echo '>=sys-fs/lvm2-2.03.20 lvm thin' > /etc/portage/package.use/lvm2
+RUN echo 'sys-fs/lvm2 lvm thin' > /etc/portage/package.use/lvm2
 
 # workaround for https://bugs.gentoo.org/734022 whereby Gentoo does not support NFS4 with musl
 RUN if [[ "$TAG" == 'musl' ]]; then echo 'net-fs/nfs-utils -nfsv4' > /etc/portage/package.use/nfs-utils ; fi
 
-# workaround for https://bugs.gentoo.org/713490 whereby Gentoo does not support tgt with musl
-RUN if [[ "$TAG" != 'musl' ]]; then emerge -qv sys-block/tgt ; fi
+# workaround for packages do not compile on musl
+# https://bugs.gentoo.org/713490 for tgt
+# https://bugs.gentoo.org/908587 for open-iscsi
+RUN if [[ "$TAG" != 'musl' ]]; then emerge -qv sys-block/tgt sys-block/open-iscsi ; fi
 
 # Install needed packages for the dracut CI container
 RUN emerge -qv \
@@ -45,7 +45,6 @@ RUN emerge -qv \
     net-misc/dhcp \
     sys-apps/busybox \
     sys-block/nbd \
-    sys-block/open-iscsi \
     sys-block/parted \
     sys-fs/btrfs-progs \
     sys-fs/cryptsetup \


### PR DESCRIPTION
See https://www-cdn.gentoo.org/support/news-items/2022-04-19-systemd-utils.html

Gentoo test container started failing on Jul-31 - https://github.com/dracutdevs/dracut/actions/runs/5714136544

After  open-iscsi  2.1.8--> 2.1.9 upgrade open-iscsi for musl as it fails to compile, see https://bugs.gentoo.org/908587, so no longer include it.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
