### PR TITLE
feat(tpm2-tss): add tpm2.target and systemd-tpm2-generator

### DIFF
--- a/modules.d/91tpm2-tss/module-setup.sh
+++ b/modules.d/91tpm2-tss/module-setup.sh
@@ -35,6 +35,8 @@ install() {
         "$sysusers"/tpm2-tss.conf \
         "$tmpfilesdir"/tpm2-tss-fapi.conf \
         "$udevrulesdir"/60-tpm-udev.rules \
+        "$systemdutildir"/system-generators/systemd-tpm2-generator \
+        "$systemdsystemunitdir/tpm2.target" \
         tpm2_pcrread tpm2_pcrextend tpm2_createprimary tpm2_createpolicy \
         tpm2_create tpm2_load tpm2_unseal tpm2
 


### PR DESCRIPTION
https://github.com/systemd/systemd/commit/4e1f0037 added a new `tpm2.target`, which is now used by `systemd-pcrphase-initrd.service`, and `systemd-tpm2-generator`, which adds a `Wants=` dependency from `sysinit.target` to `tpm2.target` when it detects that the firmware discovered a TPM2 device but the kernel didn't.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

