### PR TITLE
fix(systemd-255): handle systemd-pcrphase -> systemd-pcrextend

### DIFF
--- a/modules.d/01systemd-pcrphase/module-setup.sh
+++ b/modules.d/01systemd-pcrphase/module-setup.sh
@@ -6,7 +6,11 @@
 check() {
 
     # If the binary(s) requirements are not fulfilled the module can't be installed.
-    require_binaries "$systemdutildir"/systemd-pcrphase || return 1
+    # systemd-255 renamed the binary, check for old and new location.
+    if ! require_binaries "$systemdutildir"/systemd-pcrphase && \
+       ! require_binaries "$systemdutildir"/systemd-pcrextend; then
+       return 1
+    fi
 
     # Return 255 to only include the module, if another module requires it.
     return 255
@@ -28,6 +32,7 @@ install() {
 
     inst_multiple -o \
         "$systemdutildir"/systemd-pcrphase \
+        "$systemdutildir"/systemd-pcrextend \
         "$systemdsystemunitdir"/systemd-pcrphase-initrd.service \
         "$systemdsystemunitdir/systemd-pcrphase-initrd.service.d/*.conf" \
         "$systemdsystemunitdir"/initrd.target.wants/systemd-pcrphase-initrd.service


### PR DESCRIPTION
In systemd 255 systemd-pcrphase was renamed to systemd-pcrextend; there was no other change to it, just the rename.

Unit scripts are still named systemd-pcrphase, just the underlying binary got renamed.  Thus adapt the module
to check for either binary.

## Changes

Adds awareness of systemd-pcrextend binary allowing systemd-pcrphase module to work with systemd-255.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- []  I am providing new code and test(s) for it
// copy/rename of existing code, and existing lacks tests...

Fixes #2583 
