### PR TITLE
Make rd.udev.debug work in systemd-based initrds

### DIFF
--- a/modules.d/01systemd-udevd/module-setup.sh
+++ b/modules.d/01systemd-udevd/module-setup.sh
@@ -109,4 +109,5 @@ install() {
     _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"libudev.so.*"
 
+    inst udev-debug-generator.sh "$systemdsystemconfdir"/system-generators/udev-debug-generator.sh
 }

--- a/modules.d/01systemd-udevd/udev-debug-generator.sh
+++ b/modules.d/01systemd-udevd/udev-debug-generator.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+getargbool 0 rd.udev.debug -d -y rdudevdebug && cat > "$1" <<EOF
+[Service]
+LogLevelMax=debug
+EOF


### PR DESCRIPTION
This makes `rd.udev.debug` work in systemd-based initrds too.

## Changes

A systemd generator is added that sets log level of `systemd-udevd.service` to debug if `rd.udev.debug` is present on the kernel command line.

## Note

`rd.udev.info` is ignored as that's the default log level of udevd. The existence of this option makes some sense in the legacy `init.sh`, as it sets the log level of udevd to `err` by default, but I don't think we want to go this way...

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it