### PR TITLE
fix(configure): misleading error if C compiler is not installed

### DIFF
--- a/configure
+++ b/configure
@@ -60,6 +60,11 @@ if ! ${PKG_CONFIG} --exists --print-errors " libkmod >= 23 "; then
     exit 1
 fi
 
+if ! command -v "${CC}" > /dev/null; then
+    echo "dracut needs a C compiler (${CC} not found)." >&2
+    exit 1
+fi
+
 cat << EOF > conftest.c
 #include <fts.h>
 int main() {


### PR DESCRIPTION
While preparing a new system for development, `./configure` reaches a point where it fails with:

```
$ ./configure
dracut needs fts development files.
```

After installing the fts library, `./configure` keeps throwing the same error:

```
$ rpm -qf /usr/include/fts.h
glibc-devel-2.38-6.1.x86_64
$ ./configure
dracut needs fts development files.
```

The problem is `${CC} $CFLAGS $LDFLAGS conftest.c` can also fail if the compiler referenced by `$CC` is not installed.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it