### PR TITLE
fix(dracut.sh): append to kernel cmdline instead of override in uefi

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2482,14 +2482,15 @@ get_sbat_string() {
 if [[ $uefi == yes ]]; then
     if [[ $kernel_cmdline ]]; then
         echo -n "$kernel_cmdline" > "$uefi_outdir/cmdline.txt"
-    elif [[ $hostonly_cmdline == yes ]]; then
+    fi
+    if [[ $hostonly_cmdline == yes ]]; then
         if [ -d "$initdir/etc/cmdline.d" ]; then
             for conf in "$initdir"/etc/cmdline.d/*.conf; do
                 [ -e "$conf" ] || continue
-                printf "%s " "$(< "$conf")" >> "$uefi_outdir/cmdline.txt"
+                printf " %s" "$(< "$conf")" >> "$uefi_outdir/cmdline.txt"
             done
         elif [ -e "/proc/cmdline" ]; then
-            printf "%s " "$(< "/proc/cmdline")" > "$uefi_outdir/cmdline.txt"
+            printf " %s" "$(< "/proc/cmdline")" >> "$uefi_outdir/cmdline.txt"
         fi
     fi
 


### PR DESCRIPTION
Thanks for your great work and please advise if I should open an issue additionally/instead! :)

When creating an EFI executable with both `hostonly_cmdline=yes` and `kernel_cmdline=" quiet "` in the config file, I would expect that both cmdline parameters for my current host and the `quiet` parameters provided in `kernel_cmdline` would be added to the UEFI kernel cmdline.
What happens instead is that `kernel_cmdline=" quiet "` takes priority and overrides any arguments stored due to `hostonly_cmdline=yes`, resulting in overall parameters of only `" quiet "` and thus non-booting executables.

Looking at the docs I get the impression that this is a bug rather than intentional behavior:

>hostonly_cmdline="{yes|no}"
If set to "yes", store the kernel command line arguments needed in the initramfs. If hostonly="yes" and this option is not configured, it’s automatically set to "yes".

>kernel_cmdline="parameters"
Specify default kernel command line parameters.

This change might be considered breaking, since calls with both `hostonly_cmdline=yes` and extra parameters in `kernel_cmdline` will behave differently, e.g. when giving both `hostonly=yes` as well as mount parameters in `kernel_cmdline`?

If needed I could also attempt to clarify the documentation in this regard?

## Changes
For EFI executables, if both `kernel_cmdline` and `hostonly_cmdline` are provided, both are taken into account and appended to the UEFI kernel cmdline instead of `kernel_cmdline` taking priority.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
