### PR TITLE
fix(crypt): close crypt devices to release encryption keys get on shutdown

### DIFF
--- a/modules.d/90crypt/crypt-shutdown.sh
+++ b/modules.d/90crypt/crypt-shutdown.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Mark crypt devices for deferred removal.
+# The dm module removes holding devices, so
+# that the encryption keys can be released.
+dmsetup ls --target crypt | while read -r name _; do
+    if ! type "cryptsetup" > /dev/null 2>&1; then
+        warn "cryptsetup not installed, skipping closing of encrypted devices"
+        return
+    fi
+    cryptsetup close "$name" --deferred 2>&1 | vinfo
+done

--- a/modules.d/90crypt/crypt-shutdown.sh
+++ b/modules.d/90crypt/crypt-shutdown.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Remove leftover udev control socket to prevent cryptsetup hangup
+rm -f /run/udev/control
+
 # Mark crypt devices for deferred removal.
 # The dm module removes holding devices, so
 # that the encryption keys can be released.

--- a/modules.d/90crypt/crypt-shutdown.sh
+++ b/modules.d/90crypt/crypt-shutdown.sh
@@ -8,8 +8,8 @@ rm -f /run/udev/control
 # that the encryption keys can be released.
 dmsetup ls --target crypt | while read -r name _; do
     if ! type "cryptsetup" > /dev/null 2>&1; then
-        warn "cryptsetup not installed, skipping closing of encrypted devices"
-        return
+        systemd-cryptsetup detach "$name" deferred 2>&1 | vinfo
+    else
+        cryptsetup close "$name" --deferred 2>&1 | vinfo
     fi
-    cryptsetup close "$name" --deferred 2>&1 | vinfo
 done

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -97,9 +97,7 @@ install() {
 
     inst_hook cmdline 30 "$moddir/parse-crypt.sh"
     inst_hook shutdown 24 "$moddir/crypt-shutdown.sh"
-    if type "cryptsetup" > /dev/null 2>&1; then
-        inst_binary cryptsetup
-    fi
+    inst_multiple -o cryptsetup
     if ! dracut_module_included "systemd"; then
         inst_multiple rmdir readlink umount
         inst_script "$moddir"/cryptroot-ask.sh /sbin/cryptroot-ask

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -96,8 +96,12 @@ install() {
     fi
 
     inst_hook cmdline 30 "$moddir/parse-crypt.sh"
+    inst_hook shutdown 24 "$moddir/crypt-shutdown.sh"
+    if type "cryptsetup" > /dev/null 2>&1; then
+        inst_binary cryptsetup
+    fi
     if ! dracut_module_included "systemd"; then
-        inst_multiple cryptsetup rmdir readlink umount
+        inst_multiple rmdir readlink umount
         inst_script "$moddir"/cryptroot-ask.sh /sbin/cryptroot-ask
         inst_script "$moddir"/probe-keydev.sh /sbin/probe-keydev
         inst_hook cmdline 10 "$moddir/parse-keydev.sh"


### PR DESCRIPTION
## Changes
This pull request adds a shutdown hook to close encrypted devices and wipe their encryption keys from kernel memory.
Cryptsetup may not be installed on every system, if systemd-cryptsetup is used. That's why I made this feature optional in order not to break any running systems.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #997 #1888 
