### PR TITLE
ci: remove unused packages from Debian container

### DIFF
--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -17,7 +17,6 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     cpio \
     cryptsetup \
     curl \
-    dash \
     debhelper \
     debhelper-compat \
     dmraid \

--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -17,8 +17,6 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     cpio \
     cryptsetup \
     curl \
-    debhelper \
-    debhelper-compat \
     dmraid \
     docbook \
     docbook-xml \
@@ -52,7 +50,6 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     pkg-config \
     procps \
     qemu-system-x86 \
-    quilt \
     shellcheck \
     squashfs-tools \
     strace \

--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -49,7 +49,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     pigz \
     pkg-config \
     procps \
-    qemu-system-x86 \
+    qemu-kvm \
     shellcheck \
     squashfs-tools \
     strace \

--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -3,9 +3,7 @@ FROM docker.io/debian:latest
 MAINTAINER https://github.com/dracutdevs/dracut
 
 # Install needed packages for the dracut CI container
-# Install dracut as a linux-initramfs-tool provider so that the default initramfs-tool package does not get installed
-# Uninstall initramfs-tools-core as a workaround for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=994492
-RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --no-install-recommends dracut && \
+RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
     asciidoc \
     astyle \
@@ -60,4 +58,4 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     thin-provisioning-tools \
     vim \
     wget \
-    && apt-get clean && dpkg -P --force-depends dracut dracut-core initramfs-tools-core
+    && apt-get clean


### PR DESCRIPTION
## Changes

Improve the Debian container:

* The dash package is a required that must be present on all Debian systems.
* The debhelper and quilt packages are only needed for packaging dracut.
* To make the list of required packages more architecture independent, replace `qemu-system-x86` by `qemu-kvm` in the Debian Docker image.
* The Debian image uses initramfs-tools for generating the initramfs. Having initramfs-tools installed should not have any effect on running the test suite.

I tested locally that the changed container still successfully runs the tests that the integration test runs.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
