### PR TITLE
test: skip test 50,60 if ifcfg dracut module can not be installed

### DIFF
--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -7,6 +7,11 @@ TEST_DESCRIPTION="root filesystem on NFS with multiple nics with $USE_NETWORK"
 #DEBUGFAIL="loglevel=7 rd.shell rd.break"
 #SERIAL="tcp:127.0.0.1:9999"
 
+# skip the test if ifcfg dracut module can not be installed
+test_check() {
+    test -d /etc/sysconfig/network-scripts
+}
+
 run_server() {
     # Start server first
     echo "MULTINIC TEST SETUP: Starting DHCP/NFS server"

--- a/test/TEST-60-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-60-BONDBRIDGEVLAN/test.sh
@@ -9,6 +9,11 @@ TEST_DESCRIPTION="root filesystem on NFS with bridging/bonding/vlan with $USE_NE
 #DEBUGFAIL="rd.shell rd.break"
 #SERIAL="tcp:127.0.0.1:9999"
 
+# skip the test if ifcfg dracut module can not be installed
+test_check() {
+    test -d /etc/sysconfig/network-scripts
+}
+
 # Network topology:
 #
 #  .---------------------.    .---------------.


### PR DESCRIPTION
Test 50 and 60 have a dependency on the ifcfg dracut module.
If ifcfg dracut module is not available, than the preconditions
for these tests are not met.
    
Since ifcfg dracut module is not available in many Linux enviroments
(such as Arch or Debian), it make sense to explicitelly skip these
tests instead of failing them as they are simply not applicable
to many Linux distributions in their current form.