### PR TITLE
fix(resume): add new systemd-hibernate-resume.service

### DIFF
--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -44,6 +44,7 @@ install() {
     if dracut_module_included "systemd" && [[ -x $dracutsysrootdir$systemdutildir/systemd-hibernate-resume ]]; then
         inst_multiple -o \
             "$systemdutildir"/system-generators/systemd-hibernate-resume-generator \
+            "$systemdsystemunitdir"/systemd-hibernate-resume.service \
             "$systemdsystemunitdir"/systemd-hibernate-resume@.service \
             "$systemdutildir"/systemd-hibernate-resume
         return 0


### PR DESCRIPTION
Since https://github.com/systemd/systemd/commit/a628d933, the generator only does the initial validation of the system info and then enables the new `systemd-hibernate-resume.service`.

Not tested, but this patch will be required for systemd-v255 based on https://github.com/dracutdevs/dracut/issues/2513#issuecomment-1713597890.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2513
