### PR TITLE
fix(crypt): correct systemd-cryptsetup binary path

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -4,7 +4,7 @@
 check() {
     local fs
     # if cryptsetup is not installed, then we cannot support encrypted devices.
-    require_any_binary "$systemdutildir"/systemd-cryptsetup cryptsetup || return 1
+    require_any_binary systemd-cryptsetup cryptsetup || return 1
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         for fs in "${host_fs_types[@]}"; do
@@ -166,14 +166,13 @@ install() {
         inst_multiple -o \
             "$tmpfilesdir"/cryptsetup.conf \
             "$systemdutildir"/system-generators/systemd-cryptsetup-generator \
-            "$systemdutildir"/systemd-cryptsetup \
             "$systemdsystemunitdir"/systemd-ask-password-console.path \
             "$systemdsystemunitdir"/systemd-ask-password-console.service \
             "$systemdsystemunitdir"/cryptsetup.target \
             "$systemdsystemunitdir"/sysinit.target.wants/cryptsetup.target \
             "$systemdsystemunitdir"/remote-cryptsetup.target \
             "$systemdsystemunitdir"/initrd-root-device.target.wants/remote-cryptsetup.target \
-            systemd-ask-password systemd-tty-ask-password-agent
+            systemd-cryptsetup systemd-ask-password systemd-tty-ask-password-agent
     fi
 
     # Install required libraries.


### PR DESCRIPTION
`systemd-cryptsetup` has been moved from `/usr/lib/systemd` to `/usr/bin/` since https://github.com/systemd/systemd/commit/fb8d67cd.

This patch is not required for systemd-v255, a compat symlink will be provided for now. This PR is just a warning for the future, in case this compat symlink is removed.

## Checklist
- [ ] I have tested it locally, tests using the `crypt` module with a systemd version without the referenced commit are expected to fail.
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
