### PR TITLE
fix(dracut.sh): exit if resolving executable dependencies fails

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2045,7 +2045,13 @@ if [[ $kernel_only != yes ]]; then
         # shellcheck disable=SC2086
         find "$initdir" -type f -perm /0111 -not -path '*.ko' -print0 \
             | xargs -r -0 $DRACUT_INSTALL ${initdir:+-D "$initdir"} ${dracutsysrootdir:+-r "$dracutsysrootdir"} -R ${DRACUT_FIPS_MODE:+-f} --
-        dinfo "*** Resolving executable dependencies done ***"
+        # shellcheck disable=SC2181
+        if (($? == 0)); then
+            dinfo "*** Resolving executable dependencies done ***"
+        else
+            dfatal "Resolving executable dependencies failed"
+            exit 1
+        fi
     fi
 
     # Now we are done with lazy resolving, always install dependencies


### PR DESCRIPTION
We came across an issue where, when resolving executable dependencies, a call to a buggy glib function in `dracut-install` was causing a termination with SIGSEGV, but dracut didn't stop the build process, which resulted in an unbootable initrd, due to missing required libraries.

```
dracut: *** Resolving executable dependencies ***
xargs: /usr/lib/dracut/dracut-install: terminated by signal 11
dracut: *** Resolving executable dependencies done ***
```

Therefore, stop the initrd creation in this case.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
