### PR TITLE
chore: remove unnecessary shellcheck disable for SC2154

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -54,7 +54,6 @@ find_binary() {
     [[ -z ${1##/*} ]] || _delim="/"
 
     if [[ $1 == *.so* ]]; then
-        # shellcheck disable=SC2154
         for l in $libdirs; do
             _path="${l}${_delim}${1}"
             if { $DRACUT_LDD "${dracutsysrootdir}${_path}" &> /dev/null; }; then

--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -44,7 +44,6 @@ if ! is_func dinfo > /dev/null 2>&1; then
     dlog_init
 fi
 
-# shellcheck disable=SC2154
 if ! [[ $initdir ]]; then
     dfatal "initdir not set"
     exit 1
@@ -59,10 +58,8 @@ if ! [[ $kernel ]]; then
     export kernel
 fi
 
-# shellcheck disable=SC2154
 srcmods="$dracutsysrootdir/lib/modules/$kernel/"
 
-# shellcheck disable=SC2154
 [[ $drivers_dir ]] && {
     if ! command -v kmod &> /dev/null && vercmp "$(modprobe --version | cut -d' ' -f3)" lt 3.7; then
         dfatal 'To use --kmoddir option module-init-tools >= 3.7 is required.'
@@ -108,7 +105,6 @@ fi
 # to check for required installed binaries
 # issues a standardized warning message
 require_binaries() {
-    # shellcheck disable=SC2154
     local _module_name="${moddir##*/}"
     local _ret=0
 
@@ -154,7 +150,6 @@ require_any_binary() {
 # to check for required kernel modules
 # issues a standardized warning message
 require_kernel_modules() {
-    # shellcheck disable=SC2154
     local _module_name="${moddir##*/}"
     local _ret=0
 
@@ -180,7 +175,6 @@ dracut_need_initqueue() {
 }
 
 dracut_module_included() {
-    # shellcheck disable=SC2154
     [[ " $mods_to_load $modules_loaded " == *\ $*\ * ]]
 }
 
@@ -317,7 +311,6 @@ dracut_install() {
 dracut_instmods() {
     local _ret _silent=0
     local i
-    # shellcheck disable=SC2154
     [[ $no_kernel == yes ]] && return
     for i in "$@"; do
         [[ $i == "--silent" ]] && _silent=1
@@ -391,7 +384,6 @@ inst_fsck_help() {
 # be applied, else will ignore hostonly mode and try to install all
 # given modules.
 optional_hostonly() {
-    # shellcheck disable=SC2154
     if [[ $hostonly_mode == "strict" ]]; then
         printf -- "%s" "$hostonly"
     else
@@ -443,7 +435,6 @@ inst_rule_programs() {
     # shellcheck disable=SC2013
     for _prog in $(sed -nr 's/.*PROGRAM==?"([^ "]+).*/\1/p' "$1"); do
         _bin=""
-        # shellcheck disable=SC2154
         if [[ -x ${udevdir}/$_prog ]]; then
             _bin="${udevdir}"/$_prog
         elif [[ ${_prog/\$env\{/} == "$_prog" ]]; then
@@ -884,7 +875,6 @@ check_mount() {
     local _moddep
 
     [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
-    # shellcheck disable=SC2154
     [ "${#host_fs_types[@]}" -le 0 ] && return 1
 
     # If we are already scheduled to be loaded, no need to check again.
@@ -896,7 +886,6 @@ check_mount() {
 
     [[ $2 ]] || mods_checked_as_dep+=" $_mod "
 
-    # shellcheck disable=SC2154
     if [[ " $omit_dracutmodules " == *\ $_mod\ * ]]; then
         return 1
     fi

--- a/dracut.sh
+++ b/dracut.sh
@@ -1107,7 +1107,6 @@ if ! [[ $outfile ]]; then
     fi
 
     if [[ $uefi == "yes" ]]; then
-        # shellcheck disable=SC2154
         if [[ -n $uefi_secureboot_key && -z $uefi_secureboot_cert ]] || [[ -z $uefi_secureboot_key && -n $uefi_secureboot_cert ]]; then
             printf "%s\n" "dracut[F]: Need 'uefi_secureboot_key' and 'uefi_secureboot_cert' both to be set." >&2
             exit 1
@@ -1278,7 +1277,6 @@ trap 'exit 1;' SIGINT
 readonly initdir="${DRACUT_TMPDIR}/initramfs"
 mkdir -p "$initdir"
 
-# shellcheck disable=SC2154
 if [[ $early_microcode == yes ]] || { [[ $acpi_override == yes ]] && [[ -d $acpi_table_dir ]]; }; then
     readonly early_cpio_dir="${DRACUT_TMPDIR}/earlycpio"
     mkdir "$early_cpio_dir"
@@ -1335,7 +1333,6 @@ else
     unset enhanced_cpio
 fi
 
-# shellcheck disable=SC2154
 if [[ $no_kernel != yes ]] && ! [[ -d $srcmods ]]; then
     dfatal "Cannot find module directory $srcmods"
     dfatal "and --no-kernel was not specified"
@@ -1889,7 +1886,6 @@ mkdir -p "${initdir}"/lib/dracut
 if [[ $kernel_only != yes ]]; then
     mkdir -p "${initdir}/etc/cmdline.d"
     mkdir -m 0755 "${initdir}"/lib/dracut/hooks
-    # shellcheck disable=SC2154
     for _d in $hookdirs; do
         # shellcheck disable=SC2174
         mkdir -m 0755 -p "${initdir}/lib/dracut/hooks/$_d"
@@ -2452,7 +2448,6 @@ else
     fi
 fi
 
-# shellcheck disable=SC2154
 if ((maxloglvl >= 5)) && ((verbosity_mod_l >= 0)); then
     if [[ $allowlocal ]]; then
         "$dracutbasedir/lsinitrd.sh" "${DRACUT_TMPDIR}/initramfs.img" | ddebug

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -99,7 +99,6 @@ case "$COMMAND" in
             fi
         done
 
-        # shellcheck disable=SC2154
         if [[ $dracut_rescue_image != "yes" ]]; then
             [[ $KERNEL_INSTALL_VERBOSE == 1 ]] \
                 && echo "Skipping, 'dracut_rescue_image' not set to 'yes' in any dracut configuration file"

--- a/modules.d/90dmsquash-live-autooverlay/create-overlay-genrules.sh
+++ b/modules.d/90dmsquash-live-autooverlay/create-overlay-genrules.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-# shellcheck disable=SC2154
 case "$root" in
     live:/dev/*)
         printf 'SYMLINK=="%s", RUN+="/sbin/initqueue --settled --onetime --unique /sbin/create-overlay %s"\n' \

--- a/modules.d/90dmsquash-live-autooverlay/module-setup.sh
+++ b/modules.d/90dmsquash-live-autooverlay/module-setup.sh
@@ -18,7 +18,6 @@ installkernel() {
 install() {
     inst_multiple awk blkid cat grep mkdir mount parted readlink rmdir tr umount
     inst_multiple -o mkfs.btrfs mkfs.ext4 mkfs.xfs
-    # shellcheck disable=SC2154
     inst_hook pre-udev 25 "$moddir/create-overlay-genrules.sh"
     inst_script "$moddir/create-overlay.sh" "/sbin/create-overlay"
     dracut_need_initqueue

--- a/modules.d/95cifs/cifsroot.sh
+++ b/modules.d/95cifs/cifsroot.sh
@@ -13,12 +13,10 @@ NEWROOT="$3"
 
 cifs_to_var "$root"
 
-# shellcheck disable=SC2154
 mount.cifs "//$server/$path" "$NEWROOT" -o "$options" && { [ -e /dev/root ] || ln -s null /dev/root; }
 
 # inject new exit_if_exists
 # shellcheck disable=SC2016
-# shellcheck disable=SC2154
 echo 'settle_exit_if_exists="--exit-if-exists=/dev/root"; rm -f -- "$job"' > "$hookdir"/initqueue/cifs.sh
 # force udevsettle to break
 : > "$hookdir"/initqueue/work

--- a/modules.d/95rootfs-block/block-genrules.sh
+++ b/modules.d/95rootfs-block/block-genrules.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-# shellcheck disable=SC2154
 if [ "${root%%:*}" = "block" ]; then
     {
         printf 'KERNEL=="%s", SYMLINK+="root"\n' \
@@ -10,7 +9,6 @@ if [ "${root%%:*}" = "block" ]; then
     } >> /etc/udev/rules.d/99-root.rules
 
     # shellcheck disable=SC2016
-    # shellcheck disable=SC2154
     printf '[ -e "%s" ] && { ln -s "%s" /dev/root 2>/dev/null; rm "$job"; }\n' \
         "${root#block:}" "${root#block:}" > "$hookdir"/initqueue/settled/blocksymlink.sh
 

--- a/test/test-functions
+++ b/test/test-functions
@@ -160,7 +160,6 @@ while (($# > 0)); do
                 ) < /dev/null 2>&1 | tee "test${TEST_RUN_ID:+-$TEST_RUN_ID}.log"
             elif [[ $V == "2" ]]; then
                 set -o pipefail
-                # shellcheck disable=SC2154
                 (
                     test_setup && test_run
                     ret=$?


### PR DESCRIPTION
Remove unnecessary shellcheck comments for [SC2154](https://www.shellcheck.net/wiki/SC2154) . The current version of shellcheck is smart enough to not require these opt-out comments.

This is a rebase from a PR closed earlier by the stale bot - https://github.com/dracutdevs/dracut/pull/2235