### PR TITLE
Load the SELinux policy after switch_root and remove the selinux-loadpolicy module

### DIFF
--- a/modules.d/98selinux/selinux-loadpolicy.sh
+++ b/modules.d/98selinux/selinux-loadpolicy.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-# FIXME: load selinux policy.  this should really be done after we switchroot
+# SELinux policy load should be done after switch_root.
+#
+# This module is therefore obsolete and it is left here only
+# for backwards compatibility.
 
 rd_load_policy() {
     # If SELinux is disabled exit now


### PR DESCRIPTION
Load the SELinux policy after switch_root and remove the selinux-loadpolicy module.

This fixes the bootup process with recent kernels, as it was getting stuck on Permission Denied errors due to the early SELinux policy load.

Fixes https://github.com/dracutdevs/dracut/issues/2653
---
 .github/labeler.yml                       |    4 -
 modules.d/98selinux/module-setup.sh       |   17 -------
 modules.d/98selinux/selinux-loadpolicy.sh |   70 ------------------------------
 modules.d/99base/init.sh                  |    5 ++
 4 files changed, 5 insertions(+), 91 deletions(-)