### PR TITLE
fix(test): use bash for jobs -r parameter

### DIFF
--- a/test/TEST-20-NFS/server-init.sh
+++ b/test/TEST-20-NFS/server-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 exec < /dev/console > /dev/console 2>&1
 set -x
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -415,7 +415,7 @@ test_setup() {
     )
     # Make server's dracut image
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
-        -m "dash rootfs-block debug kernel-modules watchdog qemu network network-legacy" \
+        -m "bash rootfs-block debug kernel-modules watchdog qemu network network-legacy" \
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod e1000 i6300esb" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1

--- a/test/TEST-50-MULTINIC/server-init.sh
+++ b/test/TEST-50-MULTINIC/server-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 exec < /dev/console > /dev/console 2>&1
 set -x
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -354,7 +354,7 @@ test_setup() {
     )
     # Make server's dracut image
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
-        -m "dash rootfs-block debug kernel-modules watchdog qemu network network-legacy" \
+        -m "bash rootfs-block debug kernel-modules watchdog qemu network network-legacy" \
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod nfsv2 nfsv3 nfsv4 nfs_acl nfs_layout_nfsv41_files nfsd e1000 i6300esb ib700wdt" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1


### PR DESCRIPTION
## Changes

Test 20 - "NFSv3 root=dhcp DHCP IP:path" fails on Debian with following error message in `server.log`:

```
jobs -rp
/sbin/init: 105: jobs: Illegal option -r
```

The jobs parameter `-r` requires bash.



## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Partially fixes #1901