### PR TITLE
fix(90kernel-modules): handle rd.driver.* before rd.break=cmdline

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -146,9 +146,7 @@ install() {
     [[ -d /lib/modprobe.d ]] && inst_multiple -o "/lib/modprobe.d/*.conf"
     [[ -d /usr/lib/modprobe.d ]] && inst_multiple -o "/usr/lib/modprobe.d/*.conf"
     [[ $hostonly ]] && inst_multiple -H -o /etc/modprobe.d/*.conf /etc/modprobe.conf
-    if ! dracut_module_included "systemd"; then
-        inst_hook cmdline 01 "$moddir/parse-kernel.sh"
-    fi
+    inst_hook cmdline 01 "$moddir/parse-kernel.sh"
     inst_simple "$moddir/insmodpost.sh" /sbin/insmodpost.sh
     inst_multiple -o sysctl
 }


### PR DESCRIPTION
Handling rd.driver.* before rd.break=cmdline allows keyboard driver loaded earlier.

Uploaded the change suggested at https://github.com/dracutdevs/dracut/issues/728#issuecomment-1660733254

Fixes #728
