### PR TITLE
test: NFS tests need exportfs

### DIFF
--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -3,6 +3,10 @@
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on NFS with $USE_NETWORK"
 
+test_check() {
+    command -v exportfs &> /dev/null
+}
+
 # Uncomment this to debug failures
 #DEBUGFAIL="rd.debug loglevel=7 rd.break=initqueue rd.shell"
 SERVER_DEBUG="rd.debug loglevel=7"


### PR DESCRIPTION
Since exportfs is not a requirement for the nfs dracut module, it is good to list it as an explicit requirement for the test.
