### PR TITLE
feat(install.d): add sort-key field to rescue BLS entries

### DIFF
--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -38,6 +38,9 @@ fi
 
 [[ -n $PRETTY_NAME ]] || PRETTY_NAME="Linux $KERNEL_VERSION"
 
+SORT_KEY="$IMAGE_ID"
+[[ -z $SORT_KEY ]] && SORT_KEY="$ID"
+
 if [[ ${KERNEL_INSTALL_MACHINE_ID+x} ]]; then
     MACHINE_ID=$KERNEL_INSTALL_MACHINE_ID
 elif [[ -f /etc/machine-id ]]; then
@@ -127,6 +130,7 @@ case "$COMMAND" in
                 echo "title      $PRETTY_NAME - Rescue Image"
                 echo "version    $KERNEL_VERSION"
                 echo "machine-id $MACHINE_ID"
+                [[ -n $SORT_KEY ]] && echo "sort-key   $SORT_KEY"
                 echo "options    ${BOOT_OPTIONS[*]} rd.auto=1"
                 echo "linux      $BOOT_DIR/linux"
                 echo "initrd     $BOOT_DIR/initrd"


### PR DESCRIPTION
The `sort-key` field was added in https://github.com/systemd/systemd/pull/22519 and is used by systemd-boot to sort boot entries. Without it, rescue entries generated by this plugin are not sorted properly.

This patch mimics https://github.com/systemd/systemd/commit/d23b3bfd

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
