### PR TITLE
fix(install.d): do not generate a new initrd if any INITRD_FILE is provided

### DIFF
--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -4,6 +4,7 @@ COMMAND="$1"
 KERNEL_VERSION="$2"
 BOOT_DIR_ABS="$3"
 KERNEL_IMAGE="$4"
+INITRD_OPTIONS_SHIFT=4
 
 # If KERNEL_INSTALL_MACHINE_ID is defined but empty, BOOT_DIR_ABS is a fake directory.
 # So, let's skip to create initrd.
@@ -48,6 +49,12 @@ ret=0
 
 case "$COMMAND" in
     add)
+        if (($# > INITRD_OPTIONS_SHIFT)); then
+            [[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo \
+                "One or more INITRD_FILEs were provided to the 'add' command, skipping generating a new one"
+            exit 0
+        fi
+
         if [[ $IMAGE == "uki.efi" ]]; then
             IMAGE_PREGENERATED=${KERNEL_IMAGE%/*}/uki.efi
         else


### PR DESCRIPTION
If `kernel-install add` is called specifying one or more INITRD-FILEs, the caller just wants to use these, so there is no point in generating a new one.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
