### PR TITLE
dmsquash-live: add rd.live.join

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-generator.sh
+++ b/modules.d/90dmsquash-live/dmsquash-generator.sh
@@ -58,9 +58,17 @@ ROOTFLAGS="$(getarg rootflags)"
     if [ "$overlayfs$xor_overlayfs" = "yes" ]; then
         echo "What=LiveOS_rootfs"
         if [ "$readonly_overlay$xor_readonly" = "--readonly" ]; then
-            ovlfs=lowerdir=/run/overlayfs-r:/run/rootfsbase
+            if [ -n ${join} ]; then
+                ovlfs=lowerdir=/run/overlayfs-r:/run/rootfsjoin:/run/rootfsbase
+            else
+                ovlfs=lowerdir=/run/overlayfs-r:/run/rootfsbase
+            fi
         else
-            ovlfs=lowerdir=/run/rootfsbase
+            if [ -n ${join} ]; then
+                ovlfs=lowerdir=/run/rootfsjoin:/run/rootfsbase
+            else
+                ovlfs=lowerdir=/run/rootfsbase
+            fi
         fi
         echo "Options=${ROOTFLAGS},${ovlfs},upperdir=/run/overlayfs,workdir=/run/ovlwork"
         echo "Type=overlay"

--- a/modules.d/90overlayfs/mount-overlayfs.sh
+++ b/modules.d/90overlayfs/mount-overlayfs.sh
@@ -9,9 +9,17 @@ ROOTFLAGS="$(getarg rootflags)"
 
 if [ -n "$overlayfs" ]; then
     if [ -n "$readonly_overlay" ] && [ -h /run/overlayfs-r ]; then
-        ovlfs=lowerdir=/run/overlayfs-r:/run/rootfsbase
+        if [ -n ${join} ]; then
+            ovlfs=lowerdir=/run/overlayfs-r:/run/rootfsjoin:/run/rootfsbase
+        else
+            ovlfs=lowerdir=/run/overlayfs-r:/run/rootfsbase
+        fi
     else
-        ovlfs=lowerdir=/run/rootfsbase
+        if [ -n ${join} ]; then
+            ovlfs=lowerdir=/run/rootfsjoin:/run/rootfsbase
+        else
+            ovlfs=lowerdir=/run/rootfsbase
+        fi
     fi
 
     if ! strstr "$(cat /proc/mounts)" LiveOS_rootfs; then


### PR DESCRIPTION
Continue with question #687.

Support a union join on rootfs wiih another img.

This makes throw away layers possible, or starting different setups depending on rootfs and the join.img.

Example:

- the live bootloader features a base system and a desktop system entry, where the desktop fs resides in the join.img, while rootfs would be just a console base system.
- throw away live layer, the installer extracts the rootfs, while live session fs resides in the join.img, including the installer itself

Usage:

`rd.live.join=$name.img`