### PR TITLE
fix(dmsquash-liveiso): failure to iso-scan boot Fedora .iso images

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-liveiso-genrules.sh
+++ b/modules.d/90dmsquash-live/dmsquash-liveiso-genrules.sh
@@ -3,7 +3,7 @@
 if [ "${root%%:*}" = "liveiso" ]; then
     {
         # shellcheck disable=SC2016
-        printf 'KERNEL=="loop-control", RUN+="/sbin/initqueue --settled --onetime --unique /sbin/dmsquash-live-root `/sbin/losetup -f --show %s`"\n' \
+        printf 'KERNEL=="loop-control", RUN+="/sbin/initqueue --settled --onetime --unique /sbin/dmsquash-live-root `/sbin/losetup -f -P --show %s`"\n' \
             "${root#liveiso:}"
     } >> /etc/udev/rules.d/99-liveiso-mount.rules
 fi


### PR DESCRIPTION
Set up the iso image file loop device with the -P, --partscan option to force the kernel to scan the partition table on the newly created loop device.

This seems to solve the problem with the Fedora .iso images.

## Checklist
- [✔] I have tested it locally

Fixes #2464 
