### PR TITLE
fix(crypt): Encrypted root FS handling with generic initrd

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -30,6 +30,12 @@ depends() {
         if grep -q "tpm2-device=" "$dracutsysrootdir"/etc/crypttab; then
             deps+=" tpm2-tss"
         fi
+    elif [[ ! $hostonly ]]; then
+        deps+=" fido2 pkcs11"
+        module_check "tpm2-tss" > /dev/null 2>&1
+        if [[ $? == 255 ]]; then
+            deps+=" tpm2-tss"
+        fi
     fi
     echo "$deps"
     return 0

--- a/modules.d/90crypt/parse-crypt.sh
+++ b/modules.d/90crypt/parse-crypt.sh
@@ -174,7 +174,7 @@ else
                 } >> "$hookdir/emergency/90-crypt.sh"
             fi
         done
-    elif getargbool 0 rd.auto; then
+    elif getargbool 1 rd.auto; then
         if [ -z "$DRACUT_SYSTEMD" ]; then
             {
                 printf -- 'ENV{ID_FS_TYPE}=="crypto_LUKS", RUN+="%s ' "$(command -v initqueue)"


### PR DESCRIPTION
This pull request adds missing modules potentially required for disk decryption to a generic initrd. Additionally it changes the default for unlocking LUKS encrypted devices at boot from previously only doing so when rd.auto=1 was specified.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2437 
