### PR TITLE
fix(kernel-modules-extra): remove redundant escape for '/' in re_escape

### DIFF
--- a/modules.d/90kernel-modules-extra/module-setup.sh
+++ b/modules.d/90kernel-modules-extra/module-setup.sh
@@ -35,7 +35,7 @@ installkernel() {
     # Escape a string for usage as a part of extended regular expression.
     # $1 - string to escape
     re_escape() {
-        printf "%s" "$1" | sed 's/\([.+?^$\/\\|()\[]\|\]\)/\\\0/'
+        printf "%s" "$1" | sed 's/\([.+?^$\\|()\[]\|\]\)/\\\0/'
     }
 
     local cfg


### PR DESCRIPTION
The re_escape function in 90kernel-modules-extra/module-setup.sh incorrectly added a backslash escape for the '/' character , which is not a regular expression special character. This redundant escape triggers a 'stray \ before /' warning in grep when processing paths containing '/'.

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
