### PR TITLE
fix(dracut-lib): only remove initqueue/finished scripts, not the hook dir

### DIFF
--- a/modules.d/35connman/cm-lib.sh
+++ b/modules.d/35connman/cm-lib.sh
@@ -4,7 +4,6 @@ type getcmdline > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 cm_generate_connections() {
     if getargbool 0 rd.neednet; then
-        mkdir -p "$hookdir"/initqueue/finished
         echo '[ -f /tmp/cm.done ]' > "$hookdir"/initqueue/finished/cm.sh
         mkdir -p /run/connman/initrd
         : > /run/connman/initrd/neednet # activate ConnMan services

--- a/modules.d/35network-manager/nm-lib.sh
+++ b/modules.d/35network-manager/nm-lib.sh
@@ -20,7 +20,6 @@ nm_generate_connections() {
             /etc/NetworkManager/system-connections/* \
             /etc/sysconfig/network-scripts/ifcfg-*; do
             [ -f "$i" ] || continue
-            mkdir -p "$hookdir"/initqueue/finished
             echo '[ -f /tmp/nm.done ]' > "$hookdir"/initqueue/finished/nm.sh
             mkdir -p /run/NetworkManager/initrd
             : > /run/NetworkManager/initrd/neednet # activate NM services

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -1131,7 +1131,7 @@ show_memstats() {
 }
 
 remove_hostonly_files() {
-    rm -fr /etc/cmdline /etc/cmdline.d/*.conf "$hookdir/initqueue/finished"
+    rm -fr /etc/cmdline /etc/cmdline.d/*.conf "$hookdir"/initqueue/finished/*.sh
     if [ -f /lib/dracut/hostonly-files ]; then
         while read -r line || [ -n "$line" ]; do
             [ -e "$line" ] || [ -h "$line" ] || continue


### PR DESCRIPTION
The `remove_hostonly_files` function should only remove (as its name suggests) hostonly configuration and files. The initqueue/finished scripts considered as hostonly that must be removed are added via `wait_for_dev`. But, the `hookdirs` are always created at build time, and should not be removed.

This patch also allows to remove the `mkdir` workaround in the `network-manager` module (copied-pasted into the `connman` module after), and avoids having to add it tree-wide in many missing places.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes 87e90d7f4a344d8e0f638acfccb3e5a387a1658c
Fixes #2620
