### PR TITLE
fix(90kernel-modules): add intel_lpss_pci for MacBook Pro 2017

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -55,7 +55,7 @@ installkernel() {
             "=drivers/watchdog"
 
         instmods \
-            yenta_socket spi_pxa2xx_platform \
+            yenta_socket intel_lpss_pci spi_pxa2xx_platform \
             atkbd i8042 firewire-ohci pcmcia hv-vmbus \
             virtio virtio_ring virtio_pci pci_hyperv \
             "=drivers/pcmcia"


### PR DESCRIPTION
The MacBook Pro 2017 (MacBookPro14,1) connects the keyboard via SPI:

```
$ dmesg
input: Apple SPI Keyboard as /devices/pci0000:00/0000:00:1e.3/pxa2xx-spi.3/spi_master/spi2/spi-APP000D:00/input/input4
```

The SPI controller requires the `intel_lpss_pci` kernel module:

```
$ lspci -vv
00:1e.3 Signal processing controller: Intel Corporation Sunrise Point-LP Serial IO SPI Controller #1 (rev 21)
	Subsystem: Intel Corporation Sunrise Point-LP Serial IO SPI Controller
	Control: I/O- Mem+ BusMaster+ SpecCycle- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx-
	Status: Cap+ 66MHz- UDF- FastB2B- ParErr- DEVSEL=fast >TAbort- <TAbort- <MAbort- >SERR- <PERR- INTx-
	Latency: 0, Cache Line Size: 256 bytes
	Interrupt: pin D routed to IRQ 23
	Region 0: Memory at 9282c000 (64-bit, non-prefetchable) [size=4K]
	Capabilities: [80] Power Management version 3
		Flags: PMEClk- DSI- D1- D2- AuxCurrent=0mA PME(D0-,D1-,D2-,D3hot-,D3cold-)
		Status: D3 NoSoftRst+ PME-Enable- DSel=0 DScale=0 PME-
	Capabilities: [90] Vendor Specific Information: Len=14 <?>
	Kernel driver in use: intel-lpss
	Kernel modules: intel_lpss_pci
```

Fedora builds `intel_lpss_pci` into the kernel:

```
$ grep INTEL_LPSS_PCI /lib/modules/6.5.11-300.fc39.x86_64/config
CONFIG_MFD_INTEL_LPSS_PCI=y
```

But Ubuntu builds `intel_lpss_pci` only as module:

```
$ grep INTEL_LPSS_PCI /boot/config-6.5.0-10-generic
CONFIG_MFD_INTEL_LPSS_PCI=m
```

So explicitly include `intel_lpss_pci` to support the keyboard.

Bug-Ubuntu: https://launchpad.net/bugs/2042710
fixes: df381b7e0cd95f78e40ac70f0f3c96a2fa8dd189 ("feat(kernel-modules): driver support for macbook keyboards")

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
