### PR TITLE
fix(dracut.sh): give warning if drivers, force_drivers or filesystems…

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1951,6 +1951,10 @@ if [[ $no_kernel != yes ]]; then
     fi
 
     if [[ $drivers ]]; then
+        if [[ -z ${drivers// /} ]]; then
+            dwarn "drivers is empty, dracut may be blocked."
+        fi
+
         # shellcheck disable=SC2086
         hostonly='' instmods $drivers
     fi
@@ -1960,6 +1964,10 @@ if [[ $no_kernel != yes ]]; then
         hostonly='' instmods -c $add_drivers
     fi
     if [[ $force_drivers ]]; then
+        if [[ -z ${force_drivers// /} ]]; then
+            dwarn "force_drivers is empty, dracut may be blocked."
+        fi
+
         # shellcheck disable=SC2086
         hostonly='' instmods -c $force_drivers
         rm -f "$initdir"/etc/cmdline.d/20-force_driver.conf
@@ -1968,6 +1976,10 @@ if [[ $no_kernel != yes ]]; then
         done
     fi
     if [[ $filesystems ]]; then
+        if [[ -z ${filesystems// /} ]]; then
+            dwarn "force_drivers is empty, dracut may be blocked."
+        fi
+
         # shellcheck disable=SC2086
         hostonly='' instmods -c $filesystems
     fi


### PR DESCRIPTION
… is empty

If drivers, force_drivers or filesystems is empty, dracut may be blocked. Thus give warning to indicate users to manually interrupt.

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes https://github.com/dracutdevs/dracut/issues/2579
