### PR TITLE
test(FULL SYSTEMD): no need to include dbus to the target roots

### DIFF
--- a/test/TEST-04-FULL-SYSTEMD/test-init.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test-init.sh
@@ -37,5 +37,4 @@ if getargbool 0 rd.shell; then
     setsid $CTTY sh -i
 fi
 echo "Powering down."
-systemctl --no-block poweroff
-exit 0
+poweroff -f

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -52,7 +52,7 @@ test_setup() {
 
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
-        -m "test-root dbus" \
+        -m "test-root systemd" \
         -I "ldconfig" \
         -i ./test-init.sh /sbin/test-init \
         -i ./fstab /etc/fstab \


### PR DESCRIPTION
systemd does not depend on dbus.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

