### PR TITLE
fix(systemd-networkd): remove dbus hard dependency

### DIFF
--- a/modules.d/01systemd-networkd/module-setup.sh
+++ b/modules.d/01systemd-networkd/module-setup.sh
@@ -22,7 +22,7 @@ check() {
 depends() {
 
     # This module has external dependency on other module(s).
-    echo dbus kernel-network-modules systemd-sysusers
+    echo kernel-network-modules systemd-sysusers
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 


### PR DESCRIPTION
According to https://github.com/dracutdevs/dracut/issues/2378#issuecomment-1668136681 dbus is not a requirement for systemd-networkd.