### PR TITLE
feat(systemd): install systemd-executor

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -34,6 +34,7 @@ install() {
         "$systemdutildir"/systemd \
         "$systemdutildir"/systemd-coredump \
         "$systemdutildir"/systemd-cgroups-agent \
+        "$systemdutildir"/systemd-executor \
         "$systemdutildir"/systemd-shutdown \
         "$systemdutildir"/systemd-reply-password \
         "$systemdutildir"/systemd-fsck \


### PR DESCRIPTION
In [0] systemd gained a new binary - systemd-executor - that's used to spawn processes forked off systemd. Let's copy it into the initrd if it's available.

[0] https://github.com/systemd/systemd/pull/27890

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

/cc @bluca