### PR TITLE
fix(i18n): a couple of fixes for `--sysroot`

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -730,7 +730,7 @@ inst_decompress() {
         inst_simple "${_src}"
         # Decompress with chosen tool.  We assume that tool changes name e.g.
         # from 'name.gz' to 'name'.
-        ${_cmd} "${initdir}${_src}"
+        ${_cmd} "${initdir}${_src#"$dracutsysrootdir"}"
     done
 }
 

--- a/modules.d/10i18n/module-setup.sh
+++ b/modules.d/10i18n/module-setup.sh
@@ -38,7 +38,7 @@ install() {
         local CMD
         local FN
 
-        if [[ -f $dracutsysrootdir$1 ]]; then
+        if [[ -f $1 ]]; then
             MAPS=("$1")
         else
             MAPNAME=${1%.map*}


### PR DESCRIPTION
Keymap includes not added and compressed keymaps not decompressed.

```
dracut[I]: *** Including module: i18n ***
find: warning: ‘-name’ matches against basenames only, but the given pattern contains a directory separator (‘/’), thus the expression will evaluate to false all the time.  Did you mean ‘-wholename’?
find: warning: ‘-name’ matches against basenames only, but the given pattern contains a directory separator (‘/’), thus the expression will evaluate to false all the time.  Did you mean ‘-wholename’?
find: warning: ‘-name’ matches against basenames only, but the given pattern contains a directory separator (‘/’), thus the expression will evaluate to false all the time.  Did you mean ‘-wholename’?
find: warning: ‘-name’ matches against basenames only, but the given pattern contains a directory separator (‘/’), thus the expression will evaluate to false all the time.  Did you mean ‘-wholename’?
find: warning: ‘-name’ matches against basenames only, but the given pattern contains a directory separator (‘/’), thus the expression will evaluate to false all the time.  Did you mean ‘-wholename’?
find: warning: ‘-name’ matches against basenames only, but the given pattern contains a directory separator (‘/’), thus the expression will evaluate to false all the time.  Did you mean ‘-wholename’?
find: warning: ‘-name’ matches against basenames only, but the given pattern contains a directory separator (‘/’), thus the expression will evaluate to false all the time.  Did you mean ‘-wholename’?
find: warning: ‘-name’ matches against basenames only, but the given pattern contains a directory separator (‘/’), thus the expression will evaluate to false all the time.  Did you mean ‘-wholename’?
find: warning: ‘-name’ matches against basenames only, but the given pattern contains a directory separator (‘/’), thus the expression will evaluate to false all the time.  Did you mean ‘-wholename’?
find: warning: ‘-name’ matches against basenames only, but the given pattern contains a directory separator (‘/’), thus the expression will evaluate to false all the time.  Did you mean ‘-wholename’?
find: warning: ‘-name’ matches against basenames only, but the given pattern contains a directory separator (‘/’), thus the expression will evaluate to false all the time.  Did you mean ‘-wholename’?
find: warning: ‘-name’ matches against basenames only, but the given pattern contains a directory separator (‘/’), thus the expression will evaluate to false all the time.  Did you mean ‘-wholename’?
gzip: /var/tmp/dracut.6Iqygd/initramfs/.snapshots/12/snapshot/usr/share/kbd/keymaps/i386/include/euro1.map.gz: No such file or directory
gzip: /var/tmp/dracut.6Iqygd/initramfs/.snapshots/12/snapshot/usr/share/kbd/keymaps/i386/qwerty/us.map.gz: No such file or directory
gzip: /var/tmp/dracut.6Iqygd/initramfs/.snapshots/12/snapshot/usr/share/kbd/keymaps/xkb/us.map.gz: No such file or directory
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

