### PR TITLE
fix(install.d): do not create initramfs if the supplied image is UKI

### DIFF
--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -11,6 +11,11 @@ if ! [[ ${KERNEL_INSTALL_MACHINE_ID-x} ]]; then
     exit 0
 fi
 
+# Do not attempt to create initramfs if the supplied image is already a UKI
+if [[ "$KERNEL_INSTALL_IMAGE_TYPE" = "uki" ]]; then
+    exit 0
+fi
+
 # Mismatching the install layout and the --uefi/--no-uefi opts just creates a mess.
 if [[ $KERNEL_INSTALL_LAYOUT == "uki" && -n $KERNEL_INSTALL_STAGING_AREA ]]; then
     BOOT_DIR_ABS="$KERNEL_INSTALL_STAGING_AREA"


### PR DESCRIPTION
When the supplied kernel image is a UKI, there's no point in creating initramfs as the UKI has it built-in already. This is the situation when dracut.install is called for a distro shipped UKI.

Note, KERNEL_INSTALL_IMAGE_TYPE == "uki" is different from KERNEL_INSTALL_LAYOUT == "uki", the later can be used to create UKI upon installing a standard kernel image.

This pull request changes...

## Changes

## Checklist
- [ X ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
