### PR TITLE
feat(resume): do not attempt to install systemd-hibernate-resume@.service

### DIFF
--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -44,7 +44,6 @@ install() {
     if dracut_module_included "systemd" && [[ -x $dracutsysrootdir$systemdutildir/systemd-hibernate-resume ]]; then
         inst_multiple -o \
             "$systemdutildir"/system-generators/systemd-hibernate-resume-generator \
-            "$systemdsystemunitdir"/systemd-hibernate-resume@.service \
             "$systemdutildir"/systemd-hibernate-resume
         return 0
     fi


### PR DESCRIPTION
This service is no longer shipped since systemd-v254 (https://github.com/systemd/systemd/commit/760e99bb).

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
