### PR TITLE
revert(ci): install multipath-tools into openSUSE container

### DIFF
--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -9,5 +9,5 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     sudo kernel dhcp-client qemu-kvm /usr/bin/qemu-system-$(uname -m) e2fsprogs \
     tcpdump iproute iputils kbd NetworkManager btrfsprogs tgt dbus-broker \
     iscsiuio open-iscsi which ShellCheck shfmt procps pigz parted squashfs ntfsprogs \
-    multipath-tools util-linux-systemd systemd-boot \
+    util-linux-systemd systemd-boot \
     && dnf -y remove dracut && dnf -y update && dnf clean all


### PR DESCRIPTION
The way `multipath` works in SUSE distros differs from upstream, causing some tests to fail.

This reverts commit c08ae406bc7c7d815b0911d9429f400719afc2ae.

## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes https://github.com/dracutdevs/dracut/commit/c08ae406
