### PR TITLE
fix(network-legacy): make sure "$hookdir"/initqueue/finished exists

### DIFF
--- a/modules.d/35network-legacy/net-genrules.sh
+++ b/modules.d/35network-legacy/net-genrules.sh
@@ -116,6 +116,7 @@ command -v fix_bootif > /dev/null || . /lib/net-lib.sh
         # if you change the name of "91-default-net.rules", also change modules.d/80cms/cmssetup.sh
         echo "$cond, $runcmd" > /etc/udev/rules.d/91-default-net.rules
         if [ "$NEEDNET" = "1" ]; then
+            mkdir -p "$hookdir"/initqueue/finished
             # shellcheck disable=SC2016
             echo 'for i in /tmp/net.*.did-setup; do [ -f "$i" ]  && exit 0; done; exit 1' > "$hookdir"/initqueue/finished/wait-network.sh
         fi


### PR DESCRIPTION
Just like in network-manager and connman modules, make sure "$hookdir"/initqueue/finished exists in network-legacy as well.

Fixes #2620
