### PR TITLE
chore(gitignore): remove switch_root from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 /man/lsinitrd.1
 /dracut.pc
 /dracut-install
-/modules.d/99base/switch_root
 /test/*/test.log
 /test/*/.testdir
 test*.img


### PR DESCRIPTION
modules.d/99base/switch_root use to be a native binary that was built, but not anymore.

