### PR TITLE
refactor: maintain dracut version in dracut.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,10 @@
--include dracut-version.sh
-
-DRACUT_MAIN_VERSION ?= $(shell env GIT_CEILING_DIRECTORIES=$(CURDIR)/.. git describe --abbrev=0 --tags --always 2>/dev/null || :)
-ifeq ($(DRACUT_MAIN_VERSION),)
-DRACUT_MAIN_VERSION = $(DRACUT_VERSION)
-endif
-DRACUT_FULL_VERSION ?= $(shell env GIT_CEILING_DIRECTORIES=$(CURDIR)/.. git describe --tags --always 2>/dev/null || :)
+DRACUT_FULL_VERSION ?= $(shell ./dracut.sh --version | cut -d' ' -f 2-)
 ifeq ($(DRACUT_FULL_VERSION),)
 DRACUT_FULL_VERSION = $(DRACUT_VERSION)
+endif
+DRACUT_MAIN_VERSION ?= $(shell echo "$(DRACUT_FULL_VERSION)" | sed 's/\([0-9]\+\).*/\1/')
+ifeq ($(DRACUT_MAIN_VERSION),)
+DRACUT_MAIN_VERSION = $(DRACUT_VERSION)
 endif
 
 HAVE_SHELLCHECK ?= $(shell command -v shellcheck >/dev/null 2>&1 && echo yes)
@@ -163,7 +161,6 @@ install: all
 	mkdir -p $(DESTDIR)$(pkglibdir)/dracut.conf.d
 	install -m 0755 dracut-init.sh $(DESTDIR)$(pkglibdir)/dracut-init.sh
 	install -m 0755 dracut-functions.sh $(DESTDIR)$(pkglibdir)/dracut-functions.sh
-	install -m 0755 dracut-version.sh $(DESTDIR)$(pkglibdir)/dracut-version.sh
 	ln -fs dracut-functions.sh $(DESTDIR)$(pkglibdir)/dracut-functions
 	install -m 0755 dracut-logger.sh $(DESTDIR)$(pkglibdir)/dracut-logger.sh
 	install -m 0755 dracut-initramfs-restore.sh $(DESTDIR)$(pkglibdir)/dracut-initramfs-restore

--- a/dracut-version.sh
+++ b/dracut-version.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-# shellcheck disable=SC2034
-DRACUT_VERSION=059

--- a/dracut.sh
+++ b/dracut.sh
@@ -18,6 +18,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+DRACUT_VERSION="059"
+
 # store for logging
 
 unset BASH_ENV
@@ -36,13 +38,6 @@ readonly dracut_cmd=$(readlink -f "$0")
 set -o pipefail
 
 usage() {
-    [[ $sysroot_l ]] && dracutsysrootdir="$sysroot_l"
-    [[ $dracutbasedir ]] || dracutbasedir="$dracutsysrootdir"/usr/lib/dracut
-    if [[ -f $dracutbasedir/dracut-version.sh ]]; then
-        # shellcheck source=./dracut-version.sh
-        . "$dracutbasedir"/dracut-version.sh
-    fi
-
     #                                                   80x25 linebreak here ^
     cat << EOF
 Usage: $dracut_cmd [OPTION]... [<initramfs> [<kernel-version>]]
@@ -63,12 +58,6 @@ EOF
 }
 
 long_usage() {
-    [[ $dracutbasedir ]] || dracutbasedir="$dracutsysrootdir"/usr/lib/dracut
-    if [[ -f $dracutbasedir/dracut-version.sh ]]; then
-        # shellcheck source=./dracut-version.sh
-        . "$dracutbasedir"/dracut-version.sh
-    fi
-
     #                                                   80x25 linebreak here ^
     cat << EOF
 Usage: $dracut_cmd [OPTION]... [<initramfs> [<kernel-version>]]
@@ -290,15 +279,6 @@ For example:
     # dracut --add-drivers "module1 module2"  ...
 
 EOF
-}
-
-long_version() {
-    [[ $dracutbasedir ]] || dracutbasedir="$dracutsysrootdir"/usr/lib/dracut
-    if [[ -f $dracutbasedir/dracut-version.sh ]]; then
-        # shellcheck source=./dracut-version.sh
-        . "$dracutbasedir"/dracut-version.sh
-    fi
-    echo "dracut $DRACUT_VERSION"
 }
 
 # Fills up host_devs stack variable and makes sure there are no duplicates
@@ -854,7 +834,7 @@ while :; do
             machine_id_l="no"
             ;;
         --version)
-            long_version
+            echo "dracut $DRACUT_VERSION"
             exit 0
             ;;
         --)
@@ -1289,11 +1269,6 @@ if [[ $print_cmdline ]]; then
     sysloglvl=0
     fileloglvl=0
     kmsgloglvl=0
-fi
-
-if [[ -f $dracutbasedir/dracut-version.sh ]]; then
-    # shellcheck source=./dracut-version.sh
-    . "$dracutbasedir"/dracut-version.sh
 fi
 
 if systemd-detect-virt -c &> /dev/null; then

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -41,13 +41,13 @@ cat NEWS_header.md NEWS_header_new.md NEWS_body_new.md NEWS_body_with_conttribut
 # message for https://github.com/dracutdevs/dracut/releases/tag
 cat -s NEWS_body_new.md CONTRIBUTORS.md > release.md
 
-# dracut-version.sh
-printf "#!/bin/sh\n# shellcheck disable=SC2034\nDRACUT_VERSION=%s\n" "$NEW_VERSION" > dracut-version.sh
+# Set new dracut version
+sed -i "s/^DRACUT_VERSION=.*$/DRACUT_VERSION=\"${NEW_VERSION}\"/" dracut.sh
 
 # Check in AUTHORS and NEWS.md
 git config user.name "Dracut Release Bot"
 git config user.email "<>"
-git commit -m "docs: update NEWS.md and AUTHORS" NEWS.md AUTHORS dracut-version.sh
+git commit -m "release dracut $NEW_VERSION" NEWS.md AUTHORS dracut.sh
 git push origin master
 git tag "$NEW_VERSION" -m "$NEW_VERSION"
 git push --tags


### PR DESCRIPTION
## Changes

The git release tag does not contain the `dracut-version.sh` file and therefore `git archive` will lack this file as well. The Makefile attempts to populate version information from git tags (which is impossible in an unpacked release tarball) and, failing that, reverts to whatever would be encoded in that file if it were sourced.

Maintain the dracut version directly in `dracut.sh` and call `dracut.sh --version` to get the version number. The version can be changed with a simple sed command to a new version (for releases or for distributors that want to include the packaging version):

```
sed -i "s/^DRACUT_VERSION=.*$/DRACUT_VERSION=\"${NEW_VERSION}\"/" dracut.sh
```

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2169
