### PR TITLE
fix(pcsc): add opensc load module file

### DIFF
--- a/modules.d/91pcsc/module-setup.sh
+++ b/modules.d/91pcsc/module-setup.sh
@@ -29,7 +29,8 @@ install() {
     inst_simple "$moddir/pcscd.socket" "${systemdsystemunitdir}"/pcscd.socket
 
     inst_multiple -o \
-        pcscd
+        pcscd \
+        /usr/share/p11-kit/modules/opensc.module
 
     # Enable systemd type unit(s)
     for i in \


### PR DESCRIPTION
On Fedora, and possibly others, there is a file to load the module `opensc-pkcs11.so`.

In my tests, without this module, you can't unlock a LUKS encrypted volume using a smart card since `pscsd` is not able to establish any communication with it.

The file simply loads `opensc-pkcs11.so` with the following syntax:

`module: opensc-pkcs11.so`

There may be a more efficient way of doing this without having to attempt to add the file from various sources (each distro seems to have this file in different places).

## Changes

This pull request adds the installation statements needed to include the file that loads `opensc-pkcs11.so` on various distributions. I couldn't find where this file lives in Arch Linux. Maybe it's loaded in the configuration directly.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

