### PR TITLE
Remove False Positive Errors When Using 'livenet' And Squashfs

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -59,27 +59,32 @@ get_check_dev() {
     echo "$_udevinfo" | grep "DEVNAME=" | sed 's/DEVNAME=//'
 }
 
-# Find the right device to run check on
-check_dev=$(get_check_dev "$livedev")
-# CD/DVD media check
-[ -b "$check_dev" ] && fs=$(det_fs "$check_dev")
-if [ "$fs" = "iso9660" -o "$fs" = "udf" ]; then
-    check="yes"
-fi
-getarg rd.live.check -d check || check=""
-if [ -n "$check" ]; then
-    type plymouth > /dev/null 2>&1 && plymouth --hide-splash
-    if [ -n "$DRACUT_SYSTEMD" ]; then
-        p=$(dev_unit_name "$check_dev")
-        systemctl start checkisomd5@"${p}".service
-    else
-        checkisomd5 --verbose "$check_dev"
+# Check ISO checksum only if we have a path to a block device (or just its name
+# without '/dev'). In other words, in this context, we perform the check only
+# if the given $livedev is not a filesystem file image.
+if [ ! -f "$livedev" ]; then
+    # Find the right device to run check on
+    check_dev=$(get_check_dev "$livedev")
+    # CD/DVD media check
+    [ -b "$check_dev" ] && fs=$(det_fs "$check_dev")
+    if [ "$fs" = "iso9660" -o "$fs" = "udf" ]; then
+        check="yes"
     fi
-    if [ $? -eq 1 ]; then
-        die "CD check failed!"
-        exit 1
+    getarg rd.live.check -d check || check=""
+    if [ -n "$check" ]; then
+        type plymouth > /dev/null 2>&1 && plymouth --hide-splash
+        if [ -n "$DRACUT_SYSTEMD" ]; then
+            p=$(dev_unit_name "$check_dev")
+            systemctl start checkisomd5@"${p}".service
+        else
+            checkisomd5 --verbose "$check_dev"
+        fi
+        if [ $? -eq 1 ]; then
+            die "CD check failed!"
+            exit 1
+        fi
+        type plymouth > /dev/null 2>&1 && plymouth --show-splash
     fi
-    type plymouth > /dev/null 2>&1 && plymouth --show-splash
 fi
 
 ln -s "$livedev" /run/initramfs/livedev

--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -109,7 +109,7 @@ if [ -f "$livedev" ]; then
         auto) die "cannot mount live image (unknown filesystem type)" ;;
         *) FSIMG=$livedev ;;
     esac
-    [ -e /sys/fs/"$fstype" ] || modprobe "$fstype"
+    load_fstype "$fstype"
 else
     livedev_fstype=$(det_fs "$livedev")
     if [ "$livedev_fstype" = "squashfs" ]; then


### PR DESCRIPTION
This pull request changes...

## Changes
Remove the following false positive error messages when using a squashfs image using the livenet module
- `modprobe` can't `squashfs` driver when actually it is built-in in the kernel
- `dmsquash-live-root` trying to verify the ISO checksum for a squashfs filesystem file image
- 
## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
- One fix was provided and integrated long ago, but it got broken again. See https://github.com/dracutdevs/dracut/commit/d0cd7cd38711b5425777c3b1595dbf4288beaa23
