### PR TITLE
ci: Fix Dockerfile-Gentoo for recent systemd-utils change

### DIFF
--- a/test/container/Dockerfile-Gentoo
+++ b/test/container/Dockerfile-Gentoo
@@ -6,7 +6,7 @@ FROM docker.io/gentoo/stage3 as efistub
 COPY --from=portage /var/db/repos/gentoo /var/db/repos/gentoo
 
 # systemd-boot
-RUN echo 'sys-apps/systemd-utils boot' > /etc/portage/package.use/systemd-utils && \
+RUN echo 'sys-apps/systemd-utils boot kernel-install' > /etc/portage/package.use/systemd-utils && \
     emerge -qv sys-apps/systemd-utils
 
 # kernel and its dependencies in a separate builder


### PR DESCRIPTION
systemd-utils can now install kernel-install independently of systemd-boot, but systemd-boot requires that option to be enabled.

## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2554