### PR TITLE
Prevent assembly of unwanted MD RAID arrays

### DIFF
--- a/modules.d/90mdraid/module-setup.sh
+++ b/modules.d/90mdraid/module-setup.sh
@@ -114,7 +114,7 @@ install() {
     fi
 
     inst_hook pre-udev 30 "$moddir/mdmon-pre-udev.sh"
-    inst_hook pre-trigger 30 "$moddir/parse-md.sh"
+    inst_hook pre-udev 40 "$moddir/parse-md.sh"
     inst_hook pre-mount 10 "$moddir/mdraid-waitclean.sh"
     inst_hook cleanup 99 "$moddir/mdraid-needshutdown.sh"
     inst_hook shutdown 30 "$moddir/md-shutdown.sh"


### PR DESCRIPTION
The mdraid module modifies the 65-md-incremental-imsm.rules  during the pre-trigger phase.  Before modification, this rule will start any RAID; after modification, this rule will start only the RAID passed in with rd.md.uuid.  Because this modification occurs while udevd is running, unwanted MD arrays may be assembled if any of their component drives are enumerated before modification.

To prevent unwanted MD devices from being assembled, the modification of 65-md-incremental-imsm.rules should occur before udev is started.

This pull request changes 90mdraid/module-setup.sh so that 90mdraid/parse-md.sh is run in the pre-udev stage instead of the pre-trigger phase.

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
