### PR TITLE
docs: set KVERSION for running test suite

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -240,7 +240,7 @@ $ podman run --rm -it \
 # ./configure
 # make -j $(getconf _NPROCESSORS_ONLN)
 # cd test
-# make V=1 SKIP="16 60 61" clean check
+# make KVERSION="$(cd /lib/modules && ls -1 | tail -1)" V=1 SKIP="16 60 61" clean check
 ```
 
 with `[CONTAINER]` being one of the


### PR DESCRIPTION
## Changes

Running the test suite in podman will most likely require setting `KVERSION` because the running Linux kernel version will most likely be different to the kernel version in the container.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
