### PR TITLE
fix(zfcp_rules): use the right wwpn and lun vars and support new device format

### DIFF
--- a/modules.d/95zfcp_rules/parse-zfcp.sh
+++ b/modules.d/95zfcp_rules/parse-zfcp.sh
@@ -65,9 +65,18 @@ for zfcp_arg in $(getargs root=) $(getargs resume=); do
             IFS="-"
             set -- "$ccw_arg"
             IFS="$OLDIFS"
-            _wwpn=${4%:*}
-            _lun=${4#*:}
-            create_udev_rule "$2" "$wwpn" "$lun"
+            # The format of udev-created SCSI device nodes has changed from:
+            #   ccw-<device_bus_id>-zfcp-<wwpn>:<lun>-part<n>
+            # to:
+            #   ccw-<device_bus_id>-fc-<wwpn>-lun-<lun>-part<n>
+            if [[ $3 == "fc" ]] && [[ $5 == "lun" ]]; then
+                _wwpn="$4"
+                _lun="$6"
+            elif [[ $3 == "zfcp" ]]; then
+                _wwpn=${4%:*}
+                _lun=${4#*:}
+            fi
+            create_udev_rule "$2" "$_wwpn" "$_lun"
         fi
     )
 done


### PR DESCRIPTION
Commit c8e531239bf314ae532ca1bc820285250a3b35d7 introduced a regression that causes the parsed `_wwpn` and `_lun` from SCSI device nodes to not be passed to the `create_udev_rule` function.

Also, the format of these udev-created SCSI device nodes has changed [1], now it looks like: `ccw-<device_bus_id>-fc-<wwpn>-lun-<lun>-part<n>`

Fixes c8e531239bf314ae532ca1bc820285250a3b35d7

[1] https://www.ibm.com/docs/en/linux-on-systems?topic=nodes-udev-created

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
