### PR TITLE
fix(systemd): explicitly install some libs that will not be statically included

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -262,6 +262,8 @@ EOF
     # Install library file(s)
     _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
+        {"tls/$_arch/",tls/,"$_arch/",}"libgcrypt.so*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libkmod.so*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libnss_*"
 
 }

--- a/modules.d/01systemd-coredump/module-setup.sh
+++ b/modules.d/01systemd-coredump/module-setup.sh
@@ -40,6 +40,13 @@ install() {
         "$sysusers"/systemd-coredump.conf \
         coredumpctl
 
+    # Install library file(s)
+    _arch=${DRACUT_ARCH:-$(uname -m)}
+    inst_libdir_file \
+        {"tls/$_arch/",tls/,"$_arch/",}"liblz4.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"liblzma.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libzstd.so.*"
+
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \

--- a/modules.d/01systemd-journald/module-setup.sh
+++ b/modules.d/01systemd-journald/module-setup.sh
@@ -53,9 +53,10 @@ install() {
     # Install library file(s)
     _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
+        {"tls/$_arch/",tls/,"$_arch/",}"libgcrypt.so*" \
         {"tls/$_arch/",tls/,"$_arch/",}"liblz4.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libzstd.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"liblzma.so.*"
+        {"tls/$_arch/",tls/,"$_arch/",}"liblzma.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libzstd.so.*"
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then


### PR DESCRIPTION
Some required libraries that used to be statically included are in the process to be opened via `dlopen()`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Closes #2642
