### PR TITLE
Improve lsinitrd to ease debugging for developers and end users.

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -233,6 +233,25 @@ list_squash_content() {
     fi
 }
 
+list_cmdline() {
+    # depends on list_squash_content() having run before
+    SQUASH_IMG="squash-root.img"
+    SQUASH_TMPFILE="$TMPDIR/initrd.root.sqsh"
+    SQUASH_EXTRACT="$TMPDIR/squash-extract"
+
+    echo "dracut cmdline:"
+    # shellcheck disable=SC2046
+    $CAT "$image" | cpio --extract --verbose --quiet --to-stdout -- \
+        etc/cmdline.d/\*.conf 2> /dev/null
+    ((ret += $?))
+    if [[ -s $SQUASH_TMPFILE ]]; then
+        unsquashfs -force -d "$SQUASH_EXTRACT" -no-progress "$SQUASH_TMPFILE" etc/cmdline.d/\*.conf > /dev/null 2>&1
+        ((ret += $?))
+        cat "$SQUASH_EXTRACT"/etc/cmdline.d/*.conf 2> /dev/null
+        rm "$SQUASH_EXTRACT"/etc/cmdline.d/*.conf 2> /dev/null
+    fi
+}
+
 unpack_files() {
     SQUASH_IMG="squash-root.img"
     SQUASH_TMPFILE="$TMPDIR/initrd.root.sqsh"
@@ -422,6 +441,8 @@ else
         list_modules
         list_files
         list_squash_content
+        echo
+        list_cmdline
     fi
 fi
 


### PR DESCRIPTION
## Changes to lsinitrd

### enable unpacking files from squash-root.img

This is helpful for debugging some kdump mkdumprd that prefer dracut-squash.

### print stored dracut cmdline

It's more convenient for debugging than extracting or unpacking the corresponding files.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Factored out from another PR (https://github.com/dracutdevs/dracut/pull/2534#issuecomment-1805189234).