### PR TITLE
fix(dracut-install): handle correctly sysrootdir with trailing '/'

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -1097,6 +1097,9 @@ static int parse_argv(int argc, char *argv[])
                 case 'r':
                         sysrootdir = optarg;
                         sysrootdirlen = strlen(sysrootdir);
+                        /* ignore trailing '/' */
+                        if (sysrootdir[sysrootdirlen-1] == '/')
+                                sysrootdirlen--;
                         break;
                 case 'p':
                         if (regcomp(&mod_filter_path, optarg, REG_NOSUB | REG_EXTENDED) != 0) {


### PR DESCRIPTION
This pull request fixes incorrect handling of `--sysrootdir` argument when passed value trails with `/`

## Changes
check passed sysrootdir for trailing `/` and decrement `sysrootdirlen` by 1 if `/` is detected.

## Checklist
- [ x] I have tested it locally
- [x ] I have reviewed and updated any documentation if relevant
- [ x] I am providing new code and test(s) for it

Fixes #
https://github.com/dracutdevs/dracut/issues/2666