### PR TITLE
fix(dracut.sh): recognize kernel file in /boot named vmlinux too

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1153,7 +1153,7 @@ if ! [[ $outfile ]]; then
             outfile="$dracutsysrootdir/boot/efi/${MACHINE_ID}/${kernel}/initrd"
         elif [[ -f "$dracutsysrootdir"/lib/modules/${kernel}/initrd ]]; then
             outfile="$dracutsysrootdir/lib/modules/${kernel}/initrd"
-        elif [[ -e $dracutsysrootdir/boot/vmlinuz-${kernel} ]]; then
+        elif [[ -e $dracutsysrootdir/boot/vmlinuz-${kernel} || -e $dracutsysrootdir/boot/vmlinux-${kernel} ]]; then
             outfile="$dracutsysrootdir/boot/initramfs-${kernel}.img"
         elif [[ -z $dracutsysrootdir ]] \
             && [[ $MACHINE_ID ]] \


### PR DESCRIPTION
This pull request adds /boot/vmlinux-${kernelver} to recognized kernel file when trying to detect the output path of the initramfs file, which makes it broken on AOSC OS loongarch64 (but coincidentally worked before /efi mount point detection is implemented).

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it