### PR TITLE
fix(dracut-systemd): use `DRACUT_VERSION` instead of `VERSION`

### DIFF
--- a/modules.d/98dracut-systemd/dracut-cmdline.sh
+++ b/modules.d/98dracut-systemd/dracut-cmdline.sh
@@ -6,7 +6,7 @@ fi
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 [ -f /usr/lib/initrd-release ] && . /usr/lib/initrd-release
-[ -n "$VERSION" ] && info "dracut-$VERSION"
+[ -n "$DRACUT_VERSION" ] && info "dracut-$DRACUT_VERSION"
 
 if ! getargbool 1 'rd.hostonly'; then
     [ -f /etc/cmdline.d/99-cmdline-ask.conf ] && mv /etc/cmdline.d/99-cmdline-ask.conf /tmp/99-cmdline-ask.conf


### PR DESCRIPTION
`VERSION` can contain other values unrelated to the dracut version, which garbles the output.

E.g.:

openSUSE Tumbleweed:
```
Oct 10 14:17:58 localhost dracut-cmdline[236]: dracut-dracut-059+suse.501.gc44a365d-1.1
```

Fedora Rawhide:
```
Oct 10 14:00:42 fedora dracut-cmdline[300]: dracut-40 (Workstation Edition Prerelease) dracut-059-12.fc39
```

Arch Linux:
```
Oct 10 14:31:59 localhost dracut-cmdline[159]: dracut-dracut-059
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
