### PR TITLE
fix(dracut.sh): --regenerate-all should always be allowed to overwrite existing initramfs

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -968,13 +968,13 @@ if [[ $regenerate_all == "yes" ]]; then
     if [[ $parallel != "yes" ]]; then
         for i in *; do
             [[ -f $i/modules.dep ]] || [[ -f $i/modules.dep.bin ]] || continue
-            "$dracut_cmd" --kver="$i" "${dracut_args[@]}"
+            "$dracut_cmd" --kver="$i" --force "${dracut_args[@]}"
             ((ret += $?))
         done
     else
         for i in *; do
             [[ -f $i/modules.dep ]] || [[ -f $i/modules.dep.bin ]] || continue
-            "$dracut_cmd" --kver="$i" "${dracut_args[@]}" &
+            "$dracut_cmd" --kver="$i" --force "${dracut_args[@]}" &
         done
         while true; do
             wait -n


### PR DESCRIPTION
This argument makes dracut calls itself on every kernel passing along any other arguments. Since the goal is to *re*generate all initramfs I suppose it's implicitly understood it will overwrite files.

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
