### PR TITLE
feat(Makefile): allow setting dracut version via environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 -include dracut-version.sh
 
-DRACUT_MAIN_VERSION := $(shell env GIT_CEILING_DIRECTORIES=$(CURDIR)/.. git describe --abbrev=0 --tags --always 2>/dev/null || :)
+DRACUT_MAIN_VERSION ?= $(shell env GIT_CEILING_DIRECTORIES=$(CURDIR)/.. git describe --abbrev=0 --tags --always 2>/dev/null || :)
 ifeq ($(DRACUT_MAIN_VERSION),)
 DRACUT_MAIN_VERSION = $(DRACUT_VERSION)
 endif
-DRACUT_FULL_VERSION := $(shell env GIT_CEILING_DIRECTORIES=$(CURDIR)/.. git describe --tags --always 2>/dev/null || :)
+DRACUT_FULL_VERSION ?= $(shell env GIT_CEILING_DIRECTORIES=$(CURDIR)/.. git describe --tags --always 2>/dev/null || :)
 ifeq ($(DRACUT_FULL_VERSION),)
 DRACUT_FULL_VERSION = $(DRACUT_VERSION)
 endif


### PR DESCRIPTION
## Changes

To ease packaging dracut for Debian/Ubuntu, please support setting the dracut main/full version via environment variables:

```
$ DRACUT_MAIN_VERSION=007
$ export DRACUT_FULL_VERSION=007-bond
$ make dracut-version.sh
$ grep VERSION dracut-version.sh
DRACUT_VERSION=007-bond
```

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
