### PR TITLE
Extend description of `inst` command in dracut.modules man page

### DIFF
--- a/man/dracut.modules.7.asc
+++ b/man/dracut.modules.7.asc
@@ -261,9 +261,11 @@ not lead to an error.
 ==== inst <src> [<dst>]
 
 installs _one_ file <src> either to the same place in the initramfs or to an
-optional <dst>. inst with more than two arguments is treated the same as
-inst_multiple, all arguments are treated as files to install and none as
-install destinations.
+optional <dst>, which is expected to be a full path including the filename. If
+<dst> includes a directory that does not exist yet, it will be created before
+installing <src> to it. inst with more than two arguments is treated the same as
+inst_multiple, all arguments are treated as files to install and none as install
+destinations.
 
 ==== inst_hook <hookdir> <prio> <src>
 


### PR DESCRIPTION
This pull request extends the description of the `inst` command to mention that the filename has to be present in the `<dst>` given and that directories in `<dst>` will be created if they don't exist yet.

Background: When omitting the filename from `<dst>`, only the first call to `inst` seems to succeed, while subsequent calls are skipped without an error. Feel free to accept this PR in case this is the intended behavior. If the current behavior is considered a bug, it might be better to fix it and adapt the manpage accordinly.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it