### PR TITLE
fix: do not use modprobe --all

### DIFF
--- a/modules.d/95fcoe/parse-fcoe.sh
+++ b/modules.d/95fcoe/parse-fcoe.sh
@@ -23,7 +23,7 @@ if ! getargbool 1 rd.fcoe -d -n rd.nofcoe; then
     return 0
 fi
 
-if ! [ -e /sys/bus/fcoe/ctlr_create ] && ! modprobe -b -a fcoe && ! modprobe -b -a libfcoe; then
+if ! [ -e /sys/bus/fcoe/ctlr_create ] && ! modprobe -b fcoe && ! modprobe -b libfcoe; then
     die "FCoE requested but kernel/initrd does not support FCoE"
 fi
 

--- a/modules.d/95iscsi/parse-iscsiroot.sh
+++ b/modules.d/95iscsi/parse-iscsiroot.sh
@@ -95,7 +95,11 @@ if ! [ -e /sys/module/iscsi_tcp ]; then
     modprobe -b -q iscsi_tcp || die "iscsiroot requested but kernel/initrd does not support iscsi"
 fi
 
-modprobe --all -b -q qla4xxx cxgb3i cxgb4i bnx2i be2iscsi
+modprobe -b -q qla4xxx
+modprobe -b -q cxgb3i
+modprobe -b -q cxgb4i
+modprobe -b -q bnx2i
+modprobe -b -q be2iscsi
 
 if [ -n "$netroot" ] && [ "$root" != "/dev/root" ] && [ "$root" != "dhcp" ]; then
     if ! getargbool 1 rd.neednet > /dev/null || ! getarg "ip="; then

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -236,7 +236,9 @@ if ! getargbool 0 rd.nvmf.nonbft; then
     done
 fi
 
-initqueue --onetime modprobe --all -b -q nvme_tcp nvme_core nvme_fabrics
+initqueue --onetime modprobe -b -q nvme_tcp
+initqueue --onetime modprobe -b -q nvme_core
+initqueue --onetime modprobe -b -q nvme_fabrics
 
 parse_nvmf_discover() {
     traddr="none"

--- a/test/TEST-60-BONDBRIDGEVLAN/server-init.sh
+++ b/test/TEST-60-BONDBRIDGEVLAN/server-init.sh
@@ -64,7 +64,7 @@ ip link set dev enx525401123457 name net2
 ip link set dev enx525401123458 name net3
 ip link set dev enx525401123459 name net4
 
-modprobe --all -b -q 8021q bonding
+modprobe -b -q 8021q && modprobe -b -q bonding
 : > /dev/watchdog
 
 ip addr add 127.0.0.1/8 dev lo


### PR DESCRIPTION
busybox modprobe does not support the --all flag.

This is an issue not only when busybox dracut module is included but also potentially when squash module is used (e.g. for kdumps).

Fixes #2581
