### PR TITLE
fix(dracut.sh): build in microcode blobs by default

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -119,7 +119,6 @@ Creates initial ramdisk images for preloading modules
   --kernel-only         Only install kernel drivers and firmware files.
   --no-kernel           Do not install kernel drivers and firmware files.
   --print-cmdline       Print the kernel command line for the given disk layout.
-  --early-microcode     Combine early microcode with ramdisk.
   --no-early-microcode  Do not combine early microcode with ramdisk.
   --kernel-cmdline [PARAMETERS]
                         Specify default kernel command line parameters.
@@ -457,7 +456,6 @@ rearrange_params() {
             --long regenerate-all \
             --long parallel \
             --long noimageifnotneeded \
-            --long early-microcode \
             --long no-early-microcode \
             --long reproducible \
             --long no-reproducible \
@@ -732,9 +730,6 @@ while :; do
             hostonly_l="yes"
             kernel_only="yes"
             no_kernel="yes"
-            ;;
-        --early-microcode)
-            early_microcode_l="yes"
             ;;
         --no-early-microcode)
             early_microcode_l="no"
@@ -1561,20 +1556,16 @@ fi
 
 if [[ $early_microcode == yes ]]; then
     if [[ $hostonly ]]; then
-        if [[ $(get_cpu_vendor) == "AMD" || $(get_cpu_vendor) == "Intel" ]]; then
-            check_kernel_config CONFIG_MICROCODE || unset early_microcode
-        else
+        if [[ $(get_cpu_vendor) != "AMD" && $(get_cpu_vendor) != "Intel" ]]; then
             unset early_microcode
         fi
-    else
-        ! check_kernel_config CONFIG_MICROCODE \
-            && unset early_microcode
     fi
+
     # Do not complain on non-x86 architectures as it makes no sense
     case "${DRACUT_ARCH:-$(uname -m)}" in
         x86_64 | i?86)
             [[ $early_microcode != yes ]] \
-                && dwarn "Disabling early microcode, because kernel does not support it. CONFIG_MICROCODE!=y"
+                && dwarn "Disabling early microcode, unsupported configuration"
             ;;
         *) ;;
     esac

--- a/shell-completion/bash/dracut
+++ b/shell-completion/bash/dracut
@@ -31,7 +31,7 @@ _dracut() {
             --lvmconf --nolvmconf --debug --profile --verbose --quiet
             --local --hostonly --no-hostonly --fstab --help --bzip2 --lzma
             --xz --zstd --no-compress --gzip --list-modules --show-modules --keep
-            --printsize --regenerate-all --noimageifnotneeded --early-microcode
+            --printsize --regenerate-all --noimageifnotneeded
             --no-early-microcode --print-cmdline --reproducible --uefi
             --enhanced-cpio --rebuild --aggressive-strip --hostonly-cmdline
             --no-hostonly-cmdline --no-hostonly-default-device --nofscks


### PR DESCRIPTION
Simply build them in unconditionally. Considering the ubiquitous impact of CPU hw vulnerabilities and a lot of them being addressed by microcode or requiring microcode to apply the needed mitigations, microcode practically gets included on the majority of setups.

If anyone cares about initrd size, one can still use dracut's

  --no-early-microcode

option to prevent that.

Drop the now not needed --early-microcode option too.

For more background info on the whole topic, follow this thread:

https://lore.kernel.org/all/c67bd324-cec0-4fe4-b3b1-fc1d1e4f2967@leemhuis.info/

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
