### PR TITLE
fix(dmsquash-live): use the overlay size with thin provisioning

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -296,7 +296,7 @@ do_live_overlay() {
         dmsetup message /dev/mapper/live-overlay-pool 0 "create_thin 0"
 
         # Create a snapshot of the base image
-        echo 0 "$sz" thin /dev/mapper/live-overlay-pool 0 "$base" | dmsetup create live-rw
+        echo 0 "$thin_data_sz" thin /dev/mapper/live-overlay-pool 0 "$base" | dmsetup create live-rw
     elif [ -z "$overlayfs" ]; then
         echo 0 "$sz" snapshot "$base" "$over" PO 8 | dmsetup create live-rw
     fi


### PR DESCRIPTION
Using the overlay size in the device mapper table allows the filesystem in the base image to be extended at runtime if the overlay is larger than the base image (i.e. this makes `resize2fs /dev/mapper/live-rw` work when `rd.live.overlay.thin` is used).

This pull request changes...

## Changes

This patch changes the upper-bound of the `live-rw` device when the user requests to create a thin-provisioned overlay by specifying the `rd.live.overlay.thin` kernel parameter. The size of the overlay (typically 32GiB, but it can be specified by the user with a kernel parameter) is used rather than the size of the base image.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #

Users of Fedora Linux have been reporting this bug here: https://discussion.fedoraproject.org/t/fedora-liveos-root-system-and-available-ram/82531/1