### PR TITLE
fix `dracutbasedir` when using `dracut -l`

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -764,8 +764,8 @@ while :; do
         -q | --quiet) ((verbosity_mod_l--)) ;;
         -l | --local)
             allowlocal="yes"
-            [[ -f "$(readlink -f "${0%/*}")/dracut-init.sh" ]] \
-                && dracutbasedir="$(readlink -f "${0%/*}")"
+            [[ -f "$(readlink -f "${0%/bin/*}")/lib/dracut/dracut-init.sh" ]] \
+                && dracutbasedir="$(readlink -f "${0%/bin/*}")/lib/dracut"
             ;;
         -H | --hostonly | --host-only)
             hostonly_l="yes"


### PR DESCRIPTION
This pull request changes...

## Changes

After building from a git checkout with prefix=/usr/local, `dracut -l` reports error:

> dracut[F]: Cannot find /usr/lib/dracut/dracut-init.sh.
> dracut[F]: Are you running from a git checkout?
> dracut[F]: Try passing -l as an argument to /usr/local/bin/dracut

## Checklist
- [x ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #

Setting `dracutbasedir` in `dracut.sh` correctly to `/usr/local/lib/dracut`
