### PR TITLE
fix(dracut-initramfs-restore.sh): do not set selinux labels if disabled

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -75,9 +75,12 @@ if [[ -d squash ]]; then
     fi
 fi
 
-if [ -e /etc/selinux/config -a -x /usr/sbin/setfiles ]; then
+if grep -q -w selinux /sys/kernel/security/lsm 2> /dev/null \
+    && [ -e /etc/selinux/config -a -x /usr/sbin/setfiles ]; then
     . /etc/selinux/config
-    [ -n "${SELINUXTYPE}" ] && /usr/sbin/setfiles -v -r /run/initramfs /etc/selinux/"${SELINUXTYPE}"/contexts/files/file_contexts /run/initramfs > /dev/null
+    if [[ $SELINUX != "disabled" && -n $SELINUXTYPE ]]; then
+        /usr/sbin/setfiles -v -r /run/initramfs /etc/selinux/"${SELINUXTYPE}"/contexts/files/file_contexts /run/initramfs > /dev/null
+    fi
 fi
 
 exit 0


### PR DESCRIPTION
Also, it's not enough to check if `SELINUX=disabled` in /etc/selinux/config, because it can be disabled via kernel command line options.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
