### PR TITLE
fix(dracut-install): protect against broken links pointing to themselves

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -480,6 +480,11 @@ static char *get_real_file(const char *src, bool fullyresolve)
 
         log_debug("get_real_file: readlink('%s') returns '%s'", fullsrcpath, linktarget);
 
+        if (streq(fullsrcpath, linktarget)) {
+                log_error("ERROR: '%s' is pointing to itself", fullsrcpath);
+                return NULL;
+        }
+
         if (linktarget[0] == '/') {
                 _asprintf(&abspath, "%s%s", (sysrootdirlen ? sysrootdir : ""), linktarget);
         } else {


### PR DESCRIPTION
`readlink` does not return an error if a symbolic link points to itself, which can cause a stack overflow due to infinite recursion in the `get_real_file` function.

Although this type of recursive links should not exist, we discovered this issue on a real system. It can be reproduced as follows:

```
> ls -l /lib64/libblkid.so
-rwxr-xr-x 1 root root 224368 Aug  9 15:13 /lib64/libblkid.so
> rm -f /lib64/libblkid.so
> ln -s /lib64/libblkid.so /lib64/libblkid.so
> ls -l /lib64/libblkid.so
lrwxrwxrwx 1 root root 18 Aug  9 15:06 /lib64/libblkid.so -> /lib64/libblkid.so
> dracut -f -I "/lib64/libblkid.so" test.img
...
dracut-install: Handle '/lib64/libblkid.so'
dracut-install: dracut_install('/lib64/libblkid.so', '/lib64/libblkid.so', 0, 0, 1)
dracut-install: get_real_file('/lib64/libblkid.so')
dracut-install: get_real_file: readlink('/lib64/libblkid.so') returns '/lib64/libblkid.so'
dracut-install: get_real_file('/lib64/libblkid.so') => '/lib64/libblkid.so'
...
[infinite recursion]
...
dracut-install: dracut_install('/lib64/libblkid.so', '/lib64/libblkid.so', 0, 0, 1)
dracut-install: get_real_file('/lib64/libblkid.so')
dracut-install: get_real_file: readlink('/lib64/libblkid.so') returns '/lib64/libblkid.so'
dracut-install: get_real_file('/lib64/libblkid.so') => '/lib64/libblkid.so'
dracut-install: dracut_install('/lib64/libblkid.so', '/lib64/libblkid.so', 0, 0, 1)
/usr/lib/dracut/dracut-init.sh: line 298: 20949 Segmentation fault      (core dumped) $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${initdir:+-D "$initdir"} -a ${loginstall:+-L "$loginstall"} ${DRACUT_RESOLVE_DEPS:+-l} ${DRACUT_FIPS_MODE:+-f} ${_hostonly_install:+-H} "$@"
dracut: FAILED: /usr/lib/dracut/dracut-install --debug -D /var/tmp/dracut.dqLmOS/initramfs -a /lib64/libblkid.so
...
```

After applying this patch:

```
> dracut -f -I "/lib64/libblkid.so" test.img
...
dracut-install: Handle '/lib64/libblkid.so'
dracut-install: dracut_install('/lib64/libblkid.so', '/lib64/libblkid.so', 0, 0, 1)
dracut-install: get_real_file('/lib64/libblkid.so')
dracut-install: get_real_file: readlink('/lib64/libblkid.so') returns '/lib64/libblkid.so'
dracut-install: ERROR: '/lib64/libblkid.so' is pointing to itself.
dracut-install: ERROR: installing '/lib64/libblkid.so'
dracut: FAILED: /usr/lib/dracut/dracut-install --debug -D /var/tmp/dracut.4w8FVL/initramfs -a /lib64/libblkid.so
...
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it