### PR TITLE
feat(install.d) Support ukify for kernel-install

### DIFF
--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -3,6 +3,11 @@
 COMMAND="$1"
 KERNEL_VERSION="$2"
 BOOT_DIR_ABS="$3"
+
+if [[ ${KERNEL_INSTALL_LAYOUT} == "uki" && ${KERNEL_INSTALL_UKI_GENERATOR} == "ukify" ]]; then
+    BOOT_DIR_ABS="${KERNEL_INSTALL_STAGING_AREA}"
+fi
+
 KERNEL_IMAGE="$4"
 
 # If KERNEL_INSTALL_MACHINE_ID is defined but empty, BOOT_DIR_ABS is a fake directory.


### PR DESCRIPTION
This patch allows users to generate UKI with systemd & use dracut for initramfs. 

### How it works
Recently ([commit](https://github.com/systemd/systemd/commit/f3d1d7609d2008086f0f8369d9f842a5c09024b2)) ukify gained ability to add all initrd's placed in $KERNEL_INSTALL_STAGING_AREA to UKI file.
With this patch initrd will be placed in $KERNEL_INSTALL_STAGING_AREA for ukify users, allowing seamless automation with kernel-install.

### Checklist
- [x] I have tested it locally with latest git versions of kernel-install (systemd) & dracut

### Fixes
Need for hacks & hooks to let dracut & ukify get along well