### PR TITLE
feat(kernel-network-modules): Add Qualcomm IPC router to enable USB

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -95,7 +95,8 @@ installkernel() {
                 "=drivers/usb/misc" \
                 "=drivers/usb/musb" \
                 "=drivers/usb/phy" \
-                "=drivers/scsi/hisi_sas"
+                "=drivers/scsi/hisi_sas" \
+                "=net/qrtr"
         fi
 
         awk -F: '/^\// {print $1}' "$srcmods/modules.dep" 2> /dev/null | instmods


### PR DESCRIPTION
The x13s, and possibly other Qualcomm based devices, need the QC IPC router driver to enable USB. Without it, it's not possible to boot from USB-C attached disks.


## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
