### PR TITLE
chore: remove unnecessary shellcheck disable for SC1087

### DIFF
--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -394,7 +394,6 @@ parse_iscsi_root() {
         [[]*[]]:*)
             iscsi_target_ip=${v#[[]}
             iscsi_target_ip=${iscsi_target_ip%%[]]*}
-            # shellcheck disable=SC1087
             v=${v#[[]"$iscsi_target_ip"[]]:}
             ;;
         *)


### PR DESCRIPTION
SC1087 is not listed in shellcheckrc.

This is the only place in the code where SC1087 were silenced.
