### PR TITLE
refactor(nfs): remove leftover code

### DIFF
--- a/modules.d/95nfs/module-setup.sh
+++ b/modules.d/95nfs/module-setup.sh
@@ -128,11 +128,5 @@ install() {
     grep -E '^nfsnobody:|^rpc:|^rpcuser:' "$dracutsysrootdir"/etc/passwd >> "$initdir/etc/passwd"
     grep -E '^nogroup:|^rpc:|^nobody:' "$dracutsysrootdir"/etc/group >> "$initdir/etc/group"
 
-    # rpc user needs to be able to write to this directory to save the warmstart
-    # file
-    chmod 770 "$initdir/var/lib/rpcbind"
-    grep -q '^rpc:' "$dracutsysrootdir"/etc/passwd \
-        && grep -q '^rpc:' "$dracutsysrootdir"/etc/group
-
     dracut_need_initqueue
 }

--- a/modules.d/95nfs/parse-nfsroot.sh
+++ b/modules.d/95nfs/parse-nfsroot.sh
@@ -123,6 +123,8 @@ root="$fstype"
 # shellcheck disable=SC2016
 echo '[ -e $NEWROOT/proc ]' > "$hookdir"/initqueue/finished/nfsroot.sh
 
+# rpc user needs to be able to write to this directory to save the warmstart
+# file
 mkdir -p /var/lib/rpcbind
 chown rpc:rpc /var/lib/rpcbind
 chmod 770 /var/lib/rpcbind


### PR DESCRIPTION
- Leftover `grep`s used when `chown` was perfomed after them.
- `$initdir/var/lib/rpcbind` already created with `mkdir -m 0770`, it is not necessary to `chmod 770` again.

Follow-up to 5ebf48d2baa7d7cbad7cfc663319f8ca80f76398

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
