### PR TITLE
fix(dracut.sh): do not add device if `find_block_device` returns an error

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1666,7 +1666,7 @@ if [[ $hostonly ]] && [[ $hostonly_default_device != "no" ]]; then
         "/boot/zipl"; do
         mp=$(readlink -f "$dracutsysrootdir$mp")
         mountpoint "$mp" > /dev/null 2>&1 || continue
-        _dev=$(find_block_device "$mp")
+        _dev=$(find_block_device "$mp") || continue
         _bdev=$(readlink -f "/dev/block/$_dev")
         [[ -b $_bdev ]] && _dev=$_bdev
         [[ $mp == "/" ]] && root_devs+=("$_dev")

--- a/dracut.sh
+++ b/dracut.sh
@@ -305,6 +305,7 @@ long_version() {
 push_host_devs() {
     local _dev
     for _dev in "$@"; do
+        [[ -z $_dev ]] && continue
         [[ " ${host_devs[*]} " == *" $_dev "* ]] && return
         host_devs+=("$_dev")
     done


### PR DESCRIPTION
If `find_block_device` returns an error, the device must not be added to the list of host devices. E.g., a system with /etc mounted as overlay is pushing the empty string '' as host device.

```
//usr/bin/dracut@1658(): readlink -f /etc
/usr/bin/dracut@1658(): mp=/etc
/usr/bin/dracut@1659(): mountpoint /etc
//usr/bin/dracut@1660(): find_block_device /etc
//usr/lib/dracut/dracut-functions.sh@366(find_block_device): local _dev _majmin _find_mpt
//usr/lib/dracut/dracut-functions.sh@367(find_block_device): _find_mpt=/etc
//usr/lib/dracut/dracut-functions.sh@369(find_block_device): [[ '' != yes ]]
//usr/lib/dracut/dracut-functions.sh@370(find_block_device): [[ -d /etc/. ]]
//usr/lib/dracut/dracut-functions.sh@371(find_block_device): findmnt -e -v -n -o MAJ:MIN,SOURCE --target /etc
//usr/lib/dracut/dracut-functions.sh@372(find_block_device): read -r _majmin _dev
//usr/lib/dracut/dracut-functions.sh@373(find_block_device): [[ -b overlay ]]
//usr/lib/dracut/dracut-functions.sh@384(find_block_device): [[ overlay == *:* ]]
//usr/lib/dracut/dracut-functions.sh@372(find_block_device): read -r _majmin _dev
//usr/lib/dracut/dracut-functions.sh@372(find_block_device): '[' -n '' ']'
//usr/lib/dracut/dracut-functions.sh@389(find_block_device): return 1
//usr/lib/dracut/dracut-functions.sh@393(find_block_device): [[ ! -f /etc/fstab ]]
//usr/lib/dracut/dracut-functions.sh@395(find_block_device): findmnt -e --fstab -v -n -o MAJ:MIN,SOURCE --target /etc
//usr/lib/dracut/dracut-functions.sh@396(find_block_device): read -r _majmin _dev
//usr/lib/dracut/dracut-functions.sh@397(find_block_device): [[ -n '' ]]
//usr/lib/dracut/dracut-functions.sh@398(find_block_device): _dev=overlay
//usr/lib/dracut/dracut-functions.sh@399(find_block_device): unset _majmin
//usr/lib/dracut/dracut-functions.sh@401(find_block_device): [[ -b overlay ]]
//usr/lib/dracut/dracut-functions.sh@410(find_block_device): [[ overlay == *:* ]]
//usr/lib/dracut/dracut-functions.sh@396(find_block_device): read -r _majmin _dev
//usr/lib/dracut/dracut-functions.sh@396(find_block_device): '[' -n '' ']'
//usr/lib/dracut/dracut-functions.sh@415(find_block_device): return 1
//usr/lib/dracut/dracut-functions.sh@418(find_block_device): return 1
/usr/bin/dracut@1660(): _dev=
//usr/bin/dracut@1661(): readlink -f /dev/block/
/usr/bin/dracut@1661(): _bdev=/dev/block
/usr/bin/dracut@1662(): [[ -b /dev/block ]]
/usr/bin/dracut@1663(): [[ /etc == \/ ]]
/usr/bin/dracut@1664(): push_host_devs ''
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2592
