### PR TITLE
feat(dracut-initramfs-restore.sh): get compression method from image

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -18,11 +18,15 @@ trap 'echo "Received SIGTERM signal, ignoring!" >&2' TERM
 
 mount -o ro /boot &> /dev/null || true
 
-# shellcheck disable=SC2119
-IMG="$(get_default_initramfs_image)"
-if [[ -z $IMG ]]; then
-    echo "No initramfs image found to restore!" >&2
-    exit 1
+if [[ -f /sys/firmware/initrd ]]; then
+    IMG="/sys/firmware/initrd"
+else
+    # shellcheck disable=SC2119
+    IMG="$(get_default_initramfs_image)"
+    if [[ -z $IMG ]]; then
+        echo "No initramfs image found to restore!" >&2
+        exit 1
+    fi
 fi
 
 # check if initramfs image contains early microcode and skip it

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -111,6 +111,8 @@ if [[ $1 ]]; then
         usage
         exit 1
     fi
+elif [[ $KERNEL_VERSION == "$(uname -r)" ]] && [[ -f /sys/firmware/initrd ]]; then
+    image="/sys/firmware/initrd"
 else
     image="$(get_default_initramfs_image "$KERNEL_VERSION")"
 fi
@@ -238,7 +240,7 @@ if ((${#filenames[@]} <= 0)) && [[ -z $unpack ]] && [[ -z $unpackearly ]]; then
         fi
     else
         echo -n "Image: $image: "
-        du -h "$image" | while read -r a _ || [ -n "$a" ]; do echo "$a"; done
+        du -bh "$image" | while read -r a _ || [ -n "$a" ]; do echo "$a"; done
     fi
 
     echo "========================================================================"

--- a/man/lsinitrd.1.asc
+++ b/man/lsinitrd.1.asc
@@ -17,8 +17,11 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-lsinitrd shows the contents of an initramfs image. if <image> is omitted, then
-lsinitrd uses the default image _/efi/<machine-id>/<kernel-version>/initrd_,
+lsinitrd shows the contents of an initramfs image. If <image> is omitted and
+_<kernel version>_ is omitted or equal to the running kernel version,
+then lsinitrd uses _/sys/firmware/initrd_ if it exists. Otherwise, if <image>
+is omitted, then lsinitrd uses the default image
+_/efi/<machine-id>/<kernel-version>/initrd_,
 _/boot/<machine-id>/<kernel-version>/initrd_,
 _/boot/efi/<machine-id>/<kernel-version>/initrd_,
 _/lib/modules/<kernel-version>/initrd_ or


### PR DESCRIPTION
Instead of trying every possible compression method until the right one is found, parse the header of the initramfs image to get the right one and use it without hiding possible decompression errors, using the same logic that is implemented in `lsinitrd.sh`.

For that, refactor `lsinitrd.sh` moving common code to `dracut-functions.sh`. In particular:
- `get_machine_id`
- `get_default_initramfs_image [<kernel_version>]`
- `has_early_microcode <initramfs_image>`
- `get_decompression_command <initramfs_image_header>`

Also, added a new `get_dollar_boot` function to get the `$BOOT` partition placeholder, as defined in the [Boot Loader Specification](https://uapi-group.org/specifications/specs/boot_loader_specification). If `bootctl` is available, use it to support a possible XBOOTLDR partition, otherwise, check only the ESP, as before.

Also refactored `dracut.sh` using these new functions to get the `outfile` path.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
