### PR TITLE
ci: do not run release generation on forked repos by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,13 @@ on:
     inputs:
       tag:
         description: "release version number (3 digits)"
-        required: true
 
 permissions:
   contents: write
 
 jobs:
   release:
+    if: github.repository == 'dracutdevs/dracut' || vars.RELEASE == 'enabled' || ${{ inputs.tag }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
If RELEASE Github variable set, or manual github action, than run the job as before.

After https://github.com/dracutdevs/dracut/commit/9e1e924550a23b7fbbca5f752f32a749631db116 automatic releases are generated even on forked repos.

Use the same idea as in https://github.com/dracutdevs/dracut/commit/403f4e8e15da4fdc84f3d32a0f231eeb9b2e4ed0 to stop this from happening.

Also make version information optional as the script is now able to compute the version.    