### PR TITLE
ci: improve manual Github Action

### DIFF
--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -17,6 +17,12 @@ on:
                     - "debian"
                     - "opensuse"
                     - "gentoo"
+            env:
+                description: 'Environment (optional)'
+                default: '{"DEBUGFAIL": "rd.debug"}'
+
+env:
+    ${{ fromJSON(inputs.env) }}
 
 jobs:
     test:

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -5,12 +5,13 @@ on:
         inputs:
             test:
                 description: "Array of tests to run, such as [11,12]"
-                default: "['04']"
+                default: "[]"
             container:
                 type: choice
                 description: 'distro'
-                default: 'fedora'
+                default: 'all'
                 options:
+                    - "all"
                     - "fedora"
                     - "arch"
                     - "debian"
@@ -19,6 +20,8 @@ on:
             env:
                 description: 'Environment (optional)'
                 default: '{"DEBUGFAIL": "rd.debug"}'
+            registry:
+                description: 'Registry for containers, such as ghcr.io/dracutdevs'
 
 env:
     ${{ fromJSON(inputs.env) }}
@@ -27,6 +30,8 @@ jobs:
     matrix:
         runs-on: ubuntu-latest
         outputs:
+            registry: ${{ steps.set-matrix.outputs.registry }}
+            container: ${{ steps.set-matrix.outputs.container }}
             tests: ${{ steps.set-matrix.outputs.tests }}
         steps:
             -   name: "Checkout Repository"
@@ -36,22 +41,31 @@ jobs:
             -   id: set-matrix
                 name: "Set Matrix"
                 run: |
+                     [[ "${{ inputs.registry }}" != '' ]] && echo "registry=\"${{ inputs.registry }}\"" >> $GITHUB_OUTPUT \
+                     || ( echo "registry=\"ghcr.io/${{ github.repository_owner }}\"" >> $GITHUB_OUTPUT )
+                     [[ "${{ inputs.container }}" != 'all' ]] && echo "container=[\"${{ inputs.container }}\"]" >> $GITHUB_OUTPUT \
+                     || ( containers=$(find test/container -name "Dockerfile-*" | cut -d\- -f2 | tr '[:upper:]' '[:lower:]' | sed -z 's/\n/","/g'); echo "container=[\"${containers%??}]" >> $GITHUB_OUTPUT )
                      [[ "${{ toJson(fromJson(inputs.test)) }}" != '[]' ]] && echo "tests=${{ inputs.test }}" >> $GITHUB_OUTPUT \
                      || ( tests=$(find test -type d -a -name "TEST-*" | cut -d\- -f2 | sed -z 's/\n/","/g' ); echo "tests=[\"${tests%??}]" >> $GITHUB_OUTPUT )
     test:
         needs: matrix
         runs-on: ubuntu-latest
         timeout-minutes: 45
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+            cancel-in-progress: true
         strategy:
             matrix:
+                container: ${{ fromJSON(needs.matrix.outputs.container) }}
                 test: ${{ fromJSON(needs.matrix.outputs.tests) }}
+            fail-fast: false
         container:
-            image: ghcr.io/dracutdevs/${{ inputs.container }}
+            image: ${{ fromJSON(needs.matrix.outputs.registry) }}/${{ matrix.container }}
             options: "--privileged -v /dev:/dev"
         steps:
             -   name: "Checkout Repository"
                 uses: actions/checkout@v1
                 with:
                     fetch-depth: 0
-            -   name: "${{ inputs.container }} ${{ matrix.test }}"
+            -   name: "${{ matrix.container }} ${{ matrix.test }}"
                 run: ./tools/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -6,7 +6,6 @@ on:
             test:
                 description: "Array of tests to run, such as [11,12]"
                 default: "['04']"
-                required: true
             container:
                 type: choice
                 description: 'distro'
@@ -25,12 +24,27 @@ env:
     ${{ fromJSON(inputs.env) }}
 
 jobs:
+    matrix:
+        runs-on: ubuntu-latest
+        outputs:
+            tests: ${{ steps.set-matrix.outputs.tests }}
+        steps:
+            -   name: "Checkout Repository"
+                uses: actions/checkout@v1
+                with:
+                    fetch-depth: 0
+            -   id: set-matrix
+                name: "Set Matrix"
+                run: |
+                     [[ "${{ toJson(fromJson(inputs.test)) }}" != '[]' ]] && echo "tests=${{ inputs.test }}" >> $GITHUB_OUTPUT \
+                     || ( tests=$(find test -type d -a -name "TEST-*" | cut -d\- -f2 | sed -z 's/\n/","/g' ); echo "tests=[\"${tests%??}]" >> $GITHUB_OUTPUT )
     test:
+        needs: matrix
         runs-on: ubuntu-latest
         timeout-minutes: 45
         strategy:
             matrix:
-                test: ${{ fromJSON(inputs.test) }}
+                test: ${{ fromJSON(needs.matrix.outputs.tests) }}
         container:
             image: ghcr.io/dracutdevs/${{ inputs.container }}
             options: "--privileged -v /dev:/dev"


### PR DESCRIPTION
The main motivation is to help facilitate development of dracut using GitHub infra.

As the number of tests and number of containers grow, we could consider running less tests automatically on each PR and only run them on demand with the manual Github Action.

Running manual tests has the benefit of having the log available for everyone to see after the run, and saves the time of manually creating distro environments and uploading test logs.

1./ This commit enables setting environment variables before running the test. More specifically it sets rd.debug for manual builds by default, which can be turned off by simply clearing the "Enviroment" input (see screenshot below).

This change would allow to debug issues like #2225 on GitHub.

It also allows setting networking to e.g. systemd-networked ( {"USE_NETWORK": "systemd-networkd"} ) without changing a single line of code for e.g. #2141

2./ This commit allows to run all the test parallel. It uses "find" to compute the list of tests, so if we add new tests we do not need to update this list.

3./ This commit allows to run all test(s) in all containers in parallel using the new "all" entry. It uses "find" to compute the list of containers, so if we add new containers we do not need to update this list.